### PR TITLE
Update to Hexo 3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,15 +1,22 @@
 {
+  "hexo": {
+    "version": "3.1.1"
+  },
   "name": "hexo-site",
-  "version": "2.8.3",
   "private": true,
   "dependencies": {
-    "hexo-generator-feed": "^0.1.1",
-    "hexo-generator-sitemap": "^0.1.3",
-    "hexo-migrator-wordpress": "^0.1.0",
-    "hexo-renderer-ejs": "*",
-    "hexo-renderer-marked": "*",
-    "hexo-renderer-stylus": "*",
-    "jsdom": "1.0.0-pre.3",
-    "jquery": "2.1.1"
+    "hexo": "^3.1.1",
+    "hexo-generator-archive": "^0.1.3",
+    "hexo-generator-category": "^0.1.3",
+    "hexo-generator-feed": "^1.0.0",
+    "hexo-generator-index": "^0.1.3",
+    "hexo-generator-sitemap": "^1.0.0",
+    "hexo-generator-tag": "^0.1.2",
+    "hexo-renderer-ejs": "^0.1.0",
+    "hexo-renderer-marked": "^0.2.5",
+    "hexo-renderer-stylus": "^0.3.0",
+    "hexo-server": "^0.1.2",
+    "jquery": "^2.1.4",
+    "jsdom": "^1.5.0"
   }
 }

--- a/scripts/figure.js
+++ b/scripts/figure.js
@@ -30,7 +30,7 @@ var jsdom = require('jsdom').jsdom,
     window = jsdom("").parentWindow,
     $ = require('jquery')(window);
 
-hexo.extend.tag.register('figure', function(args, content, options) {
+hexo.extend.tag.register('figure', function(args, content) {
 
   var image_dir = hexo.config.image_dir,
       render = hexo.render,
@@ -49,4 +49,4 @@ hexo.extend.tag.register('figure', function(args, content, options) {
   }
 
   return '<figure class="generated-figure generated-figure--retina generated-figure--620 generated-figure--'+ orientation +'"><a href="' + image_dir + image +'"><img src="' + image_dir + directory + image +'" alt="'+ caption +'"></a><figcaption class="generated-figure-caption">'+ renderedCaption +'</figcaption></figure>';
-}, true);
+}, {ends: true});

--- a/scripts/food-menu.js
+++ b/scripts/food-menu.js
@@ -4,7 +4,7 @@
 * Fuet sausage
 {% endmenu /%}
 */
-hexo.extend.tag.register('menu', function(args, content, options){
+hexo.extend.tag.register('menu', function(args, content){
 
   var render = hexo.render,
       menu = render.renderSync({text: content, engine: 'markdown'});
@@ -13,4 +13,4 @@ hexo.extend.tag.register('menu', function(args, content, options){
     <h3 class="menu-header">Menu</h3>\
     ' + menu + '\
     </aside>';
-}, true);
+}, {ends: true});

--- a/scripts/note.js
+++ b/scripts/note.js
@@ -1,10 +1,10 @@
 /*
 Note
 */
-hexo.extend.tag.register('note', function(args, content, options) {
+hexo.extend.tag.register('note', function(args, content) {
 
   var render = hexo.render,
       markdownNote = render.renderSync({text: content, engine: 'markdown'});
 
   return '<div class="note">'+ markdownNote +'</div>';
-}, true);
+}, {ends: true});

--- a/source/_posts/a-day-in-saigon-vietnam.md
+++ b/source/_posts/a-day-in-saigon-vietnam.md
@@ -18,21 +18,31 @@ The War Remnants museum please, formerly known as the museum of Chinese and Amer
 
 The museum itself is cheap to get in, only a $1. Outside your heart races and the adrenaline kicks in as you explore old tanks, helicopters, jets and mounted guns. But once inside, you are numbed, and your heart breaks, as room after room, photo after photo, the museum exhibits the true atrocities and destruction of war. It's sickening, and you just want to cry.
 
-{% figure saigon-hcmc-001.jpg landscape %}A chinook at the War Remnants museum{% endfigure %}
+{% figure saigon-hcmc-001.jpg landscape %}
+A chinook at the War Remnants museum
+{% endfigure %}
 
-{% figure saigon-hcmc-002.jpg landscape %}A US tank{% endfigure %}
+{% figure saigon-hcmc-002.jpg landscape %}
+A US tank
+{% endfigure %}
 
 Exhibitions are spread across three floors. Windows filled with guns, explosives, rocket launchers, mines and other weapons are opposite photo galleries showing their harm; families escaping from burning villages, war dead with terrifying wounds, soldiers in action - from both sides; pictures of the Vietnamese soldiers seem so rare and alien. Individual galleries showcase the work of intrepid photographers, as they travelled with various forces, Vietnamese and American, risking their lives to document the war.
 
-{% figure saigon-hcmc-003.jpg landscape %}The so-called pineapple bombs{% endfigure %}
+{% figure saigon-hcmc-003.jpg landscape %}
+The so-called pineapple bombs
+{% endfigure %}
 
-{% figure saigon-hcmc-006.jpg landscape %}The war, told in pictures from both perspectives. We're used to seeing only one.{% endfigure %}
+{% figure saigon-hcmc-006.jpg landscape %}
+The war, told in pictures from both perspectives. We're used to seeing only one.
+{% endfigure %}
 
 The opposition to the war is strongly conveyed, a whole section of the museum is dedicated to the news feeds and articles of the time. From the American peace rallies to dedications for the self immolating protestors that gave their lives in protest, both in the US and in Japan.
 
 The most terrifying and depressing of all exhibits was the Agent Orange room. Large full coloured images showcase the continuing problems that use of Agent Orange (and other biological warfare) has caused in Vietnam; poisoned water supplies, poisoned food supplies and atrocious birth defects and deformities. I couldn't take it, and left to sit outside, pondering the point of all this while waiting for Samantha.
 
-{% figure saigon-hcmc-005.jpg landscape %}A room portraying the aftermath of Agent Orange attacks. Truly horrific.{% endfigure %}
+{% figure saigon-hcmc-005.jpg landscape %}
+A room portraying the aftermath of Agent Orange attacks. Truly horrific.
+{% endfigure %}
 
 ## Level 23 at the Sheraton
 
@@ -42,6 +52,10 @@ We wandered into a lavish, luxurious hotel and immediately took the lift to the 
 
 With buy one get one free cocktails and wasabi peas, we watched the sun set on our holiday. The end of a an eye-opening, incredible adventure through Vietnam and Cambodia. Sat amongst Saigon's towering skyscrapers, traffic beeping below, lights turning on, neon red appearing, a yellow glow fading, it was time to go home, home home, that far away place we'd forgotten about, two flights and 23 hours back to Brighton via Dubai. We raised our glasses one last time, this was magical, we should do it again sometime.
 
-{% figure saigon-hcmc-007.jpg portrait %}Cocktails to end an astounding holiday{% endfigure %}
+{% figure saigon-hcmc-007.jpg portrait %}
+Cocktails to end an astounding holiday
+{% endfigure %}
 
-{% figure saigon-hcmc-008.jpg portrait %}Goodnight Saigon, Goodnight Vietnam{% endfigure %}
+{% figure saigon-hcmc-008.jpg portrait %}
+Goodnight Saigon, Goodnight Vietnam
+{% endfigure %}

--- a/source/_posts/a-week-on-vulcano-sicily.md
+++ b/source/_posts/a-week-on-vulcano-sicily.md
@@ -24,20 +24,28 @@ An hour into our 45 minute journey, and our predicament hadn't changed, the up-n
 
 Miraculously Samantha and I held out, and after 90 minutes we were on dry land, but greeted by the bad-egg sulphur smell of Vulcano's nearby mud baths. Our smiling wide-eyed hotel rep enthusiastically greeted us, and from the minibus to the hotel pointed out the sights. It took all of Sam's ability to focus and hear her words. I should say now, the return journey was a non-event, it was even pleasurable. I'll repeat our learnings: never sit at the front of a hydrofoil.
 
-{% figure vulcano-031.jpg landscape %}A panorama of the Aeolian Islands from Therasia's pool{% endfigure %}
+{% figure vulcano-031.jpg landscape %}
+A panorama of the Aeolian Islands from Therasia's pool
+{% endfigure %}
 
 ## Therasia Resort Sea and Spa
 
 Our hotel, [Therasia Resort Sea & Spa](http://www.tripadvisor.co.uk/Hotel_Review-g642173-d628059-Reviews-Therasia_Resort-Isola_Vulcano_Aeolian_Islands_Islands_of_Sicily_Sicily.html), introduced itself with breathtaking views. Perched on the northernmost corner of Vulcanello, a small volcano, it looks out at a 180º vista of the Aeolian islands. From left to right we saw Alicudi, Filicudi, Salina (housing six volcanoes), Lipari — directly in front, Panarea, and in the distance to the right, Stromboli, a regularly erupting volcano dubbed “Lighthouse of the Mediterranean”. Between us and Lipari there lay only a thin channel of water, at most 1km across, and frequented by ambient sailboats. Lipari itself rises quickly into the sky, leaving behind two characteristic rocky outcrops to the West, like the ruined pillars of an ancient monument. It is these small rocks which make the view unique, and magical, and from where the hotel derives its insignia. Night and day, for six days, through sunrise and sunset, this view remained wondrous. Looking into it we felt privileged, and became calm and reflective, our pefect sea of tranquility.
 
-{% figure vulcano-008.jpg portrait %}The iconic view from Therasia Hotel's reception{% endfigure %}
+{% figure vulcano-008.jpg portrait %}
+The iconic view from Therasia Hotel's reception
+{% endfigure %}
 
 In such surroundings the hotel itself has much to live up to, and it does so, magnanimously. An infinity pool melds seamlessly with the sea, and is surrounded by unobtrusive cacti. The site is built into the rock in tiers, each tier with its own unobstructed and unique view, whether it's from the breakfast table at L'Arcipelago, a table at the Michelin recommended Il Cappero, the bar at reception or your room. In the foyer stone arches give the building a sense of grandeur befitting its environment. The staff were both friendly and helpful, and by the end of the week we couldn't help but treat many of them like friends.
 
-{% figure vulcano-001.jpg landscape %}Balcony looking out at Lipari{% endfigure %}
+{% figure vulcano-001.jpg landscape %}
+Balcony looking out at Lipari
+{% endfigure %}
 
 Our room was modest, the cheapest room available, with a garden view — the crater of Vulcano smouldering in the distance. But it too was lovely, whitewashed with a stone tiled floor, a hidden and near silent air conditioner and a bed that slept us soundly every night. The minibar was free, and the room even had complimentary flip-flops. Twice a day our room was kept both clean and tidy, our clothes neatly folded, a little almond treat left by our bedside at night.
 
-{% figure vulcano-002.jpg landscape %}Our room at Therasia Resort{% endfigure %}
+{% figure vulcano-002.jpg landscape %}
+Our room at Therasia Resort
+{% endfigure %}
 
 Come the rest of our first day, all we could do was nap and eat dinner. From L'Arcipelago we watched our first sunset, the red glowing ball silently vaporising itself in the salty ocean.

--- a/source/_posts/a-week-on-vulcano-sicily/2.md
+++ b/source/_posts/a-week-on-vulcano-sicily/2.md
@@ -11,12 +11,18 @@ Our days were restful, we didn't venture out much, choosing instead to lounge by
 
 When we did eventually venture out on our first day, we obviously did so at the wrong time, about 2pm. Leaving the confines of the hotel, we also left the sea breeze, and the roads were hot and stuffy. But we persisted, and walked down to Baia Negra, a black sand beach, then along to the smelly mud baths, and quickly away into town. It all took about two hours, and by the quiet port we took the shuttle back home.
 
-{% figure vulcano-004.jpg landscape %}Samantha reading about the mud pools{% endfigure %}
+{% figure vulcano-004.jpg landscape %}
+Samantha reading about the mud pools
+{% endfigure %}
 
-{% figure vulcano-005.jpg landscape %}A sculpture set on smelly yellow sulphur{% endfigure %}
+{% figure vulcano-005.jpg landscape %}
+A sculpture set on smelly yellow sulphur
+{% endfigure %}
 
 ## Maurizio's
 
 That night we returned, to eat at [Maurizio's](http://www.tripadvisor.co.uk/Restaurant_Review-g642173-d2314438-Reviews-Ristorante_La_Forgia_Maurizio-Isola_Vulcano_Aeolian_Islands_Islands_of_Sicily_Sic.html), he was fully booked, except for a lonesome table on the street. It was a quiet street, at times quieter than the restaurant, and it afforded us personal service and the chance to watch the world go by. The sky turned pink, then blue, and the first stars appeared. It was warm outside. Maurizio lavished on us his preprepared free hors d'oeuvres (Sam devoured the black bean and spelt with all the potato bread), then Spaghetti Eoliana and Zucchini Linguine, followed with fried Calamari and Swordfish in breadcrumbs. And when we were stuffed, unable to eat anything more, one more treat: almond biscotti and almond wine. “Thank you ever so much”, Sam told Maurizio, “ah, but what for?” he casually replied.
 
-{% figure vulcano-011.jpg landscape %}Maurizio's restaurant{% endfigure %}
+{% figure vulcano-011.jpg landscape %}
+Maurizio's restaurant
+{% endfigure %}

--- a/source/_posts/a-week-on-vulcano-sicily/3.md
+++ b/source/_posts/a-week-on-vulcano-sicily/3.md
@@ -7,31 +7,45 @@ page: 3
 
 On Tuesday the view at breakfast was even more magical. The colour of the distant sea perfectly matched the blue hue of the sky, and boats and islands alike appeared to hover strangely in the air.
 
-{% figure vulcano-012.jpg landscape %}Perfectly blue view of Lipari from our breakfast table{% endfigure %}
+{% figure vulcano-012.jpg landscape %}
+Perfectly blue view of Lipari from our breakfast table
+{% endfigure %}
 
 ## Vulcanello
 
 After our fruit salad, cappuccino and salmon on toast, we left the hotel early, eager to explore the island a little more. Our aim was to reach the top of Vulcanello, a small volcano to the north. The hot roads that lacked a sea breeze were lined with those characteristic red Sicilian flowers, planted but gorgeous nonetheless. Going East we searched for a walk up to the volcano crater, but every entrance seemed private. We took a short detour through the dry woodland and along a dirt path, hopeful, but as it turned south, and eventually stopped exactly nowhere, we gave up the expedition.
 
-{% figure vulcano-013.jpg portrait %}Samantha enjoying breakfast{% endfigure %}
+{% figure vulcano-013.jpg portrait %}
+Samantha enjoying breakfast
+{% endfigure %}
 
-{% figure vulcano-024.jpg landscape %}Sicilian flowers{% endfigure %}
+{% figure vulcano-024.jpg landscape %}
+Sicilian flowers
+{% endfigure %}
 
 ## Marina di Vulcanello
 
 Finding the main road again, and continuing East, we avoided town and discovered a sailboat marina, (“marina di vulcanello”). The trees and land opened up to a quiet bay with unobstructed views of 'the Vulcano volcano'. From the end of the jetty we sat and watched the hydrofoils come in, and the sailboats gently go out, while the sulphur rose up behind them.
 
-{% figure vulcano-017.jpg landscape %}Marina di Vulcanello{% endfigure %}
+{% figure vulcano-017.jpg landscape %}
+Marina di Vulcanello
+{% endfigure %}
 
-{% figure vulcano-018.jpg portrait %}A boat, a jetty and the Gran Cratere{% endfigure %}
+{% figure vulcano-018.jpg portrait %}
+A boat, a jetty and the Gran Cratere
+{% endfigure %}
 
 We also found Vulcano Blu, another resort, and at the end another view North, with grand views of Lipari, Panarea and Stromboli. The latter of which only visible at the time by a characteristic white puff of smoke escaping its peak. Being next to a resort we had the good fortune of stumbling on a pool and bar, in a place which would otherwise be the middle of nowhere. Sat by the pool, listening to a CD blast out Madonna's “Ray of light”, and The Lighthouse Family, we recuperated with a panini and salad, washed down with cold iced tea and a guilty coke.
 
 On the walk home we found a lost German tourist. She was elderly, looked very hot and couldn't speak a word of English. We couldn't make out what she wanted, or where she was going; Sam's broken German gave us the odd clue. Without anything around for miles, and in the heat, we led her to our hotel where a German speaker could undoubtedly help. En-route we flagged down a car, and the driver, one of the friendly hotel receptionists we knew came to the rescue — she drove us back and, after conversing in German, explained that the lady wanted to get a boat from the main port but was desperately lost. At the hotel our German friend thanked us and cooled down in the bar before taking the complementary shuttle bus to town. With our Good Samaritan task complete, we relaxed by our pool until dinner.
 
-{% figure vulcano-023.jpg landscape %}Panoramic from Vulcano Blu{% endfigure %}
+{% figure vulcano-023.jpg landscape %}
+Panoramic from Vulcano Blu
+{% endfigure %}
 
-{% figure vulcano-022.jpg portrait %}Sicilian Hibiscus against the backdrop of Vulcanello{% endfigure %}
+{% figure vulcano-022.jpg portrait %}
+Sicilian Hibiscus against the backdrop of Vulcanello
+{% endfigure %}
 
 ## Il Cappero
 
@@ -52,10 +66,18 @@ Our meal was delightful. From the lobster served in cappuccino, an inspired idea
 
 We retired for the night, but not before a quick perch by the nighttime pool, to watch the stars, the boats and the bats, which flew down in front of us to drink the pool water.
 
-{% figure vulcano-026.jpg landscape %}The bar at Therasia Hotel in evening light{% endfigure %}
+{% figure vulcano-026.jpg landscape %}
+The bar at Therasia Hotel in evening light
+{% endfigure %}
 
-{% figure vulcano-028.jpg landscape %}Samantha's silhouette against the Aeolian sunset{% endfigure %}
+{% figure vulcano-028.jpg landscape %}
+Samantha's silhouette against the Aeolian sunset
+{% endfigure %}
 
-{% figure vulcano-029.jpg landscape %}Horizon and Filicudi after sunset{% endfigure %}
+{% figure vulcano-029.jpg landscape %}
+Horizon and Filicudi after sunset
+{% endfigure %}
 
-{% figure vulcano-030.jpg landscape %}Therasia's pool in twilight{% endfigure %}
+{% figure vulcano-030.jpg landscape %}
+Therasia's pool in twilight
+{% endfigure %}

--- a/source/_posts/a-week-on-vulcano-sicily/4.md
+++ b/source/_posts/a-week-on-vulcano-sicily/4.md
@@ -7,7 +7,9 @@ page: 4
 
 In our infinite wisdom we decided to wake before dawn, to see the sun's beautiful light from the other side of the sea, and to get some good photos. But the horizon was a little hazy, and the sunrise disappointingly unspectacular. Still, it didn't stop Sam wandering the deserted hotel trying to make an image worth keeping. I meanwhile returned to bed and tried to stay awake until she returned, after all, we only had one set of keys, and she didn't have them.
 
-{% figure vulcano-032.jpg landscape %}Dawn on Vulcano{% endfigure %}
+{% figure vulcano-032.jpg landscape %}
+Dawn on Vulcano
+{% endfigure %}
 
 Today's itinerary read as follows: breakfast, pool, volcano. Salmon on toast was replaced with tuna steak on toast, and at the pool we donned our fluorescent green flip flops and bagsy'd the best sun chairs. In A Brave New World, Bernard Marx was headed out to see the savages, and above me an unmarked army helicopter and then a low flying cargo plain flew by, weaving between the islands, practically at eye level. It upset the tranquility somewhat, but Sam missed all the palaver, she was downstairs getting a tour of the spa.
 
@@ -17,29 +19,47 @@ For lunch we ate a stone baked pizza, with fruit and vanilla milkshake. Most of 
 
 At 6pm, and thoroughly relaxed, we set off to scale Vulcano, to go up when the light was right, when the heat wouldn't be overbearing and when it might all be a little bit perfect. Sunset was 8:30pm, and we reckoned two hours was enough to get us to the top. From the minibus, through town, up to the gravel entrance, and onto the sandy ash path. It was like climbing a beach, or a sand dune, sliding down slightly with every rising step. Sam, in all her preparedness was carrying far too much and wore too many clothes; red faced and panting she was overheating, and we were only 200m into the climb. She had her walking boots, trousers, t-shirt and a shirt covering her shoulders; I was in sandals, shorts and an unbuttoned short sleeved shirt. We took it slow, I carried the tripod, and Sam took tiny steps, which made it all the more arduous, every step had a cost. 300m, 400m, 500m, 600m, and finally the sand gave way to encrusted mud — a path carved out of the volcano wall, and the trek became easier. Beneath us the town, Vulcanello and the Aeolian islands spread out, with the sun casting beautiful shadows across the hills.
 
-{% figure vulcano-036.jpg portrait %}Beginning the trek up Vulcano, to the Gran Cratere{% endfigure %}
+{% figure vulcano-036.jpg portrait %}
+Beginning the trek up Vulcano, to the Gran Cratere
+{% endfigure %}
 
-{% figure vulcano-037.jpg landscape %}Samantha struggling on the Volcano, with the town and Lipari behind{% endfigure %}
+{% figure vulcano-037.jpg landscape %}
+Samantha struggling on the Volcano, with the town and Lipari behind
+{% endfigure %}
 
-{% figure vulcano-039.jpg landscape %}On the mud carved path to Gran Cratere, almost at the top{% endfigure %}
+{% figure vulcano-039.jpg landscape %}
+On the mud carved path to Gran Cratere, almost at the top
+{% endfigure %}
 
 The climb was 900m in total. At the top we found ourselves on the precipice of the volcano's crater, Gran Cratere. It wasn't spewing lava or anything, it had collapsed in on itself one hundred years ago, but there were thick sulphur fields to the East, blowing plumes of toxic smoke out into the world. And that's the smell that hits you at the top, yucky bad eggs. Still, the crater was enormous, and the eruption must have been a sight (it's a Vulcanian type of eruption, namesake and all). Sam was in a mild state of delirium, overheating, red faced and being irritable — yet this wasn't the finale, we still needed to circumnavigate the crater to reach the tallest peak on the south side. Sam let out a sort of moan, but we continued.
 
-{% figure vulcano-049.jpg landscape %}View from Vulcano's Gran Cratere volcano{% endfigure %}
+{% figure vulcano-049.jpg landscape %}
+View from Vulcano's Gran Cratere volcano
+{% endfigure %}
 
-{% figure vulcano-041.jpg landscape %}Taking a break on the summit{% endfigure %}
+{% figure vulcano-041.jpg landscape %}
+Taking a break on the summit
+{% endfigure %}
 
 Around the crater there's a thin path, trekked by a hardy few. Avoiding the sulphur fields, we took the long route round, to our left the sharp decline into the crater, on the right a larger drop, down the side of the volcano. A sombre cross with flowers highlighted the danger. As we trekked onwards the sun drew closer to the horizon. And all the bugs were out, tiny little black things determined to bite and nibble at you unless you keep moving. We eked round to the peak, and guzzled down most of our juice and water. Just as Sam made it to the pinnacle, and as she wearily raised her hands in success, a jogger breezed past her, without a bead of sweat on his brow, casual as you like.
 
-{% figure vulcano-045.jpg landscape %}Circumnavigating the crater to reach the peak{% endfigure %}
+{% figure vulcano-045.jpg landscape %}
+Circumnavigating the crater to reach the peak
+{% endfigure %}
 
 What a magnificent view from the top. We could see all eight Aeolian islands, in all their glory, spreading right across the horizon. The light had turned red, and the sun began to dip behind Filicudi; perfect timing. With a bit of a rest and some fluids Sam was back to normal and we setup the tripod and had a bit of fun. The angle wasn't quite right, so we jogged down the zig-zag path, back to the rim of the crater, and towards the sulphur fields; the smoke flowed over the cusp of the crater and down, mesmerising. We paused and watched the sun disappear, just like the night before, and the one before that, perfectly and smoothly collapsing into the sea, gorgeous, you can't ever grow tired of it, beautiful and fleeting, a little bit of planetary magic, and then it was night time. And then we were on a volcano at night.
 
-{% figure vulcano-048.jpg landscape %}Samantha and Paul at the peak of Gran Cratere, for sunset{% endfigure %}
+{% figure vulcano-048.jpg landscape %}
+Samantha and Paul at the peak of Gran Cratere, for sunset
+{% endfigure %}
 
-{% figure vulcano-052.jpg landscape %}Paul ambling down to the molten sulphur fields for some photos{% endfigure %}
+{% figure vulcano-052.jpg landscape %}
+Paul ambling down to the molten sulphur fields for some photos
+{% endfigure %}
 
-{% figure vulcano-053.jpg landscape original %}Paul photographing the islands, crater and sunset{% endfigure %}
+{% figure vulcano-053.jpg landscape original %}
+Paul photographing the islands, crater and sunset
+{% endfigure %}
 
 After all that photo taking, and with the sunset over, we had the mild problem of getting past the molten sulphur field, in the dark, and in sandals. We found a thin path upwind, and avoided the worst of it. But some sulphur vents were a little too close for comfort; they whizzed and hissed as we crept by, angry yellow chimneys with yellow slug trails. Where we couldn't avoid the smoke plumes we held our breath and ran through, the air warm on our legs and sharp on our nose. Hop, dash, jog, and done, nothing too bad.
 
@@ -47,4 +67,6 @@ It took us a mere 20 minutes to get down again, including the occasional night s
 
 We finished up just in time for the 11pm shuttle back to the hotel.
 
-{% figure vulcano-050.jpg landscape %}Vulcano at night{% endfigure %}
+{% figure vulcano-050.jpg landscape %}
+Vulcano at night
+{% endfigure %}

--- a/source/_posts/a-week-on-vulcano-sicily/5.md
+++ b/source/_posts/a-week-on-vulcano-sicily/5.md
@@ -13,14 +13,22 @@ At first all this sounded like torture. The steam in the Turkish spa stung my no
 
 Today was a little cooler and the sky was dotted with clouds. Still, the pool and our books beckoned, and the hours passed by until evening. At 8pm, ready for the sunset with wide angle lens and tripod, we waited with cocktails and bar snacks. The sun streamed through the gaps in the clouds, but never quite lit them in a spectacular way. We took the shuttle into town after that, perused some shops, and were at Maurizios for 9pm, we'd made a reservation this time and had the luxury of sitting inside the restaurant.
 
-{% figure vulcano-055.jpg landscape %}Sun breaking through the clouds over Filicudi{% endfigure %}
+{% figure vulcano-055.jpg landscape %}
+Sun breaking through the clouds over Filicudi
+{% endfigure %}
 
-{% figure vulcano-056.jpg landscape %}Therasia resort and its sublime view{% endfigure %}
+{% figure vulcano-056.jpg landscape %}
+Therasia resort and its sublime view
+{% endfigure %}
 
 ## Maurizio's (again)
 
 It's a quirky peculiar place. The walls are brushed with gold, and oriental and kitschy ornaments hang together, a large mirror with words sprawled across it, two great japanese parasols and a great bejewelled metal chandelier that looked like the imaginings of a 1920s futurist, half rocket half light fitting. Maurizio welcomed us back, and this time around we enjoyed sardine pasta and pasta del mare, being careful not to order too much. The dessert gift was this time a cardamon wine, with almond biscotti; by description neither of us should like it, but we can't say we didn't.
 
-{% figure vulcano-061.jpg portrait %}Paul at Maurizio's{% endfigure %}
+{% figure vulcano-061.jpg portrait %}
+Paul at Maurizio's
+{% endfigure %}
 
-{% figure vulcano-060.jpg portrait %}Shopping on Vulcano{% endfigure %}
+{% figure vulcano-060.jpg portrait %}
+Shopping on Vulcano
+{% endfigure %}

--- a/source/_posts/a-week-on-vulcano-sicily/6.md
+++ b/source/_posts/a-week-on-vulcano-sicily/6.md
@@ -9,15 +9,21 @@ page: 6
 
 On our last full day we didn't fancy doing much. Sam's kayaking tour was cancelled and an all day boat trip to Stromboli isn't the best way to relax before travelling home (though probably a trip we should have done, it sounded good). We went for a 'casual walk' instead, to a new part of the island. From town we found Baia Negra, and continued south from there, looking for a footpath up into the hills. But the map's marked path was closed, so we followed the unshaded roads up to the Lentia viewpoint on the west of the island. It was baking and the tarmac was hot to the touch.
 
-{% figure vulcano-065.jpg landscape %}View of Gran Cratere on route to Lentia{% endfigure %}
+{% figure vulcano-065.jpg landscape %}
+View of Gran Cratere on route to Lentia
+{% endfigure %}
 
 Lentia itself is a small village of expensive holiday homes, with a pool, a bar and a tennis court; the latter with its tall fences placed right against the best of the views, a tragedy. We stopped for a Cornetto and headed back. Looking south on the return journey, we could see Sicily and the rest of Vulcano. Beneath us were cute coves and miniature beaches, reachable only by boat.
 
 It wouldn't be a Sam and Paul holiday unless we had some fresh bread, cheese and salami as a cheap picnic lunch from the local supermarket. We picked up some snacks and Malvasia for home too, and enjoyed a homemade lunch on our hotel balcony. We spent our remaining hours in the pool until the sun began to dip. We packed our clothes, dressed up for dinner and meandered the hotel with our camera and tripod.
 
-{% figure vulcano-066.jpg landscape %}Last day in the pool{% endfigure %}
+{% figure vulcano-066.jpg landscape %}
+Last day in the pool
+{% endfigure %}
 
-{% figure vulcano-070.jpg portrait %}Samantha looked beautiful against the red light of sunset, on our final night{% endfigure %}
+{% figure vulcano-070.jpg portrait %}
+Samantha looked beautiful against the red light of sunset, on our final night
+{% endfigure %}
 
 ## Il Cappero (again)
 

--- a/source/_posts/a-week-on-vulcano-sicily/7.md
+++ b/source/_posts/a-week-on-vulcano-sicily/7.md
@@ -13,4 +13,6 @@ England welcomed us home with its first prolonged heat wave since 2006, the Lion
 
 What a stunning and relaxing holiday. Sublime wonderful views of Aeolian islands combined with the agreeable, cheerful and quite perfect Therasia hotel. It gave us the time-off we ever so needed. Five star recuperation by the sea, it does the trick.
 
-{% figure vulcano-069.jpg landscape %}Posing with the sunset for one final time{% endfigure %}
+{% figure vulcano-069.jpg landscape %}
+Posing with the sunset for one final time
+{% endfigure %}

--- a/source/_posts/a-weekend-in-harrogate.md
+++ b/source/_posts/a-weekend-in-harrogate.md
@@ -20,41 +20,75 @@ With the last of our national trust wedding vouchers from Sam's aunt, we bought 
 
 Fountains abbey is a huge, ruined 12th century monument, and a UNESCO world heritage site. It is enormous! The spire still survives, along with the main walls of the church. Gaping holes show where beautiful stained glass would have been. A stone altar partly stands, looking down the length of the ruin, it's a roofless cathedral with a grass carpet. Above us a murder of crows shouts and squabbles, fighting over sitting space on the spire. Their nests are buried into the alcoves of the ruin. A group of school kids on a guided tour pass by, dressed head to toe as traditional monks, it's a strange sight. We listen as their guide explains the lavatorium and how monks would bathe four times a year. Between all the walls we stopped and shifted to get interesting photos, waiting and hoping for the birds to swoop at the right time, but never quite getting the shot we wanted.
 
-{% figure harrogate-002.jpg landscape %}Fountains Abbey{% endfigure %}
+{% figure harrogate-002.jpg landscape %}
+Fountains Abbey
+{% endfigure %}
 
-{% figure harrogate-003.jpg landscape %}Exploring the ruins{% endfigure %}
+{% figure harrogate-003.jpg landscape %}
+Exploring the ruins
+{% endfigure %}
 
-{% figure harrogate-005.jpg landscape %}Remains of Fountains Abbey{% endfigure %}
+{% figure harrogate-005.jpg landscape %}
+Remains of Fountains Abbey
+{% endfigure %}
 
-{% figure harrogate-006.jpg landscape %}Looking down the aisle{% endfigure %}
+{% figure harrogate-006.jpg landscape %}
+Looking down the aisle
+{% endfigure %}
 
-{% figure harrogate-007.jpg portrait %}Looking up the surviving belltower{% endfigure %}
+{% figure harrogate-007.jpg portrait %}
+Looking up the surviving belltower
+{% endfigure %}
 
-{% figure harrogate-008.jpg portrait %}Paul in the doorway{% endfigure %}
+{% figure harrogate-008.jpg portrait %}
+Paul in the doorway
+{% endfigure %}
 
-{% figure harrogate-009.jpg landscape %}Crows flying overhead{% endfigure %}
+{% figure harrogate-009.jpg landscape %}
+Crows flying overhead
+{% endfigure %}
 
-{% figure harrogate-010.jpg landscape %}Cloisters{% endfigure %}
+{% figure harrogate-010.jpg landscape %}
+Cloisters
+{% endfigure %}
 
-{% figure harrogate-011.jpg portrait %}Samantha in the doorway{% endfigure %}
+{% figure harrogate-011.jpg portrait %}
+Samantha in the doorway
+{% endfigure %}
 
-{% figure harrogate-012.jpg landscape %}The ancient and beautiful Fountains Abbey{% endfigure %}
+{% figure harrogate-012.jpg landscape %}
+The ancient and beautiful Fountains Abbey
+{% endfigure %}
 
 Beyond the ruin lies a water garden, where the natural river valley is sculpted into beautiful greens with statues and ducks, and fearless frogs that leap in front of you. Pheasants (not grouse), flicked up dead leaves searching for a tasty grub. We climbed the hillside to get the best viewpoints, from Anne Boleyn's shed and the more ornate temple. And we stopped for a picnic, I'd purchased some hobnobs, chocolate ones too.
 
-{% figure harrogate-014.jpg landscape %}Friendly pheasant{% endfigure %}
+{% figure harrogate-014.jpg landscape %}
+Friendly pheasant
+{% endfigure %}
 
-{% figure harrogate-021.jpg landscape %}Grumpy toad{% endfigure %}
+{% figure harrogate-021.jpg landscape %}
+Grumpy toad
+{% endfigure %}
 
-{% figure harrogate-016.jpg portrait %}Happy Samantha{% endfigure %}
+{% figure harrogate-016.jpg portrait %}
+Happy Samantha
+{% endfigure %}
 
-{% figure harrogate-017.jpg landscape %}River view from Anne Boleyn's shed{% endfigure %}
+{% figure harrogate-017.jpg landscape %}
+River view from Anne Boleyn's shed
+{% endfigure %}
 
-{% figure harrogate-018.jpg landscape %}[A gnarly tree](http://500px.com/photo/80856857/gnarly-tree-by-samantha-hayes){% endfigure %}
+{% figure harrogate-018.jpg landscape %}
+[A gnarly tree](http://500px.com/photo/80856857/gnarly-tree-by-samantha-hayes)
+{% endfigure %}
 
-{% figure harrogate-019.jpg landscape %}Paul by the lakes{% endfigure %}
+{% figure harrogate-019.jpg landscape %}
+Paul by the lakes
+{% endfigure %}
 
-{% figure harrogate-022.jpg landscape %}Quintessential Hobnobs{% endfigure %}
+{% figure harrogate-022.jpg landscape %}
+Quintessential Hobnobs
+{% endfigure %}
 
 Further along, past all the pretty lakes and ponds, we came to the end of the grounds and a small tea room. A perfect excuse for tea and carrot cake, while watching the crows dance about the outdoor tables.
 
@@ -64,7 +98,9 @@ Beyond the tended grounds the grass grew long and scattered with mole hills. We 
 
 In the car we drove through the beautiful Yorkshire countryside to Ripon, stopping to peruse the local shops, grab a tasty homemade pork pie and explore the cathedral, complete with ancient crypt. We learnt the history of Ripon through knitted cushions adorning the church edge.
 
-{% figure harrogate-023.jpg landscape %}Ripon cathedral{% endfigure %}
+{% figure harrogate-023.jpg landscape %}
+Ripon cathedral
+{% endfigure %}
 
 ## Orchid
 

--- a/source/_posts/a-weekend-in-harrogate/2.md
+++ b/source/_posts/a-weekend-in-harrogate/2.md
@@ -15,29 +15,49 @@ An exhibition of Neil Simone's oil paintings was on show; an interesting gallery
 
 At the hotel we rested and snacked before driving west to Bolton Abbey, just inside the Yorkshire dales national park. Another ruined abbey to explore, but despite being left to ruin in the 16th century after the dissolution by Henry VIII, a functioning parish church still survives on the site. The spire and adorning buildings are long but gone, and daffodils grow up the sides of their eroding walls.
 
-{% figure harrogate-024.jpg portrait %}Bolton Abbey{% endfigure %}
+{% figure harrogate-024.jpg portrait %}
+Bolton Abbey
+{% endfigure %}
 
-{% figure harrogate-025.jpg landscape %}Samantha outside Bolton Abbey{% endfigure %}
+{% figure harrogate-025.jpg landscape %}
+Samantha outside Bolton Abbey
+{% endfigure %}
 
-{% figure harrogate-026.jpg portrait %}One big climbing frame{% endfigure %}
+{% figure harrogate-026.jpg portrait %}
+One big climbing frame
+{% endfigure %}
 
 Beyond the Abbey is a river with stepping stones to cross. Kids, adults and ramblers brave the hop skip jump as the water flows through the gaps. For the less brave a wooden bridge is available to cross.
 
-{% figure harrogate-027.jpg landscape %}Stepping stones{% endfigure %}
+{% figure harrogate-027.jpg landscape %}
+Stepping stones
+{% endfigure %}
 
-{% figure harrogate-029.jpg landscape %}Samantha risking the route{% endfigure %}
+{% figure harrogate-029.jpg landscape %}
+Samantha risking the route
+{% endfigure %}
 
-{% figure harrogate-030.jpg landscape %}Stepping stones and Bolton Abbey{% endfigure %}
+{% figure harrogate-030.jpg landscape %}
+Stepping stones and Bolton Abbey
+{% endfigure %}
 
 A trek took us up the side of the valley, with gorgeous views over the ruins and Yorkshire dales. Legs still tired we took the shorter walk, and stopped to photograph the 'V' formations of geese flying overhead.
 
-{% figure harrogate-031.jpg landscape %}Desolate view of Bolton Abbey{% endfigure %}
+{% figure harrogate-031.jpg landscape %}
+Desolate view of Bolton Abbey
+{% endfigure %}
 
-{% figure harrogate-032.jpg landscape %}View of Bolton Abbey from valley edge{% endfigure %}
+{% figure harrogate-032.jpg landscape %}
+View of Bolton Abbey from valley edge
+{% endfigure %}
 
-{% figure harrogate-033.jpg portrait %}Geese flying in a V formation{% endfigure %}
+{% figure harrogate-033.jpg portrait %}
+Geese flying in a V formation
+{% endfigure %}
 
-{% figure harrogate-034.jpg portrait %}Daffodil outside the abbey{% endfigure %}
+{% figure harrogate-034.jpg portrait %}
+Daffodil outside the abbey
+{% endfigure %}
 
 ## The Burlington, our first Michelin star
 

--- a/source/_posts/a-weekend-in-harrogate/3.md
+++ b/source/_posts/a-weekend-in-harrogate/3.md
@@ -9,44 +9,74 @@ page: 3
 
 Our final full day in Harrogate, we were up early again and I had another full English, though this time without the eggs. Sam had just the eggs, on toast. And we helped ourselves to the tea and coffee. We had another National Trust place on our list to visit. To the north west, beyond Ripon, lie Brimham Rocks. Here huge and peculiar formations of rock poke from the ground, perfect for climbing.
 
-{% figure harrogate-035.jpg portrait %}Paul at Brimham Rocks{% endfigure %}
+{% figure harrogate-035.jpg portrait %}
+Paul at Brimham Rocks
+{% endfigure %}
 
-{% figure harrogate-037.jpg portrait %}Paul amongst the rocks{% endfigure %}
+{% figure harrogate-037.jpg portrait %}
+Paul amongst the rocks
+{% endfigure %}
 
 The sky was a dark blue, and scattered with fluffy white clouds. Some huge boulders looked precarious, as if one slight push would send them tumbling after thousands of years of erosion. Each interesting new tower invited us to climb it, scrambling into the nooks and crannies, jumping and pulling to get to the top, each peak afforded sweeping views of the Yorkshire dales.
 
-{% figure harrogate-038.jpg landscape %}Samantha and the Yorkshire Dales{% endfigure %}
+{% figure harrogate-038.jpg landscape %}
+Samantha and the Yorkshire Dales
+{% endfigure %}
 
-{% figure harrogate-040.jpg landscape %}Brimham Rocks{% endfigure %}
+{% figure harrogate-040.jpg landscape %}
+Brimham Rocks
+{% endfigure %}
 
-{% figure harrogate-041.jpg portrait %}Novice bouldering{% endfigure %}
+{% figure harrogate-041.jpg portrait %}
+Novice bouldering
+{% endfigure %}
 
-{% figure harrogate-043.jpg landscape %}Queen of the rocks{% endfigure %}
+{% figure harrogate-043.jpg landscape %}
+Queen of the rocks
+{% endfigure %}
 
-{% figure harrogate-045.jpg portrait %}A view of Brimham Rocks, almost like a Halo map{% endfigure %}
+{% figure harrogate-045.jpg portrait %}
+A view of Brimham Rocks, almost like a Halo map
+{% endfigure %}
 
 The climbing abated when we stopped for tea and chocolate hobnobs. Excitingly for me, but probably not for many other people, I spotted a millipede, I've seen then many times before but never in England. Beyond the shop and tea stall a path takes you around the top-most peninsula. Past the dancing bear formation, around to the Druids writing desk, a huge twisted plinth leaning out over the edge. Then the amazing balancing rock, an enormous boulder precariously standing on the smallest point you can imagine.
 
-{% figure harrogate-001.jpg landscape %}The amazing balancing rock formation{% endfigure %}
+{% figure harrogate-001.jpg landscape %}
+The amazing balancing rock formation
+{% endfigure %}
 
-{% figure harrogate-047.jpg landscape %}Druids writing desk{% endfigure %}
+{% figure harrogate-047.jpg landscape %}
+Druids writing desk
+{% endfigure %}
 
 We climbed another formation for glorious views to the north. Large black crows skipped about the rock next to us, and the sun was warm, cutting through the crisp spring air. The fields shone green, dotted with the occasional sheep.
 
-{% figure harrogate-049.jpg landscape %}Samantha and the Yorkshire Dales{% endfigure %}
+{% figure harrogate-049.jpg landscape %}
+Samantha and the Yorkshire Dales
+{% endfigure %}
 
-{% figure harrogate-050.jpg landscape %}Paul looking out at the Yorkshire Dales{% endfigure %}
+{% figure harrogate-050.jpg landscape %}
+Paul looking out at the Yorkshire Dales
+{% endfigure %}
 
-{% figure harrogate-051.jpg landscape %}Star jumps!{% endfigure %}
+{% figure harrogate-051.jpg landscape %}
+Star jumps!
+{% endfigure %}
 
 Further round, now circling the tea room, the land turned to heath, and a pair of grouse were spotted fighting in the growth before spotting us and flying away. Atop another rock, we had just enough signal to make a phone call. It being Mothering Sunday, we called our mums, although it seems there was only enough signal for one call at a time, when Sam began her chat I would be consistently cut off. From here we could see Harrogate and the mysterious Menwith radomes at the US air base. We picnicked on the rocks and returned to the car. Before heading home we took a drive through the dales, through Pateley Bridge, Hebden and Grassington, down to Skipton and back to Harrogate.
 
-{% figure harrogate-052.jpg landscape %}Reclining on the rocks, chatting to mum{% endfigure %}
+{% figure harrogate-052.jpg landscape %}
+Reclining on the rocks, chatting to mum
+{% endfigure %}
 
-{% figure harrogate-053.jpg landscape %}One last climb before we go{% endfigure %}
+{% figure harrogate-053.jpg landscape %}
+One last climb before we go
+{% endfigure %}
 
 The rest of the day was quiet, we relaxed, I watched football on the TV, we slept and then went for dinner at the hotel restaurant. A hearty tasty meal to end the trip.
 
-{% figure harrogate-054.jpg landscape %}The Chevy we rented{% endfigure %}
+{% figure harrogate-054.jpg landscape %}
+The Chevy we rented
+{% endfigure %}
 
 On Monday I wheeled my suitcase to Harrogate station and headed into work on the train, three hours through the rolling green of East Anglia with all its power stations. Sam stayed in town for her conference, which lasted until Thursday, she changed hotels and had time to properly visit Betty's for tea and cake.

--- a/source/_posts/a-weekend-in-london-at-the-hoxton.md
+++ b/source/_posts/a-weekend-in-london-at-the-hoxton.md
@@ -15,11 +15,15 @@ The [Hoxton](http://en.wikipedia.org/wiki/Hoxton) [Hotel](http://www.hoxtonhotel
 
 Said weekend started last Friday, we each took the day off and took our quick and usual route into the centre; meeting outside Leicester Square, cases in tow, ready to be tourists for a couple of days. After apple juice and lunch in St James' park we took the Northern Line to Old Street and checked in, electrified by the overwhelming trendiness that is both the hotel and surrounding area.
 
-{% figure hoxton-20081020-our-room.JPG landscape %}Samantha in our Hoxton hotel room{% endfigure %}
+{% figure hoxton-20081020-our-room.JPG landscape %}
+Samantha in our Hoxton hotel room
+{% endfigure %}
 
 Note the scissor, paper, stone pillows. With pre-booked tickets for Avenue Q at the 5:30pm matinee it wasn't long before we were back on the streets, exploring Hoxton and Shoreditch and grabbing a Tortilla (potato quiche) and roasted veggies from the excellent and delicious [Food Hall](http://www.welovelocal.com/en/london/hackney/hoxton/delicatessen/food-hall-ec1v9lt.html) on Old Street. We LOVE this place and would spend a fortune here if left unaccompanied.
 
-{% figure hoxton-20081020-foodhall.JPG landscape %}Foodhall, we love this place{% endfigure %}
+{% figure hoxton-20081020-foodhall.JPG landscape %}
+Foodhall, we love this place
+{% endfigure %}
 
 ## Avenue Q
 
@@ -29,20 +33,28 @@ Middle of the middle in the stalls we watched the well praised Avenue Q as the G
 
 On Saturday we considered rushing to Leicester square to grab theatre tickets early in the morning; but rising late at 10am we quickly abandoned this notion, instead just following our noses. Up 'n' down Brick Lane, past _Les Trois Garcons_ - too eccentric for Sam's tastes, to the Food Hall for caramelized garlic bread, cheese, spinach tortilla and anchovy cauliflowers, respectively devoured by the canal off Upper Street near Angel.
 
-{% figure hoxton-20081020-bread.JPG landscape %}Samantha enjoying our bread and cheese picnic{% endfigure %}
+{% figure hoxton-20081020-bread.JPG landscape %}
+Samantha enjoying our bread and cheese picnic
+{% endfigure %}
 
 Darting back in via tube we saw the sites; Trafalgar square, Buckingham palace, Hyde Park and all that. After a tea/cappuccino recuperation stop spent watching the passing horses and cyclists in Hyde Park we tried to find an evening event. All the movies at the BFI film festival were sold out, as were any shows we'd planned to see - judging by the boards in the square. Music events were the next option but of course the weekend doesn't have free papers to look these up! Going out on a limb, we headed to the [Apollo Theatre](http://www.apollo-theatre-london.co.uk/) looking for tickets to Rain Man starring Josh Hartnett and Adam Godley; luck would have it they still had some and for £31 each we grabbed upper circle seats for the 7:30pm showing. With two hours to spare we had a set menu Chinese dinner at Mr Kong's in Chinatown - the usual duck pancakes, sesame bread, seaweed et al.
 
 Neither of us had seen the Dustin Hoffman movie, we went in without any expectations and without grounds for comparison. We left absolutely stunned - wow; the play was brilliant with Godley and Hartnett supremely leaving us on tender hooks. This was the first straight up play we'd seen together and no doubt we'll be back for more of the same.
 
-{% figure hoxton-20081020-rainman.JPG landscape %}Rain Man at the west end, with Josh Hartnett and Adam Godley{% endfigure %}
+{% figure hoxton-20081020-rainman.JPG landscape %}
+Rain Man at the west end, with Josh Hartnett and Adam Godley
+{% endfigure %}
 
 ## The sights
 
 Sunday took us to the areas of London we wouldn't normally go, London Bridge, Tower Bridge, the Tower of London and later South Kensington for lunch and the museums. We stopped at the Hoop & Toy in Kensington for a relatively cheap but tasty steak/burger with a bottle of red 'Cape Promise Pinotage'. With alcohol fueling our system we pleasantly stumbled around the Victoria and Albert museum, napping by the large middle Eastern carpets, and then later to the Natural History Museum - through Geology, past the birds and into the realm of the dinosaurs, before being ushered out at the close of play.
 
-{% figure hoxton-20081020-tower-bridge.JPG portrait %}Samantha on London’s tower bridge{% endfigure %}
+{% figure hoxton-20081020-tower-bridge.JPG portrait %}
+Samantha on London’s tower bridge
+{% endfigure %}
 
-{% figure hoxton-20081020-natural-history.JPG landscape %}Triceratops at the Natural History museum{% endfigure %}
+{% figure hoxton-20081020-natural-history.JPG landscape %}
+Triceratops at the Natural History museum
+{% endfigure %}
 
 More tea breaks back at the Hoxton Hotel where we picked up our bags and aimlessly chatted as the time whisked away, soaking up the coolness of the vibe, shoes off and relaxed. Then home and an end to our wonderful weekend; looking forward to the next one.

--- a/source/_posts/angkor-wat-cambodia.md
+++ b/source/_posts/angkor-wat-cambodia.md
@@ -26,7 +26,9 @@ Cheerful staff were waiting our arrival, they helped us out of the car and empha
 
 We were shown to our room, through the small tropical garden and past the Indochine Angkor posters, old suitcases and Buddha statues, up the stairs. Along the corridor's ceiling the uncontrollable ants were chasing something sweet, avoiding the geckos that liked to snack on them.
 
-{% figure angkor-wat--002.jpg landscape %}Our room at the Pavillon D'orient{% endfigure %}
+{% figure angkor-wat--002.jpg landscape %}
+Our room at the Pavillon D'orient
+{% endfigure %}
 
 The room was large, light brown and beige with a wooden floor. It got the, “Oh, wow” response from both of us. Even the mosquito nets were somehow romantic. A balcony with seats looked out towards the pool, and a writing desk had fresh fruit, complimentary red wine and an intriguing paper maché sculpture.
 

--- a/source/_posts/angkor-wat-cambodia/2.md
+++ b/source/_posts/angkor-wat-cambodia/2.md
@@ -19,7 +19,9 @@ Angkor means “city”, our guide told us. “Wat” means temple, which we kne
 
 We approached via the south gate. A bridge crosses a huge manmade moat, and the gate is a decorated narrow archway leading through a towering wall, into the walled city. The bridge is lined with 54 demon gods and guardian gods, good and evil, each holding the body of a giant snake. The snake's head would've been at the front, its tail, it's believed, is in the kingdom of the gods. Many of the figures were eroded, faces melted by weathering over centuries of wet seasons. Others were renovated or replaced. The gate is topped with a tower, which bears four faces looking in each direction and elephants at its foot, controlled by the Hindu god Indra.
 
-{% figure angkor-wat--001.jpg landscape %}A guardian god at the south gate of Angkor Thom{% endfigure %}
+{% figure angkor-wat--001.jpg landscape %}
+A guardian god at the south gate of Angkor Thom
+{% endfigure %}
 
 It was already pretty busy, but being the wet season it was, apparently, much quieter than most other times of year. It had seemed like it might rain, but the skies cleared up, and our umbrellas began their dual use as a parasol.
 
@@ -27,15 +29,23 @@ It was already pretty busy, but being the wet season it was, apparently, much qu
 
 There are five gates into Angkor Thom and they all converge on Bayon temple. We drove onwards, in our red outfitted tuk-tuk, our guide riding backwards. To our first temple, Bayon, the crazy magnificent Bayon. It is Angkor Thom's centrepiece. Like most temples it faces East, I forget the reasoning, and it has three levels. It is crowned with scattered towers adorning approximately 200 Lokesvara faces, a bodhisattva, which embodies the compassion of all Buddhas.
 
-{% figure angkor-wat--004.jpg landscape %}Bayon temple{% endfigure %}
+{% figure angkor-wat--004.jpg landscape %}
+Bayon temple
+{% endfigure %}
 
 Our guide begun with the outermost galleries, or gopura if you like. These stone galleries showed traditional Angkorian Khmer life, and the occasional historic event. Our guide finds a spot and tells us a story, that's his style, carved into the stone are the Khmer army, a Chinese army and Cham forces, distinguishable by their clothing and stretched ears. Amongst the soldiers were scenes of a cockfight, a market, boats and fishermen, and a man being bitten by a turtle. As Sam takes in everything I sneak about the corridors attempting to find a mystical photo minus blue shirted tourist.
 
-{% figure angkor-wat--005.jpg landscape %}Outermost galleries of Bayon{% endfigure %}
+{% figure angkor-wat--005.jpg landscape %}
+Outermost galleries of Bayon
+{% endfigure %}
 
-{% figure angkor-wat--007.jpg landscape %}Temple dog{% endfigure %}
+{% figure angkor-wat--007.jpg landscape %}
+Temple dog
+{% endfigure %}
 
-{% figure angkor-wat--008.jpg landscape %}Looking up at a bodhisattva face{% endfigure %}
+{% figure angkor-wat--008.jpg landscape %}
+Looking up at a bodhisattva face
+{% endfigure %}
 
 Inside and up to the first level, an inner gallery, the carvings here are purely religious, with many dancing Hindu gods. Beyond the inner gallery is the second level, the upper terrace, an open pathway that circles the central tower and sanctuary. Here the tourists gather and pose with the giant Bayon faces, up close and personal. Naturally we did the same. The faces are always in a formation of four, one looking in each direction, with varying degrees of preservation. Many still look stunning, and peculiar. Our guide knows all the best photo spots.
 
@@ -43,15 +53,25 @@ The sun is out, and away from the shade it's unbearable. Beneath the umbrellas w
 
 After a quick exploration of the dark central tower we climb down and exit Bayon. We look back at the beautiful odd thing from a distance, as an elephant and tuk tuk go by.
 
-{% figure angkor-wat--011.jpg landscape %}Many faces (part 1){% endfigure %}
+{% figure angkor-wat--011.jpg landscape %}
+Many faces (part 1)
+{% endfigure %}
 
-{% figure angkor-wat--012.jpg landscape %}Many faces (part 2){% endfigure %}
+{% figure angkor-wat--012.jpg landscape %}
+Many faces (part 2)
+{% endfigure %}
 
-{% figure angkor-wat--017.jpg portrait %}Paul being a poser{% endfigure %}
+{% figure angkor-wat--017.jpg portrait %}
+Paul being a poser
+{% endfigure %}
 
-{% figure angkor-wat--021.jpg portrait %}Samantha at the top of Bayon temple{% endfigure %}
+{% figure angkor-wat--021.jpg portrait %}
+Samantha at the top of Bayon temple
+{% endfigure %}
 
-{% figure angkor-wat--027.jpg portrait %}Looking back at Bayon temple{% endfigure %}
+{% figure angkor-wat--027.jpg portrait %}
+Looking back at Bayon temple
+{% endfigure %}
 
 ## Baphuon temple
 
@@ -59,19 +79,27 @@ We walked North West to Baphuon, a temple painstakingly restored by the French. 
 
 Once more we sat down amongst the stones to listen to a story. I idly watch the butterflies flit about by a reflection pool. Sam meanwhile discusses Cambodian-Vietnamese-Thai relations, and recent tensions. A long bridge to our right leads up to the temple.
 
-{% figure angkor-wat--028.jpg landscape %}Baphuon temple{% endfigure %}
+{% figure angkor-wat--028.jpg landscape %}
+Baphuon temple
+{% endfigure %}
 
 We're left to explore the temple; up our first set of steep temple steps. Each level resembles a completed jigsaw, lovingly pieced together. From the top we took in the views, the reflection pools and bridge stretching out beneath us, and disappearing into a thick canopy, the trees too tall to see much else. The sun is out, and it's getting hotter, Sam's Vietnamese hat is working wonders; shade and air flow. Essential headwear. Down the west side we saw the pieced together remains of the giant Buddha.
 
-{% figure angkor-wat--031.jpg landscape %}From the top of Baphuon, Sam looking somewhat nervous{% endfigure %}
+{% figure angkor-wat--031.jpg landscape %}
+From the top of Baphuon, Sam looking somewhat nervous
+{% endfigure %}
 
 ## Phimeanakas temple
 
 Not yet lunch time and to our third temple, Phimeanakas, via an ancient tree with a human nose. “There's no story for this one”, the guide said. No matter, we clambered and explored the 10th century temple, over a thousand years old and still standing, despite everything. It would've been close to the ancient royal palace, though that was a wooden masterpiece, and has since disappeared.
 
-{% figure angkor-wat--034.jpg portrait %}A gnarly old tree{% endfigure %}
+{% figure angkor-wat--034.jpg portrait %}
+A gnarly old tree
+{% endfigure %}
 
-{% figure angkor-wat--036.jpg landscape %}Phimeanakas temple{% endfigure %}
+{% figure angkor-wat--036.jpg landscape %}
+Phimeanakas temple
+{% endfigure %}
 
 Further on we come out onto the Elephant Terrance and the Terrace of the Leper King. Our guide did a poor job of explaining this one, but from here the king would watch huge processions pass by, usually of his victorious returning army. By now we were very tired and hot, and there's no shade on the terrace. As sweat poured down our faces the guide asked, “Lunch?”. At the tuk-tuk Vesna pulls out a bottle of ice cold water, “Oh wow, yes please, thank you ever so much”.
 
@@ -81,11 +109,15 @@ We ate at a small restaurant in front of Angkor Wat; rice, curry and cold drinks
 
 Post-lunch we head out to Angkor Wat, in the searing mid-afternoon heat. It is however one of the quieter times to visit. Like Angkor Thom, Angkor Wat is surrounded by a manmade moat, with a bridge into the complex. The bridge is adorned with Naga snakes, and a recent French recreation of a Naga's head sits at the front, Sam marvelled at its intricate detail. At the entrance the stone pillars are littered with bullet wounds, shots fired during the Vietnam war, in a siege that saw the Khmer defending their beloved temple.
 
-{% figure angkor-wat--038.jpg portrait %}Bullet holes at Angkor Wat{% endfigure %}
+{% figure angkor-wat--038.jpg portrait %}
+Bullet holes at Angkor Wat
+{% endfigure %}
 
 Inside the grounds were luscious, and the grasses green. Beyond two libraries, one either side of the path, were the famous reflecting pools. We posed against the reflections, Angkor Wat's five towers visible behind us.
 
-{% figure angkor-wat--039.jpg landscape %}Posing by the famous reflection pools{% endfigure %}
+{% figure angkor-wat--039.jpg landscape %}
+Posing by the famous reflection pools
+{% endfigure %}
 
 Having dodged more souvenir pedlars, we entered the vast temple. It's surrounded by an outer gallery, with detailed stonework illustrating classic Hindu stories. The important details of each bas relief are highlighted, made shiny after years of groping by tourists and guides alike.
 
@@ -99,15 +131,23 @@ We crossed into the centre of the temple, an enclosed courtyard with a towering 
 
 From the top level we had views out across the Angkor plains, trees spread out in every direction. A yellow bulb of a helium balloon bobbed amidst the forest. Everything is so very flat, and there's no high rises or buildings to spoil the view, just a dusty haze. I wonder how long it will stay like that with tourism booming. A monk dressed in orange passed us by, quietly placing golden metal petals on each of the Buddha statues, some sort of ritual we couldn't understand. We stayed up here for a while, the cool breeze that passes through the windows is lovely, and it's quiet too, relaxing.
 
-{% figure angkor-wat--042.jpg landscape %}Reclining Buddha at Angkor Wat{% endfigure %}
+{% figure angkor-wat--042.jpg landscape %}
+Reclining Buddha at Angkor Wat
+{% endfigure %}
 
-{% figure angkor-wat--043.jpg landscape %}Looking out from the top of Angkor Wat{% endfigure %}
+{% figure angkor-wat--043.jpg landscape %}
+Looking out from the top of Angkor Wat
+{% endfigure %}
 
-{% figure angkor-wat--044.jpg landscape %}The view from the top of Angkor Wat{% endfigure %}
+{% figure angkor-wat--044.jpg landscape %}
+The view from the top of Angkor Wat
+{% endfigure %}
 
 We left Angkor Wat, passing a macaque on the way out. I think it really is best from the outside, it looks simply fabulous. Inside is a little disappointing, a shadow of its former self. Although it was never quite finished, many carvings lie half finished. Late afternoon now, the sun still burning, we asked about the best place for a sunset. “Bakheng”, our guide recommended, a mountain temple atop a hill.
 
-{% figure angkor-wat--050.jpg landscape %}Angkor Wat, from the entrance{% endfigure %}
+{% figure angkor-wat--050.jpg landscape %}
+Angkor Wat, from the entrance
+{% endfigure %}
 
 ## Bakheng temple
 
@@ -115,7 +155,9 @@ As we climbed the spiralling gravel walkway up the hill the clouds materialised 
 
 By now the clouds had turned to rain, and as we sheltered under an umbrella we realised there wouldn't be a sunset worth watching. Slowly people left, and eventually we didn't have a choice. The officials closed the temple early. No sunset tonight folks. Time to go. Disappointing, but I didn't feel like we were missing much. It was like this every night of our time here, no beautiful sunsets to be had.
 
-{% figure angkor-wat--052.jpg landscape %}No sunset tonight{% endfigure %}
+{% figure angkor-wat--052.jpg landscape %}
+No sunset tonight
+{% endfigure %}
 
 On the tuk-tuk home the darkness set in. Our guide had helped with a lot of things, but he wasn't stellar, we didn't choose to have a guide on any of our future temple visits.
 

--- a/source/_posts/angkor-wat-cambodia/3.md
+++ b/source/_posts/angkor-wat-cambodia/3.md
@@ -15,11 +15,15 @@ As one of the first tuk-tuks to arrive, the kids selling items were energetic, a
 
 The temple is reached via a long muddy path. The air was misty and eerie, the path empty but for a photographer and tripod, returning from his sunrise photo shoot. At the entrance, a shaky temple wall, a small mound and a great tree rising up. Seemingly the middle of nowhere.
 
-{% figure angkor-wat--053.jpg portrait %}Ta Prohm{% endfigure %}
+{% figure angkor-wat--053.jpg portrait %}
+Ta Prohm
+{% endfigure %}
 
 But the mysticism and wonder were quickly dispelled. On entering, into the most picturesque and famous part of the temple, a renovations work crew were having their morning meeting. In yellow hard hats, against a truck and a giant crane, these workmen prepared for their day of restoration. Not the serene jungle setting I had expected, “inconvenience caused is regretted” a sign said. Brand new boardwalks and ropes protect the temple and tree roots from visitors, but also scar whatever photos you might hope to capture.
 
-{% figure angkor-wat--057.jpg landscape %}Workmen at Ta Prohm{% endfigure %}
+{% figure angkor-wat--057.jpg landscape %}
+Workmen at Ta Prohm
+{% endfigure %}
 
 Sam wasn't feeling great, and she had to wander back up the muddy path to find a “happy room”, as it is called here. Leaving me to explore this place by myself, armed with a digital SLR and a gorilla tripod.
 
@@ -27,11 +31,17 @@ Beyond the opening disappointment the temple is everything I'd expected and hope
 
 I wandered around carefree for an hour or so, three laps of this amazing place, finding something new each time. In an empty opening, amongst the roots of an ancient tree, I sat, listening to the birds, the sounds of the jungle, the rustling of the leaves, watching the swaying of the trees. I must've stayed here for ten minutes or so, uninterrupted.
 
-{% figure angkor-wat--062.jpg landscape %}A hidden room, I sat and watched, for ten minues, uninterrupted{% endfigure %}
+{% figure angkor-wat--062.jpg landscape %}
+A hidden room, I sat and watched, for ten minues, uninterrupted
+{% endfigure %}
 
-{% figure angkor-wat--058.jpg portrait %}Exploring Ta Prohm{% endfigure %}
+{% figure angkor-wat--058.jpg portrait %}
+Exploring Ta Prohm
+{% endfigure %}
 
-{% figure angkor-wat--059.jpg landscape %}Enormous, sprawling tree roots{% endfigure %}
+{% figure angkor-wat--059.jpg landscape %}
+Enormous, sprawling tree roots
+{% endfigure %}
 
 The mist cleared up, and gave way to rain. And at the temple's traditional entrance I eventually bumped into Samantha. We continued to look around, this time posing for photos at every corner. Beneath the spidery trunk, in front of the temple, in a fallen archway, next to a colossal trunk, posing with umbrellas.
 
@@ -39,27 +49,45 @@ We had no guide this time, but there wasn't any need for one. With the muddy pat
 
 We spent most of our morning here, and it was my favourite of all the Angkor temples. Stunningly beautiful. I hope future renovations and tourists do not destroy this place.
 
-{% figure angkor-wat--063.jpg landscape %}Samantha, umbrella and a spidery trunk{% endfigure %}
+{% figure angkor-wat--063.jpg landscape %}
+Samantha, umbrella and a spidery trunk
+{% endfigure %}
 
-{% figure angkor-wat--066.jpg landscape %}Another enormous trunk{% endfigure %}
+{% figure angkor-wat--066.jpg landscape %}
+Another enormous trunk
+{% endfigure %}
 
-{% figure angkor-wat--070.jpg portrait %}Paul and Ta Prohm's most famous tree{% endfigure %}
+{% figure angkor-wat--070.jpg portrait %}
+Paul and Ta Prohm's most famous tree
+{% endfigure %}
 
-{% figure angkor-wat--054.jpg landscape %}Famous, sprawling tree roots at Ta Prohm{% endfigure %}
+{% figure angkor-wat--054.jpg landscape %}
+Famous, sprawling tree roots at Ta Prohm
+{% endfigure %}
 
-{% figure angkor-wat--071.jpg portrait %}Navigating Ta Prohm's corridors{% endfigure %}
+{% figure angkor-wat--071.jpg portrait %}
+Navigating Ta Prohm's corridors
+{% endfigure %}
 
-{% figure angkor-wat--075.jpg landscape %}The front of Ta Prohm{% endfigure %}
+{% figure angkor-wat--075.jpg landscape %}
+The front of Ta Prohm
+{% endfigure %}
 
 ## Ta Keo
 
 By tuk-tuk we travelled to our next temple, Ta Keo. Vesna warned us to be careful on the slippery steps, and after one look Sam decided to stay at the bottom. But I climbed away, up two flights of steps. At the summit was a small Buddha statue where a lady explained the dedication process to me. Sam has been wearing a red cotton band, given as a thank you for a donation she made, the red means happiness, I am told. Coming back down was more difficult, and I watched as a Japanese group clambered down backwards, edging slowly and surely, a Cambodian selling paintings skipped down past them.
 
-{% figure angkor-wat--079.jpg landscape %}A steep climb at Ta Keo{% endfigure %}
+{% figure angkor-wat--079.jpg landscape %}
+A steep climb at Ta Keo
+{% endfigure %}
 
-{% figure angkor-wat--077.jpg landscape %}Be careful, at Ta Keo{% endfigure %}
+{% figure angkor-wat--077.jpg landscape %}
+Be careful, at Ta Keo
+{% endfigure %}
 
-{% figure angkor-wat--080.jpg portrait %}Temple steps{% endfigure %}
+{% figure angkor-wat--080.jpg portrait %}
+Temple steps
+{% endfigure %}
 
 A little on from here lie Thommanon and Chau Say Tevoda. These two temples sit opposite each other, and anywhere else in the world these ancient buildings would be major tourist sites in their own right. But here, against the ruins that are the rest of Angkor, they are overlooked. “Another temple”, temple fatigue quickly sets in.
 
@@ -69,31 +97,45 @@ Hungry, and a little tired, Vesna convinced us to visit Preah Khan (meaning Holy
 
 There was a muddy trek to this temple, but the rain had gone, replaced with hot hot sunshine. The path was filled with butterflies, and rhododendrons, and, at last, I saw my first snake in the wild, a little brown one that I watched from a safe distance.
 
-{% figure angkor-wat--082.jpg landscape %}Butterfly and rhododendrons{% endfigure %}
+{% figure angkor-wat--082.jpg landscape %}
+Butterfly and rhododendrons
+{% endfigure %}
 
 We entered the temple through a narrow alleyway, and the ruins stretched out ahead of us. Corridors every which way, we meandered around, with no particular direction. Oh dear, this route has led us to a dead end, a corridor blocked by fallen stone. The wall carvings here are magnificent. This temple, too, is succumbing to nature, trees have grown up and around the walls, the reclamation has begun.
 
 Without a guide you discover a new group of people that attempt to sell you things, randoms that wander the temples and attempt to sell you a tour, “this is a big temple”, one pointed out to me. I smiled and kept walking. An official guide was standing amidst the ruins and Sam asked about his uniform, and the patch he wore, “you like? you want to buy?” he responded.
 
-{% figure angkor-wat--085.jpg landscape %}Preah Khan temple{% endfigure %}
+{% figure angkor-wat--085.jpg landscape %}
+Preah Khan temple
+{% endfigure %}
 
-{% figure angkor-wat--083.jpg landscape %}Secret rooms at Preah Khan{% endfigure %}
+{% figure angkor-wat--083.jpg landscape %}
+Secret rooms at Preah Khan
+{% endfigure %}
 
 We decided on a clockwise tour of the complex, and narrowly avoided the postcard selling teenager. Once again nature caught my eye, beneath us on broken rocky path giant termites were pacing up and down, thousands of them. These things pack a nasty bite, but I stooped close to watch. On the way out we passed beneath a path-spanning web, with its creator, a giant wood spider, sitting in the middle, its body almost six inches long. Another tick in my imaginary “I spy” nature book, a giant wild spider.
 
-{% figure angkor-wat--088.jpg portrait %}Another giant tree{% endfigure %}
+{% figure angkor-wat--088.jpg portrait %}
+Another giant tree
+{% endfigure %}
 
 Starving, our tuk-tuk took us back to our hotel. But not before a roadside stop to grab some one dollar sticky rice in bamboo.
 
-{% figure angkor-wat--089.jpg landscape %}Home by Tuk Tuk{% endfigure %}
+{% figure angkor-wat--089.jpg landscape %}
+Home by Tuk Tuk
+{% endfigure %}
 
-{% figure angkor-wat--090.jpg portrait %}Sticky rice in bamboo snack{% endfigure %}
+{% figure angkor-wat--090.jpg portrait %}
+Sticky rice in bamboo snack
+{% endfigure %}
 
 ## Temple fatigue
 
 Relaxing by the hotel pool, with a pineapple smoothie, we made a speedy recovery from Angkor temple fatigue. Comforting western food helped too, guilty chips and tuna sandwich. I wrote about our travels, we slept and we showered (always showering; bug spray, dirty feet, sweat, sun lotion, dirt, chlorine; three times daily, with the jasmine-bacon scented soap).
 
-{% figure IMG_5425.JPG square %}Relaxing by the pool{% endfigure %}
+{% figure IMG_5425.JPG square %}
+Relaxing by the pool
+{% endfigure %}
 
 ## Pub street
 

--- a/source/_posts/angkor-wat-cambodia/5.md
+++ b/source/_posts/angkor-wat-cambodia/5.md
@@ -19,17 +19,27 @@ As the crowds grew larger, the sky grew brighter; every few seconds a flash woul
 
 Sun rise was at 6:02am. And a slight orange haze came over the place, a morning mist blew in, and the towers were ethereal. The sun rise wasn't spectacular, there were still too many clouds, and nothing could match what we'd seen in Halong Bay, but it was beautiful nonetheless. I enjoyed the patience necessary to get a good photo.
 
-{% figure angkor-wat--091.jpg landscape %}Angkor Wat, at dawn{% endfigure %}
+{% figure angkor-wat--091.jpg landscape %}
+Angkor Wat, at dawn
+{% endfigure %}
 
 Before heading back we took two more quick stops. First to the south gate, empty for now, we played amidst the statues and took photos. Vesna yawned, he was clearly very tired, though I imagine he has to do this a lot, we were very grateful. With our picture of an empty bridge and gate, save for a solitary cyclist, we left for Bayon. I hadn't been happy with the pictures we took a couple of days back, I knew I could do better. Once more, crazy Bayon was astounding, and this time empty. I stood in front and snapped geese preparing for their day, in front of the many towers of faces, watched from every angle. And from the corner, with Vesna's recommendation, I captured more photos, this time with the aid of a reflection pool. I think the shots came out fantastic.
 
-{% figure angkor-wat--094.jpg landscape %}The South Gate, Angkor Thom{% endfigure %}
+{% figure angkor-wat--094.jpg landscape %}
+The South Gate, Angkor Thom
+{% endfigure %}
 
-{% figure angkor-wat--096.jpg landscape %}Paul, Vesna and the tuk tuk{% endfigure %}
+{% figure angkor-wat--096.jpg landscape %}
+Paul, Vesna and the tuk tuk
+{% endfigure %}
 
-{% figure angkor-wat--097.jpg landscape %}A goose stretching in front of Bayon temple{% endfigure %}
+{% figure angkor-wat--097.jpg landscape %}
+A goose stretching in front of Bayon temple
+{% endfigure %}
 
-{% figure angkor-wat--098.jpg landscape %}The magnificent, mysterious Bayon temple{% endfigure %}
+{% figure angkor-wat--098.jpg landscape %}
+The magnificent, mysterious Bayon temple
+{% endfigure %}
 
 Alas, that's enough, and all of a sudden we needed to sleep again. Back at the hotel by 7:45am, we slept for a good few hours and woke afresh, ready for the day. And we consumed a mammoth breakfast to boot.
 
@@ -45,21 +55,31 @@ Before entering I was shocked and horrified by the appearance of a Cambodian gir
 
 The temple is famous for its red sandstone and intricate stone carvings, they've survived for a thousand years, and thanks to the nature of the stone, their pristine detail is still intact. A gravel track leads to the small temple. It's a Hindu temple, dedicated to Shiva, and the buildings are tiny. But the level of detail and intricacy in the carvings is incredible, it is the “jewel of khmer art”.
 
-{% figure angkor-wat--106.jpg landscape %}Banteay Srei temple{% endfigure %}
+{% figure angkor-wat--106.jpg landscape %}
+Banteay Srei temple
+{% endfigure %}
 
-{% figure angkor-wat--109.jpg portrait %}Sandstone carvings at Banteay Srei{% endfigure %}
+{% figure angkor-wat--109.jpg portrait %}
+Sandstone carvings at Banteay Srei
+{% endfigure %}
 
 A Cambodian family explored the grounds with us; seven kids were running about, hiding amongst the ruins, jumping in the water pools, hiding from staff members.
 
 The weathered pink sandstone occasionally opened up great crevices, perfect places for lizards to hide. In particular a beautiful foot-long blue and red spotted Tockay Gecko. It poked its head out, and then scarpered.
 
-{% figure angkor-wat--101.jpg landscape 620 %}A Tockay Gecko{% endfigure %}
+{% figure angkor-wat--101.jpg landscape 620 %}
+A Tockay Gecko
+{% endfigure %}
 
 The carvings were everywhere. We admired those on top of the gopuras, following the notes in our guide book to understand the depictions. So detailed and beautiful, the more you look the more you see. We spotted the ten headed ten armed Ravana ourselves. There were demons eating people or being attacked. The burning of the Khāṇḍava Forest and many devatas, celestial dancing girls, sprinkled about the corners.
 
-{% figure angkor-wat--111.jpg landscape %}Intricate carvings at Banteay Srei{% endfigure %}
+{% figure angkor-wat--111.jpg landscape %}
+Intricate carvings at Banteay Srei
+{% endfigure %}
 
-{% figure angkor-wat--118.jpg portrait %}Children playing at the temple{% endfigure %}
+{% figure angkor-wat--118.jpg portrait %}
+Children playing at the temple
+{% endfigure %}
 
 At the museum, where placards hang from the ceiling, the stories of the temple's history are told. The discovery, the restoration, the famous attempted pilfering by André Malraux. Outside the storm rains briefly returned, and they battered down on the metal roof. The rain had such force and tenacity, pummelling the delicate lotus flowers. But it soon cleared up again.
 
@@ -67,15 +87,21 @@ At the museum, where placards hang from the ceiling, the stories of the temple's
 
 We headed back towards Siem Reap. Vesna suggested we shout if there was anything we wanted to see more of, or learn about. We stopped by the rice paddies, and watched the farmworkers transplanting rice, they smiled as we took photos, and waved goodbye when we left.
 
-{% figure angkor-wat--119.jpg landscape %}Working in the rice paddies{% endfigure %}
+{% figure angkor-wat--119.jpg landscape %}
+Working in the rice paddies
+{% endfigure %}
 
 We stopped by a house that had piles of wood outside. The families farm the wood and cut it into 1m lengths. A lorry came by to pick up the stock to sell at market. The house was wooden, built on stilts, presumably to avoid flooding. Tyres lay strewn on hay rooftops, to keep them down in strong winds. Most houses were wooden, the occasional stone house belonged to a politician or important figure.
 
 We stopped again, this time to peruse some street side vendors. They were making sweets from palm sugar they'd harvested nearby. Young girls were stirring the sugary syrup in great metal bowls. The sweets were tasty too, we bought a couple for $1, wrapped in banana leaf packaging. Sam bought a scarf and pashmina too, while I danced with a giant flying beetle I didn't fancy being close to. Then there were the waffles, just cooked, very hot, sweetened with palm sugar; simply delicious, and possibly the best waffles we've ever tasted.
 
-{% figure angkor-wat--120.jpg landscape %}Making palm sugar sweets{% endfigure %}
+{% figure angkor-wat--120.jpg landscape %}
+Making palm sugar sweets
+{% endfigure %}
 
-{% figure angkor-wat--121.jpg landscape %}Them tasty waffles{% endfigure %}
+{% figure angkor-wat--121.jpg landscape %}
+Them tasty waffles
+{% endfigure %}
 
 ## Banteay Samré temple
 
@@ -83,11 +109,17 @@ Next stop on the temple tour was Banteay Samré, another of Vesna's recommendati
 
 The temple is red sandstone again, and an early mode for Angkor, I heard a local expert explain. A walled corridor surrounds the building, surprisingly intact all the way round. It's a flat temple, that used to have water pools, and it's peaceful and quiet. We crossed to the solitary central plinth and tower, which houses a Buddha. Sam sat here with an elderly man who explained parts of the temple, although she only understood half of what he said. A cat slept in one of the real windows, he's rock coloured and perfectly camouflaged. Meanwhile a cute girl is running around and playing with her family, but she has chicken pox, and I try to avoid her. Banteay Samré is a lovely place to explore; serene, quiet and sheltered.
 
-{% figure angkor-wat--124.jpg landscape %}Samantha cooling her wound at Banteay Samre{% endfigure %}
+{% figure angkor-wat--124.jpg landscape %}
+Samantha cooling her wound at Banteay Samre
+{% endfigure %}
 
-{% figure angkor-wat--126.jpg portrait %}Paul at Banteay Samre{% endfigure %}
+{% figure angkor-wat--126.jpg portrait %}
+Paul at Banteay Samre
+{% endfigure %}
 
-{% figure angkor-wat--127.jpg landscape %}Temple cat{% endfigure %}
+{% figure angkor-wat--127.jpg landscape %}
+Temple cat
+{% endfigure %}
 
 ## Pre Rup temple
 
@@ -95,9 +127,13 @@ Next on the temple checklist, and the last of all the temples we would see, Pre 
 
 For one last time we climb the steep steps of an ancient temple, no metal bars for support this time, Sam still braved the climb (it's going down that's hardest). From the top the forests spread out into the distance. There's a mound, which Banteay Srei sits at the foot of, and we can just make out the towers of Angkor Wat. Like every night we've been here, there isn't a spectacular sunset, though this would be a stunning place to watch one.
 
-{% figure angkor-wat--131.jpg landscape %}Samantha at the top of Pre Rup{% endfigure %}
+{% figure angkor-wat--131.jpg landscape %}
+Samantha at the top of Pre Rup
+{% endfigure %}
 
-{% figure angkor-wat--129.jpg portrait %}A view from the top of Pre Rup{% endfigure %}
+{% figure angkor-wat--129.jpg portrait %}
+A view from the top of Pre Rup
+{% endfigure %}
 
 ## Thank you Vesna
 
@@ -105,4 +141,6 @@ Early evening now, and starving, we head homeward. Goodbye temples, you are all 
 
 We remained in the hotel for some final relaxing, a bit of reading, some red wine, some food, a free spa treatment and, with one last Cambodian bed time story, sleep. What a truly wonderful time we've had here.
 
-{% figure angkor-wat--133.jpg landscape %}Going home by tuk tuk, for the last time{% endfigure %}
+{% figure angkor-wat--133.jpg landscape %}
+Going home by tuk tuk, for the last time
+{% endfigure %}

--- a/source/_posts/barcelona-spain.md
+++ b/source/_posts/barcelona-spain.md
@@ -67,7 +67,7 @@ Our hotel sat very close to the excellent and widely recommended tapas bar and r
 * Bacon, cheese and date flute
 * Sangria
 * Mushrooms and potatoes
-{% endmenu /%}
+{% endmenu %}
 
 {% figure spain-cadaques-barcelona-161.jpg landscape %}Razor clams at Cerveceria Catalana{% endfigure %}
 

--- a/source/_posts/barcelona-spain.md
+++ b/source/_posts/barcelona-spain.md
@@ -14,7 +14,9 @@ page: 1
 
 ## Cadaques to Barcelona
 
-{% figure spain-cadaques-barcelona-319.jpg portrait %}La Sagrada Família{% endfigure %}
+{% figure spain-cadaques-barcelona-319.jpg portrait %}
+La Sagrada Família
+{% endfigure %}
 
 From our [trip to Cadaqués](/2010/10/cadaques-spain/), the return route to Barcelona took us a different way. Up at 7am, checked out by 8am, with breakfast wrapped in napkins, the hotel director dropped us at the bus station in his jeep. Adiós. On the Sarfa bus we went up and around the mountain roads again, bus swaying left to right to left, perilously close to the barriers and sheer drops, shades of the [Lesvos tour bus](/2008/09/two-weeks-in-molyvos-in-lesbos-greece/4/) we’d been on. Sounds of kids getting travel sick in the back left us listening to the “500 days of summer” soundtrack. We were on our way to Figueres; the bus arrived late, and we had a mad dash sprint to the train, luggage in tow. Sam bought the tickets, I used the loo. Then down the steps, under the platform, up again and onto the train, a full 30 seconds to spare.
 
@@ -24,9 +26,13 @@ Two more hours going south, past Girona, to Barcelona--shut eye opportunity impe
 
 In the cool, air conditioned room, with its dark brown wooden décor, tiled and glistening bathroom, thick curtains and huge beds, we recovered, in four star luxury.
 
-{% figure spain-cadaques-barcelona-306.jpg portrait %}Samantha explaining the photograph I should take outside Hotel Center{% endfigure %}
+{% figure spain-cadaques-barcelona-306.jpg portrait %}
+Samantha explaining the photograph I should take outside Hotel Center
+{% endfigure %}
 
-{% figure spain-cadaques-barcelona-144.jpg landscape %}Our room in Hotel Center{% endfigure %}
+{% figure spain-cadaques-barcelona-144.jpg landscape %}
+Our room in Hotel Center
+{% endfigure %}
 
 ## Walking tour
 
@@ -34,15 +40,23 @@ Soon enough, Sam was tired of relaxing and wanted to do something. “Can we try
 
 Las Ramblas is packed with shopping stalls, pet stalls and street performers; from terrible Zorros and painted silver statues (chatting during their break), to perfectly executed floating genies that left crowds gasping. Dodgy looking men sold squeaky plastic mouthpieces and paranoid for our valuables, we hugged our bags and pockets tightly.
 
-{% figure spain-cadaques-barcelona-147.jpg landscape %}Outside Palau Güell{% endfigure %}
+{% figure spain-cadaques-barcelona-147.jpg landscape %}
+Outside Palau Güell
+{% endfigure %}
 
 First stop, Palau Güell, an early Gaudí project, closed for renovations. Then to Plaça de Sant Jaume a large open square with central fountain and surrounding eateries. Now in the Barri Gòtic quarter we meandered through thin streets, round to the catedral (not the only cathedral in BCN under scaffolding) and Iglesia Santa María del Mar. We didn’t go in, a wedding was going on, we instead sat on the wall nearby, watching the smartly dressed passers by, and the quirky artist that appeared to be a misanthrope. We stopped again at the Plaça del Rei, a quiet enclosed square with steps perfectly placed for seating--here I strained to photograph those sitting near us in an artistic way.
 
-{% figure spain-cadaques-barcelona-152.jpg portrait %}Iglesia Santa María del Mar{% endfigure %}
+{% figure spain-cadaques-barcelona-152.jpg portrait %}
+Iglesia Santa María del Mar
+{% endfigure %}
 
-{% figure spain-cadaques-barcelona-150.jpg landscape %}Man smoking in Plaça del Rei{% endfigure %}
+{% figure spain-cadaques-barcelona-150.jpg landscape %}
+Man smoking in Plaça del Rei
+{% endfigure %}
 
-{% figure spain-cadaques-barcelona-148.jpg portrait %}Narrow streets of the Barri Gòtic quarter{% endfigure %}
+{% figure spain-cadaques-barcelona-148.jpg portrait %}
+Narrow streets of the Barri Gòtic quarter
+{% endfigure %}
 
 Round the back of the cathedral we paused for strawberry and raspberry ice creams, as another performer created huge soapy bubbles, leaving the air smelling of washing up liquid.
 
@@ -52,9 +66,13 @@ The tour continued, taking us past the Museo de Picasso, we didn’t go in, then
 
 By the Picasso museum we stopped at the BCN design hub, dHUB, for their free wallpaper exhibition. Sounds dull, certainly wasn’t. Exhibits included a post-it note wall, a rucked up roll of solid paper which formed a stylish shelf, textured papers, paper that changed based on temperature and designs that flowed around wall objects, like sockets and lamps.
 
-{% figure spain-cadaques-barcelona-156.jpg landscape %}A wall of post-it notes at dHUB wallpaper exhibition{% endfigure %}
+{% figure spain-cadaques-barcelona-156.jpg landscape %}
+A wall of post-it notes at dHUB wallpaper exhibition
+{% endfigure %}
 
-{% figure spain-cadaques-barcelona-157.jpg landscape %}Wallpaper curving around a light fitting at dHUB wallpaper exhibition{% endfigure %}
+{% figure spain-cadaques-barcelona-157.jpg landscape %}
+Wallpaper curving around a light fitting at dHUB wallpaper exhibition
+{% endfigure %}
 
 ## Cerveceria Catalana tapas
 
@@ -69,8 +87,12 @@ Our hotel sat very close to the excellent and widely recommended tapas bar and r
 * Mushrooms and potatoes
 {% endmenu %}
 
-{% figure spain-cadaques-barcelona-161.jpg landscape %}Razor clams at Cerveceria Catalana{% endfigure %}
+{% figure spain-cadaques-barcelona-161.jpg landscape %}
+Razor clams at Cerveceria Catalana
+{% endfigure %}
 
-{% figure spain-cadaques-barcelona-162.jpg landscape %}Fried baby squids at Cerveceria Catalana{% endfigure %}
+{% figure spain-cadaques-barcelona-162.jpg landscape %}
+Fried baby squids at Cerveceria Catalana
+{% endfigure %}
 
 We shared tips on menu choices and Barca trips with the tables either side; a slightly drunken (three jugs of Sangria?) American-Asian now living in China, trying to chat up some Japanese girls on one side, and two English girls on a long girly weekend of sightseeing and good food, on the other.

--- a/source/_posts/barcelona-spain/2.md
+++ b/source/_posts/barcelona-spain/2.md
@@ -9,7 +9,9 @@ page: 2
 
 First Sunday of the month, and our intention was to visit the Picasso museum, because it was free. We had a bit of a lie in though, and didn’t leave the hotel until 11:30am, stopping for breakfast at Crusto, a place recommended on foursquare for their delicious Pain au Chocolat. The guy that served us was a perfectionist, and the cappuccinos came with beautiful froth designs on them. I had the croissant, but Sam tried their delicious ensaïmada, which soon became my breakfast choice as well.
 
-{% figure spain-cadaques-barcelona-164.jpg portrait original %}Coffee and day planning at Crusto{% endfigure %}
+{% figure spain-cadaques-barcelona-164.jpg portrait original %}
+Coffee and day planning at Crusto
+{% endfigure %}
 
 We fancied seeing the inside of the Palau de Música Catalana, not wanting to pay 12 euros for a tour, we asked about performances, one opera/flamenco show was on tonight, for 40 euros each, but we had to come back at 7:30pm to buy tickets, so we didn’t bother. We got into the town centre at midday-ish, and by then we realised everyone else had had the same idea about Picasso. The queue ran around the block and wasn’t really moving, so we didn’t go in, and by now we were a little bothered that the day wasn’t going to plan.
 
@@ -21,17 +23,27 @@ We were out during the hottest part of the day, foolish really. So we stopped at
 
 Back at the Picasso museum, we found the queue to be just as long. Clearly, we weren’t going to be seeing the artist’s early works. Instead we returned to dHUB, and had a late lunch (vegetable tart and potato tortilla, with an excellent almond chocolate dessert). The gift shop kept us amused, with cleverly designed vases, hooks, lamps and umbrellas packaged into bottles.
 
-{% figure spain-cadaques-barcelona-173.jpg landscape %}Lunch at dHUB{% endfigure %}
+{% figure spain-cadaques-barcelona-173.jpg landscape %}
+Lunch at dHUB
+{% endfigure %}
 
-{% figure spain-cadaques-barcelona-174.jpg portrait original %}Paul with his almond chocolate dessert{% endfigure %}
+{% figure spain-cadaques-barcelona-174.jpg portrait original %}
+Paul with his almond chocolate dessert
+{% endfigure %}
 
 The Picasso queue was still too long. Instead we delved into the world of 3D fabrication technology, another fascinating dHub exhibition. Amongst red walls and spot lights were chairs created from motion capture drawings, synthesised spiky speakers that mimic your music taste and lemon zesters in curious shapes. A video taught us the benefits of 3D printing concrete, and we’re now swotted up on cell by cell 3D printing of biological structures, one day it could be organs, but at the moment it’s limited to skin tissues. Got to take it one step at a time. From the mother’s womb, 3D foetus models can be built and with 3D printers a life size replica produced, freakish to say the least. In the up-lit whitewashed room were students’ fabricating robot experiments; bots that could build structures from cardboard using solar power, and devices that created sculpture using swarm theory. Our minds were blown.
 
-{% figure spain-cadaques-barcelona-179.jpg portrait %}3D printed chair at dHUB’s fabrication exhibition{% endfigure %}
+{% figure spain-cadaques-barcelona-179.jpg portrait %}
+3D printed chair at dHUB’s fabrication exhibition
+{% endfigure %}
 
-{% figure spain-cadaques-barcelona-180.jpg landscape %}Sam isn’t wearing her headset correctly{% endfigure %}
+{% figure spain-cadaques-barcelona-180.jpg landscape %}
+Sam isn’t wearing her headset correctly
+{% endfigure %}
 
-{% figure spain-cadaques-barcelona-182.jpg landscape %}A comfortable looking 3D printed concrete chair{% endfigure %}
+{% figure spain-cadaques-barcelona-182.jpg landscape %}
+A comfortable looking 3D printed concrete chair
+{% endfigure %}
 
 ## Pla restaurant
 
@@ -47,10 +59,14 @@ Pla cleverly seated everyone by language, good for the waitresses that couldn’
 
 My soup of the day, pumpkin, was poured over the seafood mousse and shiitake mushroom in front of me, and Sam couldn’t turn up another opportunity for seafood; Octopus carpaccio with wasabi, perfectly presenting the taste of Octopus without any of the toughness.
 
-{% figure spain-cadaques-barcelona-198.jpg portrait %}Samantha at Pla with her Iberian pork fillet{% endfigure %}
+{% figure spain-cadaques-barcelona-198.jpg portrait %}
+Samantha at Pla with her Iberian pork fillet
+{% endfigure %}
 
 Sam’s Iberian pork was divine, and I was filled with food envy; my Cod was nice, but it was just Cod, and I ought to have made a better choice. But wow, that pork, with the nut sauce, this is how pork should be.
 
 Complementary grappa pushed us over the tipsy boat.
 
-{% figure spain-cadaques-barcelona-199.jpg portrait %}Romantic lightning in Pla{% endfigure %}
+{% figure spain-cadaques-barcelona-199.jpg portrait %}
+Romantic lightning in Pla
+{% endfigure %}

--- a/source/_posts/barcelona-spain/3.md
+++ b/source/_posts/barcelona-spain/3.md
@@ -9,7 +9,9 @@ page: 3
 
 On Monday we didn’t make the same mistake, with ensaïmada’s from Crusto in hand, we were queuing for La Sagrada Família before 9am, ready for a day of Gaudí. With audio guide hanging around our necks, top notch headphones sitting uncomfortably on our ears, and Canon camera primed for photo opportunities, we dialled 1 and started the tour. “Welcome to La Sagrada Família…”.
 
-{% figure spain-cadaques-barcelona-201.jpg portrait %}Welcome to La Sagrada Família…{% endfigure %}
+{% figure spain-cadaques-barcelona-201.jpg portrait %}
+Welcome to La Sagrada Família…
+{% endfigure %}
 
 In front of us was a façade depicting Christ’s death, barren and bone-like. The sculptures highlighted events leading up to the crucifixion, our personal in-ear tour guide pointed out the important details; alpha and omega over the door, Peter and the cock crowing, a hidden snake and a fossilised palm leaf in the stone. Looking up, a great bronze statue of Christ sat between the spires, resembling his ascension to heaven, amongst the cranes at work - still building this magnificent place.
 
@@ -17,21 +19,33 @@ Inside we were amazed by the ceiling, huge pillars rising to the roof and openin
 
 In the lift, up the rightmost spire, then out onto the roof, with its fabulous views across all of Barcelona. The sun was low enough to cast interesting shadows and the sky was dotted with the odd, perfectly fluffy, cloud, as if from a Thompson’s ad. The foundations for the central spire were laid, and realising the height this would reach, I was awestruck by the magnitude of the project.
 
-{% figure spain-cadaques-barcelona-208.jpg portrait %}View of Barcelona, with a perfectly fluffy cloud{% endfigure %}
+{% figure spain-cadaques-barcelona-208.jpg portrait %}
+View of Barcelona, with a perfectly fluffy cloud
+{% endfigure %}
 
-{% figure spain-cadaques-barcelona-209.jpg landscape %}La Sagrada Família under construction{% endfigure %}
+{% figure spain-cadaques-barcelona-209.jpg landscape %}
+La Sagrada Família under construction
+{% endfigure %}
 
 We took the spiral staircase down, past Jesus on his ascent, and the balls of shiny fruit. Our tour continued, explaining the design of the windows to bring in the most light, and the differently coloured tree-like columns that support different weights. “The cathedral will seat a choir of over 1200”. It might be completed by 2040, we could come back when we’ve retired. A small exhibition explained how Gaudí used aspects of nature in his work.
 
-{% figure spain-cadaques-barcelona-215.jpg portrait %}View down one of the spires{% endfigure %}
+{% figure spain-cadaques-barcelona-215.jpg portrait %}
+View down one of the spires
+{% endfigure %}
 
-{% figure spain-cadaques-barcelona-216.jpg landscape %}Jesus on his ascent{% endfigure %}
+{% figure spain-cadaques-barcelona-216.jpg landscape %}
+Jesus on his ascent
+{% endfigure %}
 
-{% figure spain-cadaques-barcelona-220.jpg landscape %}Spiral staircases{% endfigure %}
+{% figure spain-cadaques-barcelona-220.jpg landscape %}
+Spiral staircases
+{% endfigure %}
 
 Outside again, into the heat; basking in the sun stood the second façade, dedicated to Jesus’ birth and a celebration of life. With the tree of life above the stable scenes of Christ’s birth, the façade was overflowing with flora and fauna, from turtle and tortoise at the base, to flocks of birds at the top. Too many details for our audio tour guides to point out.
 
-{% figure spain-cadaques-barcelona-323.jpg portrait %}The elaborate and detailed second façade, a celebration of life.{% endfigure %}
+{% figure spain-cadaques-barcelona-323.jpg portrait %}
+The elaborate and detailed second façade, a celebration of life.
+{% endfigure %}
 
 Beneath the cathedral lay the museum. Sketches show the masterpiece completed, but even the model replica was still being built. Gaudí’s tomb lay at the very back, in the dark, with a single spotlight pointing it out.
 
@@ -43,25 +57,37 @@ Why do Spanish supermarkets all ask you to put your bags in a locker before shop
 
 With picnic in tow, and cartons of tropical juice to refresh us (or make a mess of our clothes as we try and open them too forcefully *ahem*), part 2 of Gaudí day commenced: a trip to Park Güell.
 
-{% figure spain-cadaques-barcelona-223.jpg portrait %}Riding outdoor escalators up to Park Güell{% endfigure %}
+{% figure spain-cadaques-barcelona-223.jpg portrait %}
+Riding outdoor escalators up to Park Güell
+{% endfigure %}
 
 The L3 metro line took us to Vallcarca, then a hill with lovingly built in escalators took us to one of the park’s side entrances. Now desperate for food, we etched out a shaded place to eat, it just happened to have spectacular views of the city and live music, like ska or reggae, but better, “we have a CD, it’s really good”, Microguagua they were called.
 
 Packaged olives, brie, olive-bread and another healthy dose of saucisson perked us up. A pigeon circled us, never quite brave enough to nip in and grab anything. An American on the phone tried to explain how to find this place, but his group had climbed another hill entirely. Sitting beneath the pine tree, the odd bug falling on us, we stared out across the city. When we left the pigeon swooped in and hoovered up our crumbs.
 
-{% figure spain-cadaques-barcelona-228.jpg landscape %}Someone stood on her toe{% endfigure %}
+{% figure spain-cadaques-barcelona-228.jpg landscape %}
+Someone stood on her toe
+{% endfigure %}
 
-{% figure spain-cadaques-barcelona-229.jpg landscape %}Climbing back down from the park’s peak{% endfigure %}
+{% figure spain-cadaques-barcelona-229.jpg landscape %}
+Climbing back down from the park’s peak
+{% endfigure %}
 
 Trekking up and down hills during the hottest part of the day, we still hadn’t learnt, and sure enough, we were exhausted again. Down the hill and towards the main entrance we found a broad open space. Street musicians with their hang drums created an air of tranquillity. We rested on the curvaceous bench and looked towards the city and two gatehouses. The smoothly tiled design sat perfectly against the curve of our backs; a cool surface, a view and ergonomic lumbar support – I could sit here all day.
 
-{% figure spain-cadaques-barcelona-232.jpg landscape %}Reclining on Gaudí’s ergnomic main terrace{% endfigure %}
+{% figure spain-cadaques-barcelona-232.jpg landscape %}
+Reclining on Gaudí’s ergnomic main terrace
+{% endfigure %}
 
-{% figure spain-cadaques-barcelona-233.jpg landscape %}Columns beneath Park Güell{% endfigure %}
+{% figure spain-cadaques-barcelona-233.jpg landscape %}
+Columns beneath Park Güell
+{% endfigure %}
 
 The huge open space was built on a forest of columns, originally intended as a market place, and is guarded by a famous mosaic salamander. Rain water is collected and channelled to the creature, creating both a fountain and a drainage system.
 
-{% figure spain-cadaques-barcelona-235.jpg landscape %}The famous mosaic ‘el drac’ (the dragon){% endfigure %}
+{% figure spain-cadaques-barcelona-235.jpg landscape %}
+The famous mosaic ‘el drac’ (the dragon)
+{% endfigure %}
 
 On a quiet grassy verge we slept, this time beneath an olive tree. I read more of “One Day”, and gave Sam the chapter summaries, as if catching up with her old friends Dex and Em.
 
@@ -69,7 +95,9 @@ On a quiet grassy verge we slept, this time beneath an olive tree. I read more o
 
 Inside Casa Museu Gaudí we explored rooms where Gaudí had once lived, though unlike Dali’s place, it was only a collection of furniture he had designed, scattered wherever it might fit, some original tiles and patterns had survived. Small cat and rat sculptures poked out from ugly red chairs, and a replica of La Sagrada Família’s keystone hung over the stairs. With our backpacks sitting uncomfortably on our front, the inviting ergonomic wooden chairs mocked us.
 
-{% figure spain-cadaques-barcelona-237.jpg landscape %}Classic view from Park Güell{% endfigure %}
+{% figure spain-cadaques-barcelona-237.jpg landscape %}
+Classic view from Park Güell
+{% endfigure %}
 
 ## La Rita restaurant
 

--- a/source/_posts/barcelona-spain/4.md
+++ b/source/_posts/barcelona-spain/4.md
@@ -13,27 +13,43 @@ But I’m jumping ahead, that morning we made the short walk from our hotel to L
 
 With another set of audio guides, we walked around the attic museum. It showcased Gaudí’s work, his techniques, Barcelona in the 1920s, nature’s influences and ergonomic furniture designs. The arching roof structure throughout was fascinating.
 
-{% figure spain-cadaques-barcelona-241.jpg landscape %}Arching roof structure within Casa Milà{% endfigure %}
+{% figure spain-cadaques-barcelona-241.jpg landscape %}
+Arching roof structure within Casa Milà
+{% endfigure %}
 
 When Sam finished devouring every ounce of information we went up to the famous rooftop. Like undulating waves the roof flows, complementing the rippling grey façade and wrought iron balconies. Chimneys are elaborately sculpted, like smoke rising from the roof, capped with a soldier-like head. We tried out our improving photography skills, and we waited and waited for people to move out the way, mostly in vain.
 
-{% figure spain-cadaques-barcelona-242.jpg landscape %}Undulating rooftop of La Pedrera{% endfigure %}
+{% figure spain-cadaques-barcelona-242.jpg landscape %}
+Undulating rooftop of La Pedrera
+{% endfigure %}
 
-{% figure spain-cadaques-barcelona-245.jpg landscape %}Paul, in his M83 t-shirt, with Barcelona behind him{% endfigure %}
+{% figure spain-cadaques-barcelona-245.jpg landscape %}
+Paul, in his M83 t-shirt, with Barcelona behind him
+{% endfigure %}
 
-{% figure spain-cadaques-barcelona-249.jpg portrait %}Paul, La Pedrera and La Sagrada Família in the distance. The expression is of frustration – there’s always someone else in the picture!{% endfigure %}
+{% figure spain-cadaques-barcelona-249.jpg portrait %}
+Paul, La Pedrera and La Sagrada Família in the distance. The expression is of frustration – there’s always someone else in the picture!
+{% endfigure %}
 
 Downstairs a traditional 1920s apartment was set up, with master bedroom, maids room, children’s room, etc. I left Sam with the Canon, and she captured some of the details beautifully.
 
-{% figure spain-cadaques-barcelona-262.jpg portrait %}Ceiling detail in classic 1920s apartment{% endfigure %}
+{% figure spain-cadaques-barcelona-262.jpg portrait %}
+Ceiling detail in classic 1920s apartment
+{% endfigure %}
 
-{% figure spain-cadaques-barcelona-268.jpg portrait %}Colourful staircase near La Pedrera entrance{% endfigure %}
+{% figure spain-cadaques-barcelona-268.jpg portrait %}
+Colourful staircase near La Pedrera entrance
+{% endfigure %}
 
 On the ground floor we continued having fun with the camera, Sam picked up a lot of textures and interesting patterns, and outside we tried to compose a shot of La Pedrera, a Gaudí-an street light and tree without getting the traffic and traffic lights in the way. We’d seen an image in the gift store and rather than pay 20 euros for it, we attempted to match it, which was fun in itself.
 
-{% figure spain-cadaques-barcelona-270.jpg portrait %}Attempting to reproduce prints we’d seen in the store.{% endfigure %}
+{% figure spain-cadaques-barcelona-270.jpg portrait %}
+Attempting to reproduce prints we’d seen in the store.
+{% endfigure %}
 
-{% figure spain-cadaques-barcelona-274.jpg landscape %}Samantha posing for an artistic shot{% endfigure %}
+{% figure spain-cadaques-barcelona-274.jpg landscape %}
+Samantha posing for an artistic shot
+{% endfigure %}
 
 ## Cerveceria Catalana (again)
 
@@ -48,13 +64,17 @@ We stopped again at Cerveceria Catalana for lunch. Sitting at the bar we picked 
 * Pineapple and soft cheese
 {% endmenu %}
 
-{% figure spain-cadaques-barcelona-286.jpg landscape %}The bar at Cerveceria Catalana{% endfigure %}
+{% figure spain-cadaques-barcelona-286.jpg landscape %}
+The bar at Cerveceria Catalana
+{% endfigure %}
 
 ## Rooftop jacuzzi
 
 Siesta time approached, and the second we reached our hotel room the heavens opened. So much for escaping the heat. As we we’re in the hotel, why not try out the rooftop jacuzzis? “It won’t be busy up there”. So, in our swimwear and in the rain, we watched Barcelona from our personal jacuzzi, as the rainclouds passed and the sun came out.
 
-{% figure spain-cadaques-barcelona-288.jpg portrait %}Stormy Barcelona{% endfigure %}
+{% figure spain-cadaques-barcelona-288.jpg portrait %}
+Stormy Barcelona
+{% endfigure %}
 
 ## Mid-afternoon jaunt
 
@@ -64,11 +84,17 @@ We stopped for Ice Cream (“of course Spar will have Ice Cream”), and after S
 
 Before nipping back to the hotel to get changed for dinner, we stopped at Fundació Antoni Tàpies, another Modernista building with metal wire sculpture donning the roof. Inside a vast white room housed a Tàpies exhibition. Peculiar works of art; mounds of dirt stuck to walls, and rusting canvas with graffiti’d fractions. It was all a bit over our heads.
 
-{% figure spain-cadaques-barcelona-303.jpg landscape %}Tàpies exhibition at Fundació Antoni Tàpies{% endfigure %}
+{% figure spain-cadaques-barcelona-303.jpg landscape %}
+Tàpies exhibition at Fundació Antoni Tàpies
+{% endfigure %}
 
-{% figure spain-cadaques-barcelona-298.jpg landscape %}Classic Barcelona street scene{% endfigure %}
+{% figure spain-cadaques-barcelona-298.jpg landscape %}
+Classic Barcelona street scene
+{% endfigure %}
 
-{% figure spain-cadaques-barcelona-304.jpg portrait %}Wire sculpture above [Fundació Antoni Tàpies](http://en.wikipedia.org/wiki/Fundaci%C3%B3_Antoni_T%C3%A0pies){% endfigure %}
+{% figure spain-cadaques-barcelona-304.jpg portrait %}
+Wire sculpture above [Fundació Antoni Tàpies](http://en.wikipedia.org/wiki/Fundaci%C3%B3_Antoni_T%C3%A0pies)
+{% endfigure %}
 
 ## El Túnel d’en Marc Palou
 
@@ -90,10 +116,16 @@ The French waiter tried to seat us by the window, naively we sat further inside 
 
 The décor of the place was plain, but it made the food all the more vibrant. Everything we ate was cooked to perfection, and delicious. A simple poached egg and salad tasted unreal, and the meat on my shoulder of kid just fell off. I was amazed and mystified with the taste of kid, with a flavour of its own I couldn’t pin down what made it so different. The desserts were sublime, never have I tasted strawberries so good, and we savoured every bite of the chocolate.
 
-{% figure spain-cadaques-barcelona-309.jpg portrait %}Paul with his shoulder of kid at El Túnel d’en Marc Palou{% endfigure %}
+{% figure spain-cadaques-barcelona-309.jpg portrait %}
+Paul with his shoulder of kid at El Túnel d’en Marc Palou
+{% endfigure %}
 
-{% figure spain-cadaques-barcelona-307.jpg portrait %}Samantha with her foie gras terrine{% endfigure %}
+{% figure spain-cadaques-barcelona-307.jpg portrait %}
+Samantha with her foie gras terrine
+{% endfigure %}
 
 On the way home we stopped outside Casa Batlló to relax in front of the lit up façade, now quiet and still in the night.
 
-{% figure spain-cadaques-barcelona-311.jpg portrait %}Casa Batlló{% endfigure %}
+{% figure spain-cadaques-barcelona-311.jpg portrait %}
+Casa Batlló
+{% endfigure %}

--- a/source/_posts/barcelona-spain/5.md
+++ b/source/_posts/barcelona-spain/5.md
@@ -7,25 +7,37 @@ page: 5
 
 On our last day in Barcelona, we packed up and checked out at 12. Leaving our luggage at the hotel, we took our final trip to Crusto. Ensaïmada for breakfast and some fine home-made pizza for lunch, sliced and wrapped.
 
-{% figure spain-cadaques-barcelona-324.jpg portrait original %}Ensaïmadas and coffee at Crusto{% endfigure %}
+{% figure spain-cadaques-barcelona-324.jpg portrait original %}
+Ensaïmadas and coffee at Crusto
+{% endfigure %}
 
 ## Gaudí roundup
 
 First stop of the day, La Pedrera gift shop, to grab some Gaudí tile reproductions, a poster and tea towel (of course). Then on to La Sagrada Família, to work on our photography skills a little more and eat lunch in the pleasant surroundings of the cathedral and park (far enough away from the construction site whirr). Snap, snap, snap, we tried artistic compositions of the nativity façade, reflections in the lake and reflections in sunglasses included. The sun hot on our necks one last time, we’d escaped the sun burn monster.
 
-{% figure spain-cadaques-barcelona-322.jpg portrait %}La Sagrada Família in black and white{% endfigure %}
+{% figure spain-cadaques-barcelona-322.jpg portrait %}
+La Sagrada Família in black and white
+{% endfigure %}
 
-{% figure spain-cadaques-barcelona-337.jpg portrait %}Reflections of La Sagrada Família{% endfigure %}
+{% figure spain-cadaques-barcelona-337.jpg portrait %}
+Reflections of La Sagrada Família
+{% endfigure %}
 
-{% figure spain-cadaques-barcelona-363.jpg portrait original %}Sam and Paul outside the La Sagrada Família construction site{% endfigure %}
+{% figure spain-cadaques-barcelona-363.jpg portrait original %}
+Sam and Paul outside the La Sagrada Família construction site
+{% endfigure %}
 
-{% figure spain-cadaques-barcelona-361.jpg landscape %}Reflections of La Sagrada Família part two {% endfigure %}
+{% figure spain-cadaques-barcelona-361.jpg landscape %}
+Reflections of La Sagrada Família part two 
+{% endfigure %}
 
 ## One last tapas
 
 Heading back, we spent an age in Vinçon, a department store filled with ingenious furniture and gadgets. Then one last stop at Cerveceria Catalana for Barcelona’s best tapas, before grabbing our bags, repacking them, chilling on the hotel roof by the jacuzzis, then casually heading down to the metro station.
 
-{% figure spain-cadaques-barcelona-368.jpg portrait %}One last tapas{% endfigure %}
+{% figure spain-cadaques-barcelona-368.jpg portrait %}
+One last tapas
+{% endfigure %}
 
 {% menu %}
 * Pork with apple on skewers

--- a/source/_posts/bedroom-farce-and-inception.md
+++ b/source/_posts/bedroom-farce-and-inception.md
@@ -15,7 +15,9 @@ date: 2010-07-30 20:46:40
 
 Amongst our search for a house to purchase, in Brighton or Haywards Heath, we've been out a couple of nights this week to relax. Firstly, at last, to see the new Chris Nolan movie, "Inception" at the old school Dukes of York cinema in Brighton. And secondly, to Brighton's Theatre Royal for Alan Ayckbourn's "Bedroom Farce" starring Maxwell Caulfield.
 
-{% figure bedroom-farce.jpg landscape original %}Bedroom Farce poster{% endfigure %}
+{% figure bedroom-farce.jpg landscape original %}
+Bedroom Farce poster
+{% endfigure %}
 
 I'd been lucky enough to not know anything about "Inception" before stepping in, beyond that it was supposedly weird and confusing and starred some of my favourite actors--namely Leonardo DiCaprio, Joseph Gordon-Levitt and Ellen Page. I've embedded the trailer below and highly recommend seeing it. If you've seen ExistenZ it might be a bit deja-vu in places. Many of the concepts were similar to Alex Garland's book, "The Coma", which you could probably read in an hour or so (or ten minutes if reading whilst asleep, or one minute if you're asleep whilst asleep).
 

--- a/source/_posts/beijing-china.md
+++ b/source/_posts/beijing-china.md
@@ -27,21 +27,29 @@ The alleyways here are fascinating. Grey-bricked single storey buildings line th
 
 Many of the buildings are quirky boutique shops and our hotel was just off The Alley, the main shopping hutong. It's Beijing's equivalent of Brighton’s lanes. Lots of good little eateries and bars, shops selling tea, clothes, sculptures, porcelain, hand painted art, leather-ware, stationary, souvenirs, and even ocarinas. The whole time we stayed here the alley was busy, filled with trendy looking Chinese teens (with bow ties in their hair, or kitten ears, or chunky platform boots and punk jackets, or t-shirts bearing nonsense English phrases — “truck furniture”), Chinese tourists with their big cameras and the occasional English speaker.
 
-{% figure china-beijing-003.jpg landscape %}A music bar in Beijing’s hutong{% endfigure %}
+{% figure china-beijing-003.jpg landscape %}
+A music bar in Beijing’s hutong
+{% endfigure %}
 
-{% figure china-beijing-004.jpg landscape %}Pu-er tea being sold in a hutong tea shop{% endfigure %}
+{% figure china-beijing-004.jpg landscape %}
+Pu-er tea being sold in a hutong tea shop
+{% endfigure %}
 
 The taxi couldn't get down the alley, so we were dropped off at the north gate and wheeled our luggage through the crowds and shops to our hotel, where we said goodbye, for now, to our guide.
 
 ## Courtyard 7
 
-{% figure china-beijing-005.jpg landscape %}Courtyard 7 at night{% endfigure %}
+{% figure china-beijing-005.jpg landscape %}
+Courtyard 7 at night
+{% endfigure %}
 
 The [courtyard](http://www.tripadvisor.co.uk/Hotel_Review-g294212-d1141369-Reviews-Courtyard_7-Beijing.html) is an escape from the hustle and bustle outside, in its tranquility it's easy to forget the enormous city you're in. The courtyard is a 300 year old original, surrounded in red-beamed grey-tiled historic rooms, each furnished with Chinese antiques.
 
 From reception you pass through a stone arch into a small yard with a restaurant. Through another wooden gate and you're faced with a beautiful walled courtyard, one room either side. We had been given a free upgrade, and through a small arch at the back we found our room, with its private courtyard, rocking chair, Chinese paintings and delightful fittings — golden fabrics, wood panelled bathroom and sauna, traditional bed and curtains.
 
-{% figure china-beijing-001.jpg landscape %}Our traditional room at Courtyard 7{% endfigure %}
+{% figure china-beijing-001.jpg landscape %}
+Our traditional room at Courtyard 7
+{% endfigure %}
 
 Breakfast was included, which was a spread of fresh fruit, salad, salami and cheese, with tea and coffee. It was quite average, but that's our only real complaint.
 
@@ -49,4 +57,6 @@ Breakfast was included, which was a spread of fresh fruit, salad, salami and che
 
 After checking in and settling down we set out to explore our surroundings. In the alley we queued at all the food stands that looked popular; a bag of fried squid bits, some fried sweet potato — oddly doused in sugar, lobster and cabbage fried balls, passion fruit drink, and a Tiger beer. Stuffed, and with a bit of bellyache, we retired for the night.
 
-{% figure china-beijing-002.jpg landscape %}Shops along Beijing’s busiest hutong{% endfigure %}
+{% figure china-beijing-002.jpg landscape %}
+Shops along Beijing’s busiest hutong
+{% endfigure %}

--- a/source/_posts/beijing-china/2.md
+++ b/source/_posts/beijing-china/2.md
@@ -19,13 +19,17 @@ After breakfast we met our guide, Ashley, for the start of a four part whistle s
 
 [Lama temple](http://en.wikipedia.org/wiki/Yonghe_Temple) (or Yonghe temple) is “the most renowned Tibetan Buddhist temple outside of Tibet”, says the Lonely Planet. To our eyes it seemed very similar to the Buddhist temples we'd seen in Vietnam, particularly those in Hue. A tree lined road leads up to the temple, and at the entrance there's a burning altar where people burnt incense and said prayers. The sky was a bright white, without any defining features, Beijing’s infamous smog perhaps? Large green persimmon hung from trees dotted about the courtyards.
 
-{% figure china-beijing-day-2-015.jpg landscape %}Burning incense at Lama temple, Beijing{% endfigure %}
+{% figure china-beijing-day-2-015.jpg landscape %}
+Burning incense at Lama temple, Beijing
+{% endfigure %}
 
 The temple is made up of five halls, which appear to be in rows, each row separated with a courtyard. For Beijing's city centre, and with the number of people there, it was quiet. As we passed through each of the halls, from the Hall of the Heavenly Kings, to the Hall of Harmony and Peace, and so on, Ashley taught us about the poses and ranks of the different Buddhist statues we could see. Still a little jet-lagged, or mostly just tired, we didn't take much of it in. At the far end of the temple complex lies the Pavilion of Ten Thousand Happinesses, which holds an enormous 18m high standing Buddha, resplendent in gold and carved from a single piece of Sandalwood.
 
 We exited via a small door in the temple wall, which opens up onto a busy highway and a car park filled with coaches. Our driver was waiting, and we clambered in and sped off to our next stop, the Temple of Heaven.
 
-{% figure china-beijing-day-2-014.jpg landscape %}Lama temple’s Pavilion of Ten Thousand Happinesses{% endfigure %}
+{% figure china-beijing-day-2-014.jpg landscape %}
+Lama temple’s Pavilion of Ten Thousand Happinesses
+{% endfigure %}
 
 ### Temple of Heaven
 
@@ -33,15 +37,21 @@ What should have been a short trip took 45mins; the mid-morning traffic was busi
 
 The [Temple of Heaven](http://en.wikipedia.org/wiki/Temple_of_Heaven) (Tiāntán, 天坛) is predominantly an extensive park containing some important religious structures, namely the iconic Hall of Prayer for Good Harvests. With Ashley we ambled through the park's perfectly manicured paths and a menagerie of activity groups. In the discordant park, where the loudspeakers blast out tinny songs at volumes they can't cope with (to drown out the neighbouring music), we passed by choir groups, dance troupes, tai chi martial artists with plastic swords — and (tai) [chi ball](http://en.wikipedia.org/wiki/Chi_ball) players too. The paved areas are filled with these groups, formed mostly of Beijing's healthy retirees, enjoying the outdoors — it's free for them to enter. In this cacophony [Chinese magpies](http://en.wikipedia.org/wiki/Azure-winged_magpie) flitted about the grounds and black squirrels scurried about the grass, which you cannot walk on.
 
-{% figure china-beijing-day-2-018.jpg landscape %}Tai chi in the park{% endfigure %}
+{% figure china-beijing-day-2-018.jpg landscape %}
+Tai chi in the park
+{% endfigure %}
 
 The park was similar to all the city parks (often People's parks) we found in China; the paths, plants and grass all look perfect. The paths and courtyards are filled with groups partaking in dance and martial arts — at all times of the day. And walking on the luscious green grass is always expressly forbidden.
 
 From the park we climbed white-stone steps up to the Hall of Prayer for Good Harvests. Ashley explained that traditionally the emperor would come here and, you guessed it, pray for good harvests. Some of the emperors duties could be shirked off to other high ranking officials, but this act always had to be performed by the emperor. The hall is a unique "triple-gabled" wooden structure, rebuilt in 1889 after being struck by lightning (I wonder if the harvests were good that year). Around the hall we spotted at least three couples having their wedding photos taken; in Shanghai the brides had been dressed all in white, but here the dresses were red or turquoise and were "traditional with a modern twist", Ashley pointed out. You can't enter the building, but climbing to the top does give you a view out across smoggy Beijing.
 
-{% figure china-beijing-day-2-013.jpg landscape %}A bride having her photo taken at the Temple of Heaven{% endfigure %}
+{% figure china-beijing-day-2-013.jpg landscape %}
+A bride having her photo taken at the Temple of Heaven
+{% endfigure %}
 
-{% figure china-beijing-day-2-012.jpg landscape %}Samantha and Paul outside the Hall of Prayer for Good Harvests{% endfigure %}
+{% figure china-beijing-day-2-012.jpg landscape %}
+Samantha and Paul outside the Hall of Prayer for Good Harvests
+{% endfigure %}
 
 The park here had ripe persimmon too, so ripe that they were falling from the trees almost rotten, squishing on the concrete in a big mush. And as we exited, right by the car park, one fell and narrowly missed a child, everyone jumped in surprise as the orange pulp splashed everywhere.
 
@@ -49,7 +59,9 @@ The park here had ripe persimmon too, so ripe that they were falling from the tr
 
 We told Ashley that we'd like to try some traditional local food for lunch, and she took us to a restaurant on the [South East corner of Tiananmen square](https://www.google.co.uk/maps/search/61+guangchang+east,+tiananmen+square,+beijing/@39.9019876,116.4001769,18z). The picture shows the name of the place, but I can't translate it. The place specialised in hot pot, and it was busy. On a table for three we chose some fairly safe options — stir fried beef and onions, fried chicken and cashews, and mushrooms with pak choi (the menu had pictures, and included a lot of things we wouldn't dream of eating — offal soup, tripe). Sam also ordered a pot of yellow chrysanthemum tea which we split between three of us — Ashley instructed us to point the teapot’s spout away from everyone, and showed us how to hold the cups.
 
-{% figure china-beijing-day-2-019.jpg landscape %}Restaurant near Tiananmen Square{% endfigure %}
+{% figure china-beijing-day-2-019.jpg landscape %}
+Restaurant near Tiananmen Square
+{% endfigure %}
 
 ### Tiananmen Square
 
@@ -59,13 +71,21 @@ Tiananmen square (Tiān'ānmén Guǎngchǎng, 天安门广场) is vast and formi
 
 Our timing meant we also got to see a changing of the guard at the national flag pole, where three green-uniformed members of the People's Liberation Army marched across the square, exchanged salutes and stood at their new posts. From the flag pole we passed through the subway to the gate of heavenly peace, out of the square and onwards to the Forbidden City.
 
-{% figure china-beijing-day-2-011.jpg landscape %}A guard rail on Tiananmen square{% endfigure %}
+{% figure china-beijing-day-2-011.jpg landscape %}
+A guard rail on Tiananmen square
+{% endfigure %}
 
-{% figure china-beijing-day-2-010.jpg landscape %}Changing of the guard at Tiananmen square{% endfigure %}
+{% figure china-beijing-day-2-010.jpg landscape %}
+Changing of the guard at Tiananmen square
+{% endfigure %}
 
-{% figure china-beijing-day-2-009.jpg landscape %}National Museum of China{% endfigure %}
+{% figure china-beijing-day-2-009.jpg landscape %}
+National Museum of China
+{% endfigure %}
 
-{% figure china-beijing-day-2-016.jpg landscape %}Gate of Heavenly Peace and Chairman Mao’s portrait{% endfigure %}
+{% figure china-beijing-day-2-016.jpg landscape %}
+Gate of Heavenly Peace and Chairman Mao’s portrait
+{% endfigure %}
 
 ### Forbidden City
 
@@ -73,19 +93,27 @@ You can't come to Beijing, or even China, and not visit the [Forbidden City](htt
 
 Entrance is through the [Meridian Gate](http://en.wikipedia.org/wiki/Meridian_Gate) from the south. Like we'd seen at the [Imperial City in Hue](/2012/12/hue-vietnam/), the central arch (of five) — as well as the following paths and steps, were reserved exclusively for the emperor. Servants and officials had to use the side entrances. It was under renovation but its red walls already glowed after a _recent_ repaint in 2008, for the olympics.
 
-{% figure china-beijing-day-2-007.jpg landscape %}Meridian Gate, entrance to the Forbidden City{% endfigure %}
+{% figure china-beijing-day-2-007.jpg landscape %}
+Meridian Gate, entrance to the Forbidden City
+{% endfigure %}
 
 From the gate we entered the first courtyard, which is traversed by the Golden Stream and five marble bridges, leading up to the [Gate of Supreme Harmony](http://en.wikipedia.org/wiki/Gate_of_Supreme_Harmony). In these outer areas of the city the emperor conducted the running of the country, we were told. The buildings themselves are now, disappointingly, empty — their lavish furnishings presumably stripped bare when foreign forces arrived in the 20th century. But the buildings themselves are still decadent; 11 golden dragons perch on each corner of the rooftop, bronze lions guard the entrances, and bright red pillars are topped with ornate gold and green motifs.
 
-{% figure china-beijing-day-2-005.jpg landscape %}Forbidden city courtyard and Gate of Supreme Harmony{% endfigure %}
+{% figure china-beijing-day-2-005.jpg landscape %}
+Forbidden city courtyard and Gate of Supreme Harmony
+{% endfigure %}
 
 Next comes the most impressive building of all, [The Hall of Supreme Harmony](http://en.wikipedia.org/wiki/Hall_of_Supreme_Harmony), which lies at the centre of the Forbidden City. Its built on three levels of marble and is the largest wooden structure in China. Crowds push and shove to peek through the entrance and get a glimpse of the emperor's old throne. Its closely followed by the [Hall of Middle Harmony](http://en.wikipedia.org/wiki/Hall_of_Central_Harmony) and [Hall of Preserving Harmony](http://en.wikipedia.org/wiki/Hall_of_Preserving_Harmony).
 
 Beyond the grand halls and courtyards lies the city within a city — the inner court, a network of red walled roads connect the emperors’ former residences, bridal chambers, living quarters for the palace’s harem and even an Imperial Garden — a perfectly landscaped Chinese garden with pruned shrubs, trees and rockeries (or "perilous rocks" as the signs said). This was our favourite part of the city, the buildings were smaller but were unique, had character and still showed signs of how they'd have been used.
 
-{% figure china-beijing-day-2-004.jpg landscape %}Paul standing on one of the city’s many red walled roads{% endfigure %}
+{% figure china-beijing-day-2-004.jpg landscape %}
+Paul standing on one of the city’s many red walled roads
+{% endfigure %}
 
-{% figure china-beijing-day-2-003.jpg landscape %}Sam and Paul in the Imperial Garden{% endfigure %}
+{% figure china-beijing-day-2-003.jpg landscape %}
+Sam and Paul in the Imperial Garden
+{% endfigure %}
 
 On our last legs, tired after quite the sightseeing experience, we exited the city through another ornate gate, the North gate. Ashley had promised us Chinese tea in the park, and right opposite the park's exit is [Jingshan park](http://en.wikipedia.org/wiki/Jingshan_Park), a manmade hill looking over the city.
 
@@ -95,13 +123,19 @@ Exhausted, Ashley directed us through Jingshan park (entrance 4¥; 40p) to a tea
 
 Ashley said something about the tea house being for members only, but from the looks of the other patrons it seemed like a tourist-only kind of place. Nevertheless we sat down and enjoyed our first Chinese tea ceremony. We tried oolong (with a tall thin cup for smelling first), ginseng oolong, jasmine, pu-er, and red rose tea; and then flatly ignored the pressure to buy some of the fresh tea, which came in pots starting at 300RMB each (about £30). We'd already discovered that tea in China was expensive, often costing as much as a meal, but this was prohibitively so (we later found some much cheaper higher quality jasmine tea — refrigerated to keep it fresh no less — in Chengdu).
 
-{% figure china-beijing-day-2-002.jpg portrait %}Our first Chinese tea ceremony{% endfigure %}
+{% figure china-beijing-day-2-002.jpg portrait %}
+Our first Chinese tea ceremony
+{% endfigure %}
 
-{% figure china-beijing-day-2-001.jpg landscape %}Samantha enjoying a cup of ginseng oolong tea{% endfigure %}
+{% figure china-beijing-day-2-001.jpg landscape %}
+Samantha enjoying a cup of ginseng oolong tea
+{% endfigure %}
 
 Before leaving the park, on our tired legs we climbed to the top of Jingshan for the towering twilight views over Beijing and the Forbidden City — but the clouds and smog obscured much of it. Our city tour was over now and we said our farewells to Ashley (a good patient guide who'd spent longer with us than she needed to) and walked back to the Hutong (the scale of Beijing's maps are hard to fathom — the streets are so wide, long and straight that at a glance most distances seem shorter than they are in reality — the walk back took a further 40 minutes). The pedometer reading for the day sits at 21,317 steps.
 
-{% figure china-beijing-day-2-017.jpg landscape %}A smoggy Forbidden City as seen from Jingshan park{% endfigure %}
+{% figure china-beijing-day-2-017.jpg landscape %}
+A smoggy Forbidden City as seen from Jingshan park
+{% endfigure %}
 
 ## Dinner at Dali courtyard two — Dali Su
 

--- a/source/_posts/beijing-china/3.md
+++ b/source/_posts/beijing-china/3.md
@@ -13,7 +13,9 @@ page: 3
 
 ## Walking the Great Wall at Jinshanling
 
-{% figure china-beijing-day-3-004.jpg landscape %}The Great Wall of China at Jinshanling{% endfigure %}
+{% figure china-beijing-day-3-004.jpg landscape %}
+The Great Wall of China at Jinshanling
+{% endfigure %}
 
 Up too early for the hotel’s breakfast (they packed us something), we waited for our driver with a Dutch couple, Jan and Emmie, who’d be joining us on our trip to China's Great Wall. They too had booked through Rickshaw Travel ([China Travel Plan](http://www.chinatravelplan.co.uk/)) and we shared much of the same itinerary — later we'd travel to Xi’an together on the sleeper train and then see the Terracotta warriors together, we’d even bump into each other again at Guilin airport on route to [Hong Kong](/2014/09/hong-kong-china/).
 
@@ -23,29 +25,41 @@ Through a game of charades with our driver, who spoke no English, we arranged a 
 
 The maps of the wall are confusing, we had one, Jan and Emmie had one, and they both looked different, the park had one but it too was different. Once you get to the wall you only need to know left or right and then when to stop, a map ought not to be too difficult. After some confusion we took the Shalinggou path to the wall. The paved trail climbs swiftly and ends abruptly, leaving you staring up at the base of a restored 16ft wall, steep steps take you up onto the wall’s surface.
 
-{% figure china-beijing-day-3-008.jpg landscape %}Jan comparing maps of the wall{% endfigure %}
+{% figure china-beijing-day-3-008.jpg landscape %}
+Jan comparing maps of the wall
+{% endfigure %}
 
 From the top of the wall you can’t help but smile, this place is a little bit special and it looks exactly like all the pictures. Stretching out into the distant East and West the wall hugs the hilltops, snaking along the highest point — beacons and towers visible from miles away; to the North and South are fabulous mountain ranges. It’s tremendously exciting just to be here, but we also had the place to ourselves; no tour groups, no other hikers, just the four of us in the morning fog, the temperature perfect for a ramble, the air quiet but for chirping birds. It was overcast and the visibility wasn’t great but as the day passed the clouds lifted a little. Still, this was one of our highlights in all of China.
 
-{% figure china-beijing-day-3-006.jpg landscape %}Looking West from the Dark Tower{% endfigure %}
+{% figure china-beijing-day-3-006.jpg landscape %}
+Looking West from the Dark Tower
+{% endfigure %}
 
 ### West to East
 
 We hiked from Shalinggou path to the East gate, which would take us 4 hours, walking fairly slowly and stopping to take a lot of pictures. The first tower we came to was “Dark Tower”, legend says it was struck by lightning and caught fire — and a girl named Hei Gu (meaning ‘black’) died trying to put out the fire, when it was rebuilt it took its name from her and became the dark tower. We continued East, up and over some hills, up and down steps, through some more towers along to Large Jinshan Tower — named by the soldiers who built it in 1569, after their hometown. This tower is two storeys high, and you can climb its hidden stairs to see out from the top where the views are all the more spectacular (you may also inadvertently and hilariously scare your wife who can hear your voice but can’t see you). The wall continues but begins to deteriorate, the level easy-going floor crumbles, some of the wind-sheltering “wall-top walls” have fallen away and the slopes decline and climb at a steeper gradient, still, it’s not too arduous (although I imagine in the heat of the midday sun it could be tough).
 
-{% figure china-beijing-day-3-003.jpg landscape %}Deteriorating Great Wall heading East at Jinshanling{% endfigure %}
+{% figure china-beijing-day-3-003.jpg landscape %}
+Deteriorating Great Wall heading East at Jinshanling
+{% endfigure %}
 
 Half-way along we stopped at a tower for tea and coffee. Many locals sit in the towers along the wall, ready to serve you light refreshments, tea, coffee, snacks, for a small but reasonable fee. At tiny plastic chairs Sam, Jan and Emmie sat inside to enjoy some coffee, while I found a perch outside with a good view to eat my packed breakfast (a sandwich with every possible filling crammed in — ham, mayo, gherkin, cheese, tomato, onion, and more), urging on the occasional sweaty tourist, three suited and exhausted Chinese businessmen in particular.
 
 Pushing onwards we reached the Houchuan pass, via a crumbling and trodden trail, it was one of the main passages to go in and out of the wall and would have been heavily guarded. A section of the wall shortly after this is too damaged to walk on and was undergoing repair, we followed the mud trail around the bottom of the tower, slippery and tricky at times, but we soon found our way back onto the ancient wonder. Our final stop along the wall was at the “East tower with five holes”, built in 1569 and named after the five arrow holes in the North and South walls. Labourers working to repair the wall were on their lunch break. The wall continues East, towards [Sīmǎtái](http://en.wikipedia.org/wiki/Simatai) and a scenic view of the reservoir, but you have to return by the route you came — back to this tower. Its 5km long and was only reopened to the public in 2014. Regrettably we chose not to continue, the time we were meeting the driver was approaching, we didn’t have much food and it’s a long way back down to the car park (though also, it’s a long way back to China!).
 
-{% figure china-beijing-day-3-002.jpg landscape %}The Great Wall’s “East tower with five holes”{% endfigure %}
+{% figure china-beijing-day-3-002.jpg landscape %}
+The Great Wall’s “East tower with five holes”
+{% endfigure %}
 
 The hike down the hill to our driver was hard on the knees, and we all got a bit of the wobbly-thigh by the end. Our driver was there (we were afraid he wouldn’t be), and soon enough we were headed back to Beijing. The main road, big and capable of handling a lot of traffic, was quiet. Road signs used cartoons to warn against speeding; an elephant in a car warned about overloading, and a giraffe about clearance. Then we fell asleep.
 
-{% figure china-beijing-day-3-001.jpg portrait %}Paul on The Great Wall of China{% endfigure %}
+{% figure china-beijing-day-3-001.jpg portrait %}
+Paul on The Great Wall of China
+{% endfigure %}
 
-{% figure china-beijing-day-3-007.jpg landscape %}Samantha on The Great Wall{% endfigure %}
+{% figure china-beijing-day-3-007.jpg landscape %}
+Samantha on The Great Wall
+{% endfigure %}
 
 ## Dinner in the Hutong
 
@@ -53,6 +67,8 @@ Arriving back at Courtyard 7, we cleaned ourselves up and headed out again prett
 
 Away from the more touristy parts of the Hutong the narrow alleys open up onto hidden residential courtyards, local markets selling fresh fruit and veg, and small cafes and restaurants which double as homes. We wandered until a place took our fancy; “[Grandma Creative Kitchen](https://foursquare.com/v/grandma-creative-kitchen/5321881d498e957b25309a10)”, looked quaint and lovely. Our waiter spoke very little English, and he spoke it nervously — it felt like a good opportunity to try out my nervous mandarin, but it mostly confused more than helped. We ordered tea, soup, duck, chicken and rice; it felt like homemade food and it was all tasty. The Chinese don’t seem to do courses, no starters and desserts and the food comes quickly and all at once.
 
-{% figure china-beijing-day-3-010.jpg landscape %}Romantic lighting at Grandma Creative Kitchen{% endfigure %}
+{% figure china-beijing-day-3-010.jpg landscape %}
+Romantic lighting at Grandma Creative Kitchen
+{% endfigure %}
 
 Craving something sweet we stopped at chintzy looking cafe, [Lady](https://foursquare.com/v/lady/5412eaf9498e157a7bb153f6),  that wouldn’t have been out of place in Brighton’s lanes. Inside the sofas and tables were occupied mostly by cats, a boy was toying with a grey kitten — teasing it with a green furry thing; the cats had their own beds and their pictures were on the wall, one of the tables doubled as a fish tank. It felt like most of the family that lived here were using the cafe as a lounge, watching TV, doing some work on a laptop, making the most of the space. We ordered some [mojitos and cheesecake](http://instagram.com/p/s2IQ7_NFMY/), and mostly enjoyed watching the cats and the atrociously bad Chinese soap playing out on the TV (we’d come across that cheesy moustached main character again in our adventures).

--- a/source/_posts/beijing-china/4.md
+++ b/source/_posts/beijing-china/4.md
@@ -15,13 +15,17 @@ page: 4
 
 We had no planned activities on our last day in Beijing, and we took the opportunity to have a lie in — the remainder of the morning was spent packing. As we’d done many times before, when we left the hotel we headed out into the Hutong for a spot of shopping, mostly to buy all the bits and pieces we’d seen in shops but hadn’t got around to purchasing; some Pu-er tea, a Lotus-motif tea caddy, etc. At the North end of the alley we explored further. Music shops were openly selling bootlegged copies of Western music. Sam tried a white yoghurt like drink from a street stall, and an elderly man sat on a corner playing gorgeous traditional music on a plucked lute.
 
-{% figure china-beijing-day-4-002.jpg landscape %}Exploring Beijing’s hutong one last time<br/> (I don’t know what this man is pointing at){% endfigure %}
+{% figure china-beijing-day-4-002.jpg landscape %}
+Exploring Beijing’s hutong one last time<br/> (I don’t know what this man is pointing at)
+{% endfigure %}
 
 The Hutong is right next to [Beijing’s Bell and Drum towers](http://en.wikipedia.org/wiki/Gulou_and_Zhonglou), towers that were used to announce the time and in the past would have looked out across Beijing. Being so close we paid them a visit, but it’s a good job we didn’t cross the city to get there as they were both closed for renovation — situated on a roundabout this seemed to be causing some traffic chaos too, although that could just be the norm. In Britain a building site would be closed off and signs would hang everywhere warning you not to enter, here we strolled across the half built areas, taking a look at the bits we could (as others were also doing).
 
 We stopped for lunch at a Vietnamese place (you might guess that it was called Pho), and continued shopping until I grew tired. The biggest of our purchases were some calligraphy and painting pieces from Nanluo art gallery, which we spent a long time deliberating about and I spent an even longer time trying to find a cash machine to pay for the things. With the evening drawing near we opted to relax and make the most of Courtyard 7; chilling beneath a parasol we drank jasmine tea until the restaurant opened for food orders. The hotel’s food was lovely too; eel and rice and pork dumpling, although the random [ginkgo seeds](http://en.wikipedia.org/wiki/Ginkgo_biloba) that we also ordered were odd and not at all good, turns out it’s something ancient and related to Chinese medicine.
 
-{% figure china-beijing-day-4-001.jpg landscape %}Samantha at the exit to Courtyard 7{% endfigure %}
+{% figure china-beijing-day-4-001.jpg landscape %}
+Samantha at the exit to Courtyard 7
+{% endfigure %}
 
 ## Sleeper train to Xi’an
 
@@ -31,4 +35,6 @@ Sam ran around the station buying food and supplies (and weirdly a metal hip fla
 
 Eventually we boarded and the train left for [Xi’an](/2014/09/xian-china/) on time. We had a soft sleeper berth which comes with four bunks, a small table, air conditioning, a newspaper, a flask for boiling water and a vase with a flower. It was all very cosy and comfortable and significantly nicer than our [sleeper train experiences in Vietnam](/2012/12/hanoi-and-halong-bay-vietnam/), we even arranged for jasmine tea to be delivered to us at 7am. We were joined by a polite Chinese couple who couldn’t speak a word of English, though it didn’t stop them sharing their crabapples. We tried to engage them in a game of cards but there wasn’t a game we all knew the rules for. They both went to sleep, I wrote my blog and Sam went next door to chat for hours about Chinese culture and Xi’an with Emmie, Jan and a very talkative Xi’an resident.
 
-{% figure china-beijing-day-4-003.jpg landscape %}Soft sleeper berth from Beijing to [Xi’an](/2014/09/xian-china/){% endfigure %}
+{% figure china-beijing-day-4-003.jpg landscape %}
+Soft sleeper berth from Beijing to [Xi’an](/2014/09/xian-china/)
+{% endfigure %}

--- a/source/_posts/birthday-surprise.md
+++ b/source/_posts/birthday-surprise.md
@@ -31,9 +31,13 @@ The exhibition itself was marvellous. It was split into three acts, “deconstru
 
 In deconstruction we examined costumes: a Charlie Chaplin outfit in brown dusty colour; Michael Kaplan's Fight Club designs and Tyler Durden's famous blood stained red jacket; The Dude's bathrobe from The Big Leboswki; Jason Bourne's 'blend-in' style; The Addams Family, including Wednesday's sword-ed dress and Morticia's spider sequinned number; four outfits from Oceans Eleven; a selection of Elizabeths from assorted interpretations; and Indiana Jones with whip, customised Fedora, worn leather jacket, dusty shoes and gun holster.
 
-{% figure birthday-hollywood-costumes-11.jpeg portrait original %}Charlie Chaplin{% endfigure %}
+{% figure birthday-hollywood-costumes-11.jpeg portrait original %}
+Charlie Chaplin
+{% endfigure %}
 
-{% figure birthday-hollywood-costumes-08.jpeg landscape original %}The Addams Family and Fight Club{% endfigure %}
+{% figure birthday-hollywood-costumes-08.jpeg landscape original %}
+The Addams Family and Fight Club
+{% endfigure %}
 
 Each came with an insight into that specific costume design process; for instance, how Indy's hat was customised so his face could be seen, and how his jacket was sandpapered to look worn, and how the whole piece was put together to look like an old adventure flick, from a simple Spielberg sketch.
 
@@ -41,15 +45,23 @@ In dialogue we listened to actors, directors and designers talk about their cost
 
 The room opened out to two more exhibits, a collection of genre costumes — period, sci-fi, computer generated, where, obviously, Darth Vader was the star of the show; and a collection of Meryl Streep and Robert De Niro costumes from their movies; Taxi Driver, Raging Bull, The Iron Lady, etc.
 
-{% figure birthday-hollywood-costumes-14.jpeg landscape original %}Changing Contexts, with Darth Vader{% endfigure %}
+{% figure birthday-hollywood-costumes-14.jpeg landscape original %}
+Changing Contexts, with Darth Vader
+{% endfigure %}
 
-{% figure birthday-hollywood-costumes-12.jpeg landscape original %}Meryl Streep and Robert De Niro costumes{% endfigure %}
+{% figure birthday-hollywood-costumes-12.jpeg landscape original %}
+Meryl Streep and Robert De Niro costumes
+{% endfigure %}
 
 Beyond was the third room, the finale. This room was filled with costumes of all the famous characters you could imagine, classics that have defined the memories of millions. From Kate Winslett's Titanic costume, with its enormous purple hat; to action heroes Spider-man, Batman, Terminator, Hans Solo, Superman, Bond, Neo in the Matrix, Harry Potter and the yellow tracksuit from Kill Bill; to Keira Knightley's dress from Atonement, Holly Golightly from Breakfast at Tiffany's and Marilyn Monroe's dresses from Some Like it Hot and the infamous billowing white dress, behind a protective glass screen.
 
-{% figure birthday-hollywood-costumes-03.jpeg landscape original %}Costume finale with Hans Solo, Superman, Neo, Terminator and Kill Bill{% endfigure %}
+{% figure birthday-hollywood-costumes-03.jpeg landscape original %}
+Costume finale with Hans Solo, Superman, Neo, Terminator and Kill Bill
+{% endfigure %}
 
-{% figure birthday-hollywood-costumes-16.jpeg portrait original %}Spider-man{% endfigure %}
+{% figure birthday-hollywood-costumes-16.jpeg portrait original %}
+Spider-man
+{% endfigure %}
 
 That was excellent. Simply fantastic. In the tacky Hollywood gift shop outside we discussed our favourite moments, and examined design and fashion books. I couldn't help but wonder how I would define a costume for myself, and what message I want my clothes to put across. Perhaps when I go clothes shopping next time, if I consider it a design process, I might enjoy it a little more.
 
@@ -57,6 +69,8 @@ That was excellent. Simply fantastic. In the tacky Hollywood gift shop outside w
 
 The museum was closing now, open late on a Friday, but shutting now it was 9 o'clock. We stepped out into the cold streets of Kensington, hungry for some dinner. We stumbled on Comptoir Libanais, a Lebanese restaurant with an exciting menu, and teaming with diners. Seated at the far end Sam enjoyed a Lamb and Prune tagine, and I had the lamb and harissa burger with Lebanese fries, which were simply scrumptious.
 
-{% figure birthday-comptoir-01.JPG portrait %}Lebanese Burger at Comptoir Libanais{% endfigure %}
+{% figure birthday-comptoir-01.JPG portrait %}
+Lebanese Burger at Comptoir Libanais
+{% endfigure %}
 
 We walked the snowy, icy streets of Kensington back to our hotel. It wasn't even my birthday yet, and I was having a fabulous time.

--- a/source/_posts/birthday-surprise/2.md
+++ b/source/_posts/birthday-surprise/2.md
@@ -10,9 +10,13 @@ Come Saturday morning, in our hotel bed, I opened the presents and cards Samanth
 
 For breakfast we returned to Comptoir Libanais and both ordered the Breakfast Beiruty; Sumac fried egg on toasted Comptoir bun, halloumi and zaatar croissants, organic labneh, warm pita bread, Lebanese rose jelly, fig jam, coffee and freshly made to order orange juice. It was even better than dinner the night before.
 
-{% figure birthday-2013-02b.JPG portrait 620 %}Breakfast Beiruty at Comptoir Libanais{% endfigure %}
+{% figure birthday-2013-02b.JPG portrait 620 %}
+Breakfast Beiruty at Comptoir Libanais
+{% endfigure %}
 
-{% figure birthday-2013-01.JPG portrait 620 %}Natural History Museum in the snow{% endfigure %}
+{% figure birthday-2013-01.JPG portrait 620 %}
+Natural History Museum in the snow
+{% endfigure %}
 
 ## Wildlife Photographer of the Year
 
@@ -64,7 +68,9 @@ At last we settled on our order:
 
 The food was stunning. My langoustine were perfect, delicate, soft and tasty. Sam couldn't believe how a sweet potato could taste so strong, and it was excellent with the crab (and a bit of bread). Her fish was lovely too, and the mash had large parts of lobster. My mallard, I'd been warned, might contains pellets, as it was wild. It didn't, and it too was marvellous. The dessert to share was a perfect Sam and Paul concoction — passion fruit and mango, with profiteroles? Yes please.
 
-{% figure birthday-2013-09.JPG landscape %}View from the OXO tower{% endfigure %}
+{% figure birthday-2013-09.JPG landscape %}
+View from the OXO tower
+{% endfigure %}
 
 After we'd finished we explored a little more, and stood outside, in the cold, taking photos of the view. We walked back along the Thames, on the slippery snowy paths, to Southbank, across the bridge to Embankment, and onto a tube to our hotel. What an incredible birthday.
 
@@ -74,4 +80,6 @@ The following morning we discussed whether to do and see more, perhaps peruses t
 
 And that was that, my birthday over. We checked out, took the tube to Victoria and the train home, or at least to Three Bridges, where, from there, we took a replacement bus down the A23.
 
-{% figure birthday-2013-13.JPG landscape %}Home in the snow{% endfigure %}
+{% figure birthday-2013-13.JPG landscape %}
+Home in the snow
+{% endfigure %}

--- a/source/_posts/board-games-in-the-pub-and-a-dash-of-culture.md
+++ b/source/_posts/board-games-in-the-pub-and-a-dash-of-culture.md
@@ -20,7 +20,9 @@ This year felt like a double birthday. On Tuesday, the day before, Sam treated m
 
 Come Thursday it was my last day at TSL, and with it came cake, presents and a pub send off! Friday was lost to a hangover, and all those good intentions for a day off between jobs fell into oblivion.
 
-{% figure IMG_2911.JPG landscape original %}‘Good luck Paul’ leaving cake{% endfigure %}
+{% figure IMG_2911.JPG landscape original %}
+‘Good luck Paul’ leaving cake
+{% endfigure %}
 
 ## Out and about
 

--- a/source/_posts/bordeaux-france.md
+++ b/source/_posts/bordeaux-france.md
@@ -68,19 +68,25 @@ We flew with EasyJet and landed at Merignac airport in the early afternoon. The 
 
 ## Petit Hôtel Labottière
 
-{% figure france-bordeaux-002.jpg landscape %}Petit Hôtel Labottière{% endfigure %}
+{% figure france-bordeaux-002.jpg landscape %}
+Petit Hôtel Labottière
+{% endfigure %}
 
 I described [Petit Hotel Labottiere](http://www.petithotellabottiere.fr/) as a “private chateau”; it’s a lovingly restored stately home hidden in the centre of Bordeaux. With only two rooms it’s exclusive, and [Trip Advisor](http://www.tripadvisor.co.uk/Hotel_Review-g187079-d1187499-Reviews-Petit_Hotel_Labottiere-Bordeaux_Gironde_Aquitaine.html) users rate it as the best place to stay in town. Just off Rue Fondaudège, behind an understated turquoise door lies this 18th century residence. Inside there’s a sitting room with a grandfather clock, to the right an exquisite dining hall with ornate chandeliers and cabinets filled with ancient books; it’s here we’d have a luxurious French breakfast each morning. The hall opens up onto a gravel courtyard and faces the old mansion; Daniel Korber, the owners’ son gives each guest a tour of this impeccable building where his parents still live.
 
 The rooms themselves are off to the left, not in the main building, but in a more recently built annex. They are modern but classically appointed. Antique sculptures and oil paintings decorate the room, there’s a desk with a lock and key — and hidden compartments, and an old style wardrobe. When you open the curtains and heavy shutters the window looks down on the courtyard. It’s delightfully French. With a charismatic owner and a fabulous homemade French breakfast, it was perfect for Sam.
 
-{% figure france-bordeaux-slr-025.jpg landscape %}Our room at Petit Hôtel Labottière{% endfigure %}
+{% figure france-bordeaux-slr-025.jpg landscape %}
+Our room at Petit Hôtel Labottière
+{% endfigure %}
 
 When we arrived Lea greeted us, she’d look after us throughout our time here (and would make our lovely breakfasts) — about our age we got on with her very well. While we waited for Daniel we sat in the courtyard with some cold beer, the sun blazing down on this peculiarly hot autumn afternoon. While we’re in the courtyard, let’s wax lyrical about the breakfast.
 
 On Sunday morning at 9am it was warm enough to sit outside. Our petit déjeuner consisted of fresh French baguette and croissants; two types of paté (duck and fish), smoked salmon, jams, chorizo, a selection of cheese, omelette, two [canelé](http://en.wikipedia.org/wiki/Canel%C3%A9) — Bordeaux’s pastry speciality, a delicious raspberry tart, fresh fruit, chocolate and “grandma’s cream” — an old family recipe that Daniel’s grandmother would make for him as a treat. It was all served on beautiful crockery and silver platters. We had coffee and hot chocolate to wash it all down. Daniel joked, “You must eat it all. You can’t visit Bordeaux and be half starved”. Every part of breakfast was delicious, and we gorged ourselves on this feast every morning; some bits changed — the salmon swapped for sausages, or the raspberry tart for a pear one; everything tasted divine.
 
-{% figure france-bordeaux-007.jpg landscape %}Breakfast in the garden{% endfigure %}
+{% figure france-bordeaux-007.jpg landscape %}
+Breakfast in the garden
+{% endfigure %}
 
 Anyhow, back to Saturday, and Daniel met us in the courtyard. He gave us some guides and pointed out places to eat and drink, places to see and places to avoid as they’re “too touristy”. Lea showed us to our room, we rested on the double-mattress double bed and then set off out to enjoy our first evening in Bordeaux.
 
@@ -94,21 +100,29 @@ Continuing our stroll into town; Bordeaux’s old town is small and easily explo
 
 Keep walking along the river and you reach the picturesque postcard view of Bordeaux; [Place de la Bourse](http://en.wikipedia.org/wiki/Place_de_la_Bourse) reflected perfectly in [Miroir d’eau](http://en.wikipedia.org/wiki/Miroir_d'eau), the world’s largest reflecting pool. We arrived at 6pm, and the sun was dipping perfectly between the streets casting long shadows on the “mirror”. Hundreds of kids were playing in the water; the square fills up and the children splash about and parents walk through in flip-flops. A dance troupe brought out some chairs and begun an avant-garde routine, miming to each other with short sharp dances. The square then drains itself of water, the large granite tiles are left with a thin glistening layer of water on top, creating a magical reflection. It stays for ten minutes until the mirror emits a fog which fills the air with an eerie low hanging cloud. Then the cycle repeats.
 
-{% figure france-bordeaux-003.jpg landscape %}Panorama of Miroir d’eau{% endfigure %}
+{% figure france-bordeaux-003.jpg landscape %}
+Panorama of Miroir d’eau
+{% endfigure %}
 
-{% figure france-bordeaux-slr-023.jpg landscape %}Dance act on Miroir d’eau{% endfigure %}
+{% figure france-bordeaux-slr-023.jpg landscape %}
+Dance act on Miroir d’eau
+{% endfigure %}
 
 The French eat late, and our dinner reservation was a couple of hours away, if we had one. I’d booked online and had no reply, I called up and was told the restaurant was fully booked, only to receive an email shortly after confirming my reservation. It was also booked at 7:30pm, when the restaurant is closed until 8. It was of course fine. But while we waited we meandered about the city’s thin streets, snacking on the smallest of pain au chocolat as we were famished (we’d had no lunch). Outside Bordeaux’s opera house we people watched until it was time to eat.
 
 ## Le Gabriel Restaurant
 
-{% figure france-bordeaux-slr-022.jpg landscape %}Le Gabriel Restaurant{% endfigure %}
+{% figure france-bordeaux-slr-022.jpg landscape %}
+Le Gabriel Restaurant
+{% endfigure %}
 
 For tonight’s dinner we’d begin the first of Sam’s [Michelin-star](http://www.viamichelin.co.uk/web/Restaurant/Bordeaux-33000-Le_Gabriel-257611-41102) birthday treats; a meal at [Le Gabriel](http://restaurant.bordeaux-gabriel.fr/). The building sits right in the centre of Place de la Bourse, looking out at Miroir d’eau and the Garonne river. Confusingly there’s a downstairs bistro with the same name, and many [Trip Advisor reviews](http://www.tripadvisor.co.uk/Restaurant_Review-g187079-d1538814-Reviews-Le_Gabriel-Bordeaux_Gironde_Aquitaine.html) get the two mixed up. The Michelin guide in its brilliant understated-ness says:
 
 > An exceptional setting depicts this establishment in the central pavilion of the famous Place de la Bourse facing the water mirror. Its delightful 18C sitting rooms are perfect suited to the creative, flavoursome cuisine. Look forward to a very special moment.
 
-{% figure france-bordeaux-006.jpg landscape %}Le Gabriel Restaurant decor{% endfigure %}
+{% figure france-bordeaux-006.jpg landscape %}
+Le Gabriel Restaurant decor
+{% endfigure %}
 
 On the second floor a soirée of waiters greeted us, “Bonsoir”; they led us around the corner into a whitewashed room with white tables, white linen and white seats. On the walls were two pieces of modern art; abstract and not usually our thing, they fascinated us throughout our meal. We chose the 7 course “Menu découverte”:
 
@@ -130,9 +144,13 @@ Our waiter was Romain, his English was excellent and with each course he’d del
 * A bottle of “G, Chateau Guiraud” from Bordeaux (a crisp and very different Sauvignon and Sémillon blend)
 {% endmenu%}
 
-{% figure france-bordeaux-004.jpg landscape %}Langoustine with beetroot and rhubarb{% endfigure %}
+{% figure france-bordeaux-004.jpg landscape %}
+Langoustine with beetroot and rhubarb
+{% endfigure %}
 
-{% figure france-bordeaux-005.jpg landscape %}Lightly smoked lamb with truffle{% endfigure %}
+{% figure france-bordeaux-005.jpg landscape %}
+Lightly smoked lamb with truffle
+{% endfigure %}
 
 This meal is up there with the best meal we’ve ever eaten, which was at [The Burlington in 2012](/2012/04/a-weekend-in-harrogate/2/#The_Burlington,_our_first_Michelin_star). The fresh uncooked mackerel with an explosion of citrus caviar was superlative, and the following foie-gras and ginger was guiltily fabulous; these were the best two courses and they were perfect.
 

--- a/source/_posts/bordeaux-france/2.md
+++ b/source/_posts/bordeaux-france/2.md
@@ -7,35 +7,53 @@ pages: 4
 
 After our amazing homemade breakfast in the courtyard of our hotel, we set about exploring Bordeaux proper. We left via the public gardens again, which were looking beautiful in the early morning autumn sun; leaves golden, grass green. I juggled with some of the freshly fallen brown conkers, and Sam photographed the barnacle geese at the edge of the pond.
 
-{% figure france-bordeaux-009.jpg portrait %}Samantha at breakfast{% endfigure %}
+{% figure france-bordeaux-009.jpg portrait %}
+Samantha at breakfast
+{% endfigure %}
 
 ## Chartrons market
 
 From the park we strolled down Rue Ferrere, along the centre of a boulevard lined with horse-chestnut trees, leaves crunched beneath our feet. This brought us out onto Quai des Chartrons, which has a market every Sunday morning. From packed stalls there were the local speciality, [canelé](http://en.wikipedia.org/wiki/Canel%C3%A9), fresh seafood — crabs, mussels, fish, large langoustine, squid, cuttlefish and even sea anemones. And of course there were stands dedicated to Arcachon’s famous oysters. Fresh fruit and veg stalls had the European usuals, and the cheese stalls were a wonder; with several varieties of the creamy Comte we loved last night. We even found a stall selling Chinese pu-er tea and Sichuan pepper. Of course the biggest problem we had exploring this market was that we’d just eaten the most enormous breakfast, we were stuffed and couldn’t eat another thing. We hung about until we got hungry.
 
-{% figure france-bordeaux-slr-017.jpg landscape %}Fromage{% endfigure %}
+{% figure france-bordeaux-slr-017.jpg landscape %}
+Fromage
+{% endfigure %}
 
-{% figure france-bordeaux-slr-018.jpg landscape %}French market vendor{% endfigure %}
+{% figure france-bordeaux-slr-018.jpg landscape %}
+French market vendor
+{% endfigure %}
 
-{% figure france-bordeaux-slr-019.jpg landscape %}Canele stall at Chartrons market{% endfigure %}
+{% figure france-bordeaux-slr-019.jpg landscape %}
+Canele stall at Chartrons market
+{% endfigure %}
 
-{% figure france-bordeaux-slr-021.jpg landscape %}Crabs for sale at the market{% endfigure %}
+{% figure france-bordeaux-slr-021.jpg landscape %}
+Crabs for sale at the market
+{% endfigure %}
 
 Approaching midday, and the sun was hot; in late October it was too hot to stay out in the sunshine and we kept to the shade of the stalls. We bought ourselves fresh fruit smoothies, some spiced fried potatoes, a lamb and pepper kebab and some aubergine. Meanwhile French locals walked by in blue and white striped tops and a man played classic tunes on an accordion. By mid-afternoon the stalls were shutting, and we wandered off in search of Bordeaux’s cathedrals.
 
-{% figure france-bordeaux-slr-016.jpg landscape %}Lunch from the market{% endfigure %}
+{% figure france-bordeaux-slr-016.jpg landscape %}
+Lunch from the market
+{% endfigure %}
 
 ## Exploring Bordeaux
 
 In Chartrons we stumbled on Eglise St Louis des Chartrons, a church with a beautiful façade on a street that reminded me of Brighton. And from here he continued south, returning to the river to see the water mirror once again, and to make the most of the sunshine. In the old quarter we hopped between the ancient streets, discovering that on a Sunday in France everything is shut. All but a few open-air tourist restaurants were closed, and those expensive eateries outside were where the French liked to smoke; e-cigarettes and smoking bans have yet to catch on. To our misfortune, Cathédrale Saint-André was also closed, a ticket-only concert was about to begin. We walked slowly back to our hotel via Place Gambetta, where buskers were playing jazz, and then a side road from where we stumbled on the Roman ruins of Rue de Colisée. At the end of a residential street stands a great stone arch, the heart of, and all that remains of, the Palais Gallien amphitheatre, destroyed by the Bordeaux authorities in 1793.
 
-{% figure france-bordeaux-slr-015.jpg landscape %}A Jaguar in the heart of old town Bordeaux{% endfigure %}
+{% figure france-bordeaux-slr-015.jpg landscape %}
+A Jaguar in the heart of old town Bordeaux
+{% endfigure %}
 
-{% figure france-bordeaux-slr-013.jpg portrait %}The old streets of Bordeaux{% endfigure %}
+{% figure france-bordeaux-slr-013.jpg portrait %}
+The old streets of Bordeaux
+{% endfigure %}
 
 In Jardin Public we watched the evening come, with cheap wine and beer from the garden’s Orangerie, and then, as the sun passed low between the trees, we watched from the grass, waiting until the park was about to close before we left.
 
-{% figure france-bordeaux-011.jpg landscape %}Le Jardin Public at sunset{% endfigure %}
+{% figure france-bordeaux-011.jpg landscape %}
+Le Jardin Public at sunset
+{% endfigure %}
 
 ## Steak and french fries at L’Entrecôte
 
@@ -43,7 +61,9 @@ After a quick rest in the hotel room we headed back out to find dinner. Tonight 
 
 We thought on a Sunday evening we might be lucky. It’s one of the few places open, but with it being a Sunday the queues would be shorter. We were right, and when we arrived we were immediately seated on the second floor; the place was rammed, and the tables are so packed in that to sit down our waitress needed to pull out the table for me to slide in. Our seats not yet warm, we’d ordered two medium steaks (for medium in France is rare, red and bloody) and a bottle of red.
 
-{% figure france-bordeaux-012.jpg landscape %}Steak and french fries{% endfigure %}
+{% figure france-bordeaux-012.jpg landscape %}
+Steak and french fries
+{% endfigure %}
 
 It is the complete opposite of a Michelin meal, and that was just fine. The service is ruthlessly efficient and fast, and we marvelled at its factory-like operation. After our walnut salad entree, the steak arrived amidst a piled heap of french fries. The pink steak in its standard mustard sauce tasted great, and the fries smothered in the steak fat were salty and yum. We left room for their profiteroles too.
 

--- a/source/_posts/bordeaux-france/3.md
+++ b/source/_posts/bordeaux-france/3.md
@@ -7,17 +7,23 @@ pages: 4
 
 ## A day trip to Saint-Émilion
 
-{% figure france-bordeaux-slr-009.jpg landscape %}Saint-Émilion{% endfigure %}
+{% figure france-bordeaux-slr-009.jpg landscape %}
+Saint-Émilion
+{% endfigure %}
 
 Today was Sam’s actual birthday. And after another sublime French breakfast, this time in the dining hall, we returned to our room to open some presents. On this special day we had plans for a day trip, we were heading East to [Saint-Émilion](http://en.wikipedia.org/wiki/Saint-%C3%89milion), a quintessential French vineyard town, where wine has been made since the 4th century.
 
-{% figure france-bordeaux-slr-012.jpg portrait %}Samantha on her 30th birthday{% endfigure %}
+{% figure france-bordeaux-slr-012.jpg portrait %}
+Samantha on her 30th birthday
+{% endfigure %}
 
 On Rue Fondaudège we bought a baguette and some sliced saucisson, to go with some chocolate and fruit. There’s a lovely fromagerie here too, but at 11am on a Monday it’s closed; it seems Sunday trading extends into Monday morning. No worries we thought, a vineyard town in France is bound to have its own cheese shop. We walked down to Quinconces, hopped on the tram to Gare Saint-Jean and tried to buy our tickets. But all ticket machines were offline, and no-one in the station could sell us anything, “our systems are down”, we were told. We were given a voucher to use onboard instead. With some time to kill, we sat outside in the sunshine with some coffee at Café Brasserie Le Terminus.
 
 The train was an old diesel one, decades old it was roomy and comfortable, and oozed more character than a rickety old London train ever could. The journey to Saint-Émilion took about 40mins and no officer ever came to sell us tickets. There’s no ticket office at Saint-Émilion, and no-one came on the way back, so the trip was free. A little extra present for Samantha. Everyone else on the train was going to Saint-Émilion too.
 
-{% figure france-bordeaux-slr-014.jpg landscape %}Train to Saint-Émilion{% endfigure %}
+{% figure france-bordeaux-slr-014.jpg landscape %}
+Train to Saint-Émilion
+{% endfigure %}
 
 The station, two rail lines and a hut, is a 10 minute walk out of town through recently harvested vineyards with picturesque views out across the Gironde valley. In summer and on weekends this place gets rammed with tourists; but on a peculiarly hot Monday afternoon in October it was just right. The village is perched at the top of a hill, where steep and narrow cobbled streets climb up to ancient romanesque churches. Picnic time, we explored the sandstone labyrinth for a fromagerie; every other building is a _boutique de vin_, separated by the occasional restaurant, gift shop or _macaronerie_. Without luck, we stopped at the tourist office and asked, “where’s the cheese shop?” … “Sir, there is no cheese shop”.
 
@@ -25,17 +31,23 @@ The station, two rail lines and a hut, is a 10 minute walk out of town through r
 
 At the top of the hill behind Église Monolithe we devoured our French picnic, then boarded the incredibly touristy [Great Vineyard Train](http://www.saint-emilion-tourisme.com/uk/3-what-to-do/18-vineyard/71-train-of-the-great-vineyards.html); one of those cheesy electric vehicles made up to look like a train, one of those things. From the top of each carriage a speaker boomed facts about the vineyards we passed, first in French, then just as we’d gone past, in English. It was all wonderfully touristy. The train [does a round trip](https://www.google.com/maps/d/viewer?mid=zgbCVqBc6T7M.k3t78B6i49vk), and takes about half an hour. Some vineyards were older than others, some were better, and evidently there’s much to learn about growing vines and making wine; the details escape us though, we are not connoisseurs; perhaps if we were we wouldn’t be on the train.
 
-{% figure france-bordeaux-slr-011.jpg landscape %}Le Train des Grands Vignobles (The tourist train){% endfigure %}
+{% figure france-bordeaux-slr-011.jpg landscape %}
+Le Train des Grands Vignobles (The tourist train)
+{% endfigure %}
 
 We paid a little extra too, for a tour of [Chateau Rochebelle](http://www.tripadvisor.co.uk/Attraction_Review-g488277-d3258734-Reviews-Chateau_Rochebelle-Saint_Emilion_Gironde_Aquitaine.html). A guide greeted us from the train and showed us underground to their 18th century cellars — formerly a quarry. Barrels lined stone walled halls, and bottled wines from different vintages were stored along narrow corridors. In the dark he explained their process, and why their wine is obviously the best wine, he emphasised its French-ness, and how many surrounding vineyards were American or Chinese owned. In the daylight again, in a little shop, we tried a single glass of young red wine, and avoided the sales pitch.
 
-{% figure france-bordeaux-slr-010.jpg landscape %}Tour of Chateau Rochebelle{% endfigure %}
+{% figure france-bordeaux-slr-010.jpg landscape %}
+Tour of Chateau Rochebelle
+{% endfigure %}
 
 ### Cheese and wine
 
 Back on the train again, we completed our route around the village. Peckish by early afternoon, we sat in Saint-Émilion’s main square at Amelia Canta — the courtyard was bathed in sunshine, and lies beneath the towering steeple of the monolithic church. An English couple next to us were just finishing off a cheese board. Perfect! A single waiter hurriedly rushed about, meeting everyones demands with a smile and a quip. We polished off three cheeses, some bread and half a bottle of red wine (2009, Chateau La Grace Dieu) before continuing our exploration of the town. We had our cheese and wine at last.
 
-{% figure france-bordeaux-slr-008.jpg landscape %}Cheese and wine{% endfigure %}
+{% figure france-bordeaux-slr-008.jpg landscape %}
+Cheese and wine
+{% endfigure %}
 
 ### Église Monolithe
 
@@ -43,11 +55,17 @@ With it being autumn the sun began to dip and the light turned a golden yellow. 
 
 Stopping just short of the spire itself there’s a narrow walkway which lets you squeeze right the way around for fabulous panoramic views in all directions. The vineyards disappear into the hazy horizon whichever way you look. Beneath us were the pastel brown rooftops of the ancient town, the narrow streets now in shadow.
 
-{% figure france-bordeaux-slr-007.jpg landscape %}View of Saint-Émilion from Église Monolithe{% endfigure %}
+{% figure france-bordeaux-slr-007.jpg landscape %}
+View of Saint-Émilion from Église Monolithe
+{% endfigure %}
 
-{% figure france-bordeaux-slr-006.jpg landscape %}Vineyards everywhere{% endfigure %}
+{% figure france-bordeaux-slr-006.jpg landscape %}
+Vineyards everywhere
+{% endfigure %}
 
-{% figure france-bordeaux-slr-005.jpg landscape %}Autumnal French vineyards{% endfigure %}
+{% figure france-bordeaux-slr-005.jpg landscape %}
+Autumnal French vineyards
+{% endfigure %}
 
 The trains were irregular, and we needed to be back in Bordeaux for a restaurant reservation. Back down the tower, through the streets, out of town, past the vineyards, onto the train and back to the UNESCO city we rushed. Our connections were timed perfectly, we stepped off the train and onto a tram and were whisked across the city; we were back at our hotel and freshened up with minutes to spare.
 
@@ -59,7 +77,9 @@ For Michelin star number two, and one of the few high-end restaurants that opens
 
 Less formal than Le Gabriel, the unassuming front door leads through a narrow corridor into a room with tables laid out for two to four people. The building feels like a converted residence, and the room opens up onto a garden. The walls are jasmine white, with orchids on shelves. With the sommelier’s help we ordered a fruity Clos Floridene (2012) white wine.
 
-{% figure france-bordeaux-016.jpg landscape %}Le Pavillon des Boulevards{% endfigure %}
+{% figure france-bordeaux-016.jpg landscape %}
+Le Pavillon des Boulevards
+{% endfigure %}
 
 Once again we ordered the tasting menu. 8 courses this time, _quelques amuse-bouches_. The restaurant was full, most tables seated well dressed couples or families of three. All of us seemed to be having the same tasting menu, and we spied our later courses as the waiters brought them out, brushing aside an obstructing ornamental bamboo tree each time they passed.
 
@@ -81,13 +101,19 @@ Once again we ordered the tasting menu. 8 courses this time, _quelques amuse-bou
 * Coffee
 {% endmenu %}
 
-{% figure france-bordeaux-014.jpg landscape %}Razor clam and scallop{% endfigure %}
+{% figure france-bordeaux-014.jpg landscape %}
+Razor clam and scallop
+{% endfigure %}
 
 The menu is from memory, we misplaced our printed list of exactly what we ate; so many courses, they blur into one fabulous meal. What stood out were the eggs; the opening amuse-bouche, a fake egg shell with real quails egg inside, and to end with the reverse; a real egg shell but containing a fake egg, a white mousse with a yellow centre, above chocolate. Brilliantly quirky symmetry. And everything in-between was sumptuous. From the fish cocktail, presented as a cocktail drink to the melt in the mouth pigeon.
 
-{% figure france-bordeaux-013.jpg landscape %}Tuna fish cocktail{% endfigure %}
+{% figure france-bordeaux-013.jpg landscape %}
+Tuna fish cocktail
+{% endfigure %}
 
-{% figure france-bordeaux-015.jpg landscape %}Pigeon done three ways{% endfigure %}
+{% figure france-bordeaux-015.jpg landscape %}
+Pigeon done three ways
+{% endfigure %}
 
 We stayed until late, finishing our wine and then having coffee. Everything here has a touch of design flair; the sugar for Sam’s coffee came in cubes, each neatly arranged in a grid.
 

--- a/source/_posts/bordeaux-france/4.md
+++ b/source/_posts/bordeaux-france/4.md
@@ -9,13 +9,19 @@ pages: 4
 
 For our final day we had two things planned, a tour of the stately home at Petit Hôtel Labottière, then lunch at Le Chapon Fin, Sam’s third Michelin star of the weekend. Sadly our host, Daniel, was taken ill; Lea was running around trying to do everything herself. She’d prepared us another filling French breakfast which we gorged on in the ornate dining hall.
 
-{% figure france-bordeaux-slr-004.jpg landscape %}Breakfast in the dining hall{% endfigure %}
+{% figure france-bordeaux-slr-004.jpg landscape %}
+Breakfast in the dining hall
+{% endfigure %}
 
 In Daniel’s absence Lea showed us around the stately home where he used to live, and where his parents still do. She apologised that she didn’t have the same architectural knowledge and detailed history of the city as Daniel; but her stories and explanations were plentiful. Each room has been lovingly restored, and the decor is a mix of antique French with Asian influences. Great oil paintings hang from the walls, one shows a monkey feasting on tropical fruits above a Chinese dresser, another is quintessential European — a royal scene by a river. Between paintings sit ornate delicately crafted clocks and mirrors. We were taken aback by a beautiful mirror, in the style of the long portrait paintings of misty Chinese mountains and valleys, this gold framed mirror echoed those sentiments, swirling from a carved house at the bottom to clouds at the top. Enormous crystal chandeliers hang from the ceiling, with multicoloured red and green glass, clearly fashionable and elegant in its day.  All the downstairs rooms are connected to a central hall, the house’s entranceway. It’s from here that a grand staircase goes up, but we aren’t allowed upstairs.
 
-{% figure france-bordeaux-slr-003.jpg landscape %}Interior of Petit Hôtel Labottière{% endfigure %}
+{% figure france-bordeaux-slr-003.jpg landscape %}
+Interior of Petit Hôtel Labottière
+{% endfigure %}
 
-{% figure france-bordeaux-slr-001.jpg landscape %}Stairs to the second floor{% endfigure %}
+{% figure france-bordeaux-slr-001.jpg landscape %}
+Stairs to the second floor
+{% endfigure %}
 
 ## Le Chapon Fin
 
@@ -25,9 +31,13 @@ Our lunchtime reservation was at 1pm, and we hoped that by then we’d have reco
 
 [Le Chapon Fin’s](http://www.chapon-fin.com/) decor is spectacular, you can’t help but gawp. It has an ornate hall that appears partly consumed by a sprawling stone grotto; the cave at the rear ekes out into the building, along the walls and into the ceiling. Well placed mirrors emphasise the effect. Our table for two was nestled in one of these coves, giving us a view of the whole restaurant.
 
-{% figure france-bordeaux-001.jpg landscape %}Le Chapon Fin grotto{% endfigure %}
+{% figure france-bordeaux-001.jpg landscape %}
+Le Chapon Fin grotto
+{% endfigure %}
 
-{% figure france-bordeaux-018.jpg landscape %}Panorama of Le Chapon Fin{% endfigure %}
+{% figure france-bordeaux-018.jpg landscape %}
+Panorama of Le Chapon Fin
+{% endfigure %}
 
 In front of us three stereotypical French businessmen were lunching; a three-piece suited businessman, a man with a 6inch white moustache — waxed and pointed at the ends, and a guy with a toupee; they ended their meal with cigars. To the left another business group, two men were selling something to an important looking lady; a box of papers sat on the floor waiting to be signed — they were special guests too, the chef came to meet them after their food.
 
@@ -45,15 +55,21 @@ Lunchtime is too early for a tasting menu, instead we chose a three course lunch
 
 Our third Michelin star was distinct from our two previous. The flavours and ingredients were more adventurous; smoked popcorn with duck kidney is a once in a lifetime dish. The deconstructed lemon tart was perfect, all in all it was superb.
 
-{% figure france-bordeaux-017.jpg landscape %}Spaghetti courgette, apple sauce, smoked popcorn, sweetened duck kidneys{% endfigure %}
+{% figure france-bordeaux-017.jpg landscape %}
+Spaghetti courgette, apple sauce, smoked popcorn, sweetened duck kidneys
+{% endfigure %}
 
 We asked for a copy of the menu, ie a written version of what we’d just eaten. Our waitress was quite apologetic, she didn’t have that, “but here, why not have this”, she said and passed us the large Le Chapon Fin menu itself. For the rest of the day we walked around with a menu tucked under our arm, too large to fit into our bags, we resigned ourselves to looking like property moguls with an important dossier. Back at home the menu took pride and place amongst all of Samantha’s 30th birthday cards. A fine memento for an exquisite meal.
 
-{% figure france-bordeaux-slr-028.jpg landscape %}Sam and Paul at Le Chapon Fin{% endfigure %}
+{% figure france-bordeaux-slr-028.jpg landscape %}
+Sam and Paul at Le Chapon Fin
+{% endfigure %}
 
 Walking about town for one last time before our evening flight home, we did at last get to visit [Cathédrale Saint-André](http://en.wikipedia.org/wiki/Bordeaux_Cathedral), with its Grand Organ and vaulted ceiling.
 
-{% figure france-bordeaux-slr-027.jpg portrait %}Samantha beneath the Grand Organ, with her menu{% endfigure %}
+{% figure france-bordeaux-slr-027.jpg portrait %}
+Samantha beneath the Grand Organ, with her menu
+{% endfigure %}
 
 ## A final picnic
 
@@ -63,4 +79,6 @@ We no longer had a key to our hotel, so while we waited for Lea to arrive at our
 
 We took the last flight out of Bordeaux that night, then drove home to Brighton, where Sam would have all her presents and cards waiting for her.
 
-{% figure france-bordeaux-slr-026.jpg landscape %}Goodbye Bordeaux{% endfigure %}
+{% figure france-bordeaux-slr-026.jpg landscape %}
+Goodbye Bordeaux
+{% endfigure %}

--- a/source/_posts/borneo-rainforest-lodge/2.md
+++ b/source/_posts/borneo-rainforest-lodge/2.md
@@ -9,57 +9,89 @@ pages: 5
 
 Borneo rainforest lodge has a spectacular canopy walk, 300m in length, 26m high at its tallest point. The swinging bridges are tied to great menogaris trees. Their trunks feel like concrete. At 6:30am, to the songs of gibbons, we headed there. Shortly after sunrise the forest is eery and misty and clouds dangle in the treetops, waiting for the sun to set them free. The red and green bridges swung as we walked across, resonating with our footsteps, unsteady but secure. The handrails feel precariously low in the middle, and Samantha braved her vertigo, going last and stepping slowly. We crossed to the end and back again. Our only spotting was a small blue bird, possibly a rufous winged philentoma. On the road back we passed some birders, a telescope was setup in the road, and we narrowly missed seeing the rare Bornean bristlehead through a scope, instead it flew overhead and out of sight. Though we did see two large bushy-crested hornbills, some land crabs and a large black-feathered bird with red under its wing, but I haven’t a clue what it was.
 
-{% figure borneo-015.jpg portrait %}The rainforest lodge canopy walk{% endfigure %}
+{% figure borneo-015.jpg portrait %}
+The rainforest lodge canopy walk
+{% endfigure %}
 
-{% figure borneo-016.jpg portrait %}Samantha, from the top of the canopy{% endfigure %}
+{% figure borneo-016.jpg portrait %}
+Samantha, from the top of the canopy
+{% endfigure %}
 
-{% figure borneo-iphone-026.jpg landscape %}Paul and Samantha on the canopy walkway{% endfigure %}
+{% figure borneo-iphone-026.jpg landscape %}
+Paul and Samantha on the canopy walkway
+{% endfigure %}
 
-{% figure borneo-017.jpg landscape %}The troupe{% endfigure %}
+{% figure borneo-017.jpg landscape %}
+The troupe
+{% endfigure %}
 
 ## Coffincliff trail
 
 The 8am breakfast felt like lunch, especially when you’re eating fried rice and noodles (a habit I’d like to continue in London if anywhere sold that sort of thing so early). By 10 we were off out again on the longest of our treks, the ominous sounding Coffincliff trail, still only 3km but mostly up. “My friends are waiting for us”, Faezen said, pointing at the leeches dangling from the trail signpost. “They detect your heat”, he demonstrated by waving his hand underneath, the thin tip of the leech swaying to and fro as his palm went by. Ahead of us a group of pig-tailed macaques crossed, “That’s Judas and his family”, Faezen warned us to keep our distance, “they’re dangerous and may attack, don’t stare at them”. Wildlife spottings were otherwise sparse, mostly millipedes and strange fungi, with the occasional pygmy or black squirrel. We did pick up on the scent of monkey piss at one point, “either someone has a really bad UTI or there’s a monkey about”, Ed, a medic, noted. Half-way we came to the coffincliff, a vertical wall where tribes buried their dead in ironwood coffins, human bones still littered the area — dislodged from their resting place by monkeys, sunbears and the like.
 
-{% figure borneo-019.jpg portrait %}A leech in waiting{% endfigure %}
+{% figure borneo-019.jpg portrait %}
+A leech in waiting
+{% endfigure %}
 
-{% figure borneo-iphone-028.jpg portrait %}Samantha in full jungle trekking gear{% endfigure %}
+{% figure borneo-iphone-028.jpg portrait %}
+Samantha in full jungle trekking gear
+{% endfigure %}
 
-{% figure borneo-iphone-029.jpg portrait %}Paul, in a white shirt in the jungle{% endfigure %}
+{% figure borneo-iphone-029.jpg portrait %}
+Paul, in a white shirt in the jungle
+{% endfigure %}
 
 ## Jacuzzi pool
 
 Beyond the cliff we climbed to a viewpoint which overlooked the lodge and hill after hill of million year old virgin rainforest. When it’s gone, it’s gone I thought in a brief but sombre moment, how much longer will it last? We continued on to the fairy waterfall, another 10 minutes down a steep hill, and then all the way back to a jacuzzi pool. By jacuzzi pool they meant a natural pond with waterfall and hungry fish (and no leeches, at least not in the water). “In the Amazon the piranha take flesh and bone, here they just nibble”, that’s how it was sold to us, they weren’t Piranhas (they were Perulean fish), but they did give a good pedicure, nibbling at the dead skin on our feet (and elsewhere if you got in deeper and didn’t move).
 
-{% figure borneo-iphone-031.jpg landscape %}No signs of civilisation, rainforest in every direction{% endfigure %}
+{% figure borneo-iphone-031.jpg landscape %}
+No signs of civilisation, rainforest in every direction
+{% endfigure %}
 
 As per usual in the rainforest the sweltering hot sun gave way to dark clouds and rumbles of thunder. And just as everyone came out of the pool, to dry off, the heavens opened once more. We all crammed under what little cover there was in the wooden changing rooms, protecting our bags whilst changing out of swimwear. In the dripping wet we clambered back to the lodge, thankful to have both wet weather gear and an umbrella.
 
 Between activities, and as the rain fell, I reclined out on our chalet’s veranda watching the river and the few birds that flitted about between the raindrops. A little spider-eater fed from wild ginger and banana flowers, and a small lizard scuttled up a tree. Despite the storm it was peaceful, the sound of rain patting leaves was calming.
 
-{% figure borneo-023.jpg landscape %}The rain{% endfigure %}
+{% figure borneo-023.jpg landscape %}
+The rain
+{% endfigure %}
 
-{% figure borneo-025.jpg portrait %}[Little spiderhunter](http://www.projectnoah.org/spottings/233026068 "Project Noah") feeding on a wild ginger flower{% endfigure %}
+{% figure borneo-025.jpg portrait %}
+[Little spiderhunter](http://www.projectnoah.org/spottings/233026068 "Project Noah") feeding on a wild ginger flower
+{% endfigure %}
 
 ## Tubing and the Hornbill trail
 
 In the afternoon the group split between two activities; Sam, Jamie and Darren went tubing down the river while Ed, Faezen and I did another short walk through the forest. The tubing was apparently great fun, in swimwear and flip-flops they left with huge inflated rubber rings. The river took them downstream where they saw red leaf monkeys and Sam had a special encounter with two playful yet enormous moths; possibly an atlas moth and a moon moth. But beauty is fleeting and in the river she didn’t have a camera. Still, the guides with her were jealous. At the shallow points they hoisted the tube to their waste and walked downstream, the river not really deep enough at low tide. Ed and I followed the Hornbill trail again, from the river view point we saw the same red leaf monkeys. We walked for about an hour with our guide, periodically checking socks and boots for intrepid leeches. In a leafless dead tree the black ruffled feathers of a crested eagle were unmissable. Down by the river, where we expected to meet the others, the pig-tailed macaques were back. Judas watched as a group of 12 or so ate, groomed and played on the riverbank before climbing away in the trees.
 
-{% figure borneo-027.jpg portrait %}Crested eagle{% endfigure %}
+{% figure borneo-027.jpg portrait %}
+Crested eagle
+{% endfigure %}
 
 ## Night trek
 
 The rain continued until nightfall, and we waited it out in our river-view outdoor bath. It stopped just as our night time trek began. Armed with torches, some good, some pathetic, we ventured into the night in search of the nocturnal. We furiously shone light up and down tree trunks, into dark crevices, into the foliage; hoping to catch a glimpse of something, maybe two bright eyes reflecting back at us. But like before, dripping water and moving leaves thwarted us. At the frog-pond we located the croak sounds of a five-horned frog and stumbled on a scary palm sized huntsman spider above our heads. Near the staff quarters we found a brown wood owl and a family of grazing sambar deer. Faezen pointed to a tree with his torch, “look here, in the hole”, a female tarantula with babies. They all sat perfectly still, waiting for their meal to wander by.
 
-{% figure borneo-030.jpg landscape %}Five-horned frog hiding beneath us{% endfigure %}
+{% figure borneo-030.jpg landscape %}
+Five-horned frog hiding beneath us
+{% endfigure %}
 
-{% figure borneo-031.jpg landscape %}Huntsman spider above our heads{% endfigure %}
+{% figure borneo-031.jpg landscape %}
+Huntsman spider above our heads
+{% endfigure %}
 
-{% figure borneo-033.jpg landscape %}Brown wood owl{% endfigure %}
+{% figure borneo-033.jpg landscape %}
+Brown wood owl
+{% endfigure %}
 
-{% figure borneo-034.jpg landscape %}Sambar deer and calf{% endfigure %}
+{% figure borneo-034.jpg landscape %}
+Sambar deer and calf
+{% endfigure %}
 
-{% figure borneo-035.jpg landscape %}Tarantula, nest, and young{% endfigure %}
+{% figure borneo-035.jpg landscape %}
+Tarantula, nest, and young
+{% endfigure %}
 
 ## Cocktails and rhino-beetles
 

--- a/source/_posts/borneo-rainforest-lodge/3.md
+++ b/source/_posts/borneo-rainforest-lodge/3.md
@@ -9,9 +9,13 @@ pages: 5
 
 Our first trek wasn’t until 8:30am, but Sam awoke before dawn and went out for a quiet walk on her own. She was on the lookout for gibbons, but this morning they were shy, not even singing their howling chorus. Nevertheless, Sam enjoyed her meander about the riverside, lodge and nature trail. A mouse-deer ran by, too fast for her to snap a good photo, and many birds (and birders) were about, searching for their morning meals.
 
-{% figure borneo-039.jpg landscape %}Pink flower near the lodge{% endfigure %}
+{% figure borneo-039.jpg landscape %}
+Pink flower near the lodge
+{% endfigure %}
 
-{% figure borneo-041.jpg portrait %}[Whiskered treeswift](http://www.projectnoah.org/spottings/232956086 "Project Noah"){% endfigure %}
+{% figure borneo-041.jpg portrait %}
+[Whiskered treeswift](http://www.projectnoah.org/spottings/232956086 "Project Noah")
+{% endfigure %}
 
 ## Orangutan
 
@@ -19,9 +23,13 @@ Six of us plus Faezen set out one last time together for a short morning trek al
 
 With the orangutans heading out of sight, Faezen, and now another guide too, led us off-trail into the dense jungle itself, heading after them. We quietly, and ever-so carefully, trampled through the trees and vines towards the tree they’d stopped in. Finding angles to view the treetop was difficult, we squatted on the floor, or leaned precariously, and moved our heads about to and fro, looking for line of sight to the wonderful wild apes. And there they were, sitting quietly in the treetop, eating, relaxing, grooming, two of them. I lined up the camera, full zoom at 200mm, hand-held, manual focus, and delicately began snapping, but that elusive profile shot of an orangutan looking right at us evaded me. Either leaves covered my view, or they looked away, nonetheless it was magical just to have the opportunity. We were motionless and transfixed for almost 20 minutes, whatever creepy crawlies were clambering on us from the close proximity leaves, they were irrelevant. In that moment we watched the orangutans, and nothing else mattered. It was incredible.
 
-{% figure borneo-046.jpg landscape %}Two wild orangutan in Danum valley{% endfigure %}
+{% figure borneo-046.jpg landscape %}
+Two wild orangutan in Danum valley
+{% endfigure %}
 
-{% figure borneo-045.jpg portrait 620 %}Wild orang-utan amongst the foliage{% endfigure %}
+{% figure borneo-045.jpg portrait 620 %}
+Wild orang-utan amongst the foliage
+{% endfigure %}
 
 When we did decide to leave, our guide pointed out, “This is leech paradise, watch out for the baby ones”. And, as expected, we all had leeches somewhere on us. The babies were so tiny, it’s hard to imagine how’d you’d ever stop them from getting through the gaps in your clothes. Miraculously Sam and I were bite free. Sam stayed the longest, and from the trail, even though I knew she was there and not far away, and wearing bright clothes, I couldn’t see her. The plants obscured all view of her. When she did materialise, I’ll always remember that smile, an ear-to-ear grin. Yes, those last 20 minutes were a little bit special.
 
@@ -33,9 +41,13 @@ On the lodge veranda we all shared one last meal together, swapping emails and d
 
 In the late afternoon we began the long Segama trail which crosses the river and continues alongside its bank before crossing back and joining the Ginger trail, which in turn ends at the canopy walkway. About 4hrs of hiking in total. The smells of barritonia filled the air again; a fragrant jungle. Either brave or foolish, I set out in a t-shirt this time — without signs of rain, and with a lower humidity this was probably the most pleasant of conditions (ultimately my arms were bitten by a peculiar jungle bug that left an itching mark which frustrated me all the way home). Scattered on the floor were “fake coconut seeds”, a large kernel with two silky white wings, they float down from trees like butterflies. I saved one and threw it from the canopy bridge to watch it fly.
 
-{% figure borneo-067.jpg portrait %}Crossing a high bridge, jungle trekking in a t-shirt{% endfigure %}
+{% figure borneo-067.jpg portrait %}
+Crossing a high bridge, jungle trekking in a t-shirt
+{% endfigure %}
 
-{% figure borneo-065.jpg portrait %}Samantha beneath a giant strangling fig{% endfigure %}
+{% figure borneo-065.jpg portrait %}
+Samantha beneath a giant strangling fig
+{% endfigure %}
 
 We came across red leaf monkeys again, more millipedes (though no giants), great strangling fig trees and odd fungi. We heard the calls of hornbills. With clear skies above us and the sun setting there was a lovely blue light filling the forest, which gave way to the colours of dusk. The cicadas stopped, and on time, as if scheduled, the calls of leafhoppers begun, like an alarm siren they droned incessantly. A wake-up call for the nocturnal. Near our path was another new noise, a beeping, not unlike the regular chirps of sonar; it was a little litter frog hiding in a branch.
 
@@ -45,4 +57,6 @@ By sundown we were at the canopy walk. Faezen pointed out two flying squirrel ne
 
 It then became a night trail, and as we followed the road back to the lodge we used our torches to search for creatures. In a tree we spotted another tarantula, and a timid mouse deer hid amongst the bushes. But despite tonight’s perfect conditions we were relatively unlucky, the tarsiers and loris remained out of sight. It was World Earth Day, so between 8pm and 9pm all the lights were out at the lodge. It meant we were eating our last dinner here by candlelight. Ordinarily that’s romantic, but light attracts bugs, lots and lots of them, so too does food. It was awkward at best. We finished up quickly and called it a night.
 
-{% figure borneo-068.jpg landscape %}Frog found on our quiet night trail{% endfigure %}
+{% figure borneo-068.jpg landscape %}
+Frog found on our quiet night trail
+{% endfigure %}

--- a/source/_posts/borneo-rainforest-lodge/4.md
+++ b/source/_posts/borneo-rainforest-lodge/4.md
@@ -11,19 +11,29 @@ I don’t know how she did it, but Sam convinced me to get up before 6am on our 
 
 Alone we walked the nature trail and then the canopy walk. We were the first to cross the bridge where beautiful dew-drop spider webs spanned our path, we left them intact where we could. Rather crazily I balanced the camera on a slim wooden ledge, focused, set a timer and ran to join Samantha for some photos of the both of us, something we usually forget to do.
 
-{% figure borneo-072.jpg landscape %}Spider's web across the canopy trail{% endfigure %}
+{% figure borneo-072.jpg landscape %}
+Spider's web across the canopy trail
+{% endfigure %}
 
-{% figure borneo-073.jpg portrait %}The morning jungle mist in Danum valley{% endfigure %}
+{% figure borneo-073.jpg portrait %}
+The morning jungle mist in Danum valley
+{% endfigure %}
 
-{% figure borneo-074.jpg landscape %}Samantha and Paul on the canopy walk{% endfigure %}
+{% figure borneo-074.jpg landscape %}
+Samantha and Paul on the canopy walk
+{% endfigure %}
 
-{% figure borneo-083.jpg portrait %}The jungle is big{% endfigure %}
+{% figure borneo-083.jpg portrait %}
+The jungle is big
+{% endfigure %}
 
 ## Selamba trail
 
 After breakfast we met Faezen again. He showed us a butler moth that had died in his room. This morning’s trail, our last, was the Selamba trail, followed by a part of the Hornbill trail. For the last time we set-off from the lodge, headed past the staff quarters and along the riverbank. Two new villas were being built, ready for April and an opening ceremony, the Malaysian Prime Minister was coming too. On the trail Faezen explained how tribes made blow pipes from ironwood (a branch is placed upright in a waterfall, which erodes away the fleshy inner part to create a tube, it only takes 6 months). On the floor were “fake durian”, black rotten husks that don’t contain any fruit (and didn’t smell).
 
-{% figure borneo-090.jpg landscape %}From the selamba trail to the hornbill trail{% endfigure %}
+{% figure borneo-090.jpg landscape %}
+From the selamba trail to the hornbill trail
+{% endfigure %}
 
 ## The Great Argus
 
@@ -31,15 +41,23 @@ Emerging from the Selamba trail, Faezen spoke on his walkie-talkie and marched u
 
 <figure class="generated-figure generated-figure--retina generated-figure--620 generated-figure--video"><div class="video-wrapper"><iframe class="vimeo" src="http://player.vimeo.com/video/95799833" width="620" height="413" frameborder="0"></iframe></div><figcaption class="generated-figure-caption">Video of The Great Argus</figcaption></figure>
 
-{% figure borneo-101.jpg landscape %}A wild [Great Argus](http://www.projectnoah.org/spottings/232956084 "Project Noah") in Danum valley, we watched him for 40 minutes{% endfigure %}
+{% figure borneo-101.jpg landscape %}
+A wild [Great Argus](http://www.projectnoah.org/spottings/232956084 "Project Noah") in Danum valley, we watched him for 40 minutes
+{% endfigure %}
 
-{% figure borneo-096.jpg landscape %}The Great Argus, waiting for a female before he dances{% endfigure %}
+{% figure borneo-096.jpg landscape %}
+The Great Argus, waiting for a female before he dances
+{% endfigure %}
 
-{% figure borneo-103.jpg landscape %}Yes, you rang?{% endfigure %}
+{% figure borneo-103.jpg landscape %}
+Yes, you rang?
+{% endfigure %}
 
 Eventually we had to leave, but on the way out we had another surprise. On the forest floor a tiny blue and red bird moved about, this too was a rare bird, endemic to Borneo it was a blue-headed pita. And once again we were lucky to see it, and then it was gone, our last wildlife spotting at the Borneo Rainforest Lodge. What a way to end the trip.
 
-{% figure borneo-106.jpg landscape %}A rare blue-headed pita{% endfigure %}
+{% figure borneo-106.jpg landscape %}
+A rare blue-headed pita
+{% endfigure %}
 
 ## Concrete jungle
 

--- a/source/_posts/borneo-rainforest-lodge/5.md
+++ b/source/_posts/borneo-rainforest-lodge/5.md
@@ -9,7 +9,9 @@ pages: 5
 
 Our return to Kuala Lumpur was brief, a one night stay at the funky and swanky Aloft Hotel. We split up the flights and road travel from Borneo with our international flights to give us a chance to recover. Of course, we chose somewhere with a gorgeous rooftop infinity pool and for our six waking hours in KL we spent most of it by the pool drinking caipirinhas and mojitos. At the hotel’s Nook restaurant we had our last taste of Malaysia; it was suitably decked out in lime green to fit in with our holiday theme.
 
-{% figure borneo-iphone-039.jpg landscape %}Chilling out at Aloft hotel{% endfigure %}
+{% figure borneo-iphone-039.jpg landscape %}
+Chilling out at Aloft hotel
+{% endfigure %}
 
 Getting to the airport from Aloft is effortless, at KL Sentral there’s an express train direct to the terminal. Ingeniously it has a desk for you to check-in your bags and get your boarding tickets, right from the train station. Our heavy rucksacks were whisked away out of sight, presumably packed onto the train, and delivered straight to our flight. Amazing.
 
@@ -17,4 +19,6 @@ Getting to the airport from Aloft is effortless, at KL Sentral there’s an expr
 
 From KL we flew to Dubai in an Airbus A380 — the double-decker plane. Then on to Gatwick and Brighton. 24 hours later we were in bed, sleeping off our jet lag, our incredible Borneo adventure was over. From the dizzying heights of the Petronas Towers, to the humid Sarawakan rainforests, to the decadent luxury of a Shangri-la, and finally to Danum valley’s incredible jungle wilderness; Malaysia, Borneo — you are sublime.
 
-{% figure borneo-iphone-044.jpg landscape %}Goodbye Borneo{% endfigure %}
+{% figure borneo-iphone-044.jpg landscape %}
+Goodbye Borneo
+{% endfigure %}

--- a/source/_posts/brighton-parade-and-beachy-head.md
+++ b/source/_posts/brighton-parade-and-beachy-head.md
@@ -11,7 +11,9 @@ date: 2010-08-09 18:39:15
 
 With mum visiting for the weekend, it was another excuse to explore Brighton’s lanes and this weekend only, watch the pride parade as it passed through the town centre. Then on Sunday we travelled East to see the cliffs at Beachy Head.
 
-{% figure beachy-head-1.jpg portrait %}Lighthouse at Beachy Head{% endfigure %}
+{% figure beachy-head-1.jpg portrait %}
+Lighthouse at Beachy Head
+{% endfigure %}
 
 Up and out early (for a Saturday at least), we meandered through the North Laine, shopping for books and sunglasses, stopping for some cyber candy, passing through the pavilion gardens and halting at the parade to see the LGBT floats go by, one by one, to the tunes of Katy Perry’s “I kissed a girl”, Abba and so on.
 
@@ -25,19 +27,27 @@ On Sunday we took a day trip, east along the south coast. Down the A27, past the
 
 Sitting on benches looking out across the bay, we dined on a quickly packed bread, saucisson and cheese picnic (with unwieldy bread knife and an inquisitive jackdaw watching us drop breadcrumbs everywhere).
 
-{% figure beachy-head-4.jpg landscape %}View of Eastbourne from Beachy Head{% endfigure %}
+{% figure beachy-head-4.jpg landscape %}
+View of Eastbourne from Beachy Head
+{% endfigure %}
 
 A small museum showed us how the lighthouse was built, it had gone all out on its exhibits, with buttons that sink ships or make sounds of sea birds.
 
 After the enlightenment of how to build a lighthouse in the sea, we took the path around the steep cliff to see the wonder, peering over the edge and feeling a little vertigo. We were sombre at the markings and tributes to those that had jumped.
 
-{% figure beachy-head-6.jpg portrait %}Samantha and the sea{% endfigure %}
+{% figure beachy-head-6.jpg portrait %}
+Samantha and the sea
+{% endfigure %}
 
 As the sun shone on the sea, it glistened a gorgeous laguna blue, and I marvelled at the tranquillity of the place. It’d be a great place to catch the sunset.
 
-{% figure beachy-head-7.jpg portrait %}View from the cliff edge{% endfigure %}
+{% figure beachy-head-7.jpg portrait %}
+View from the cliff edge
+{% endfigure %}
 
-{% figure beachy-head-8.jpg landscape %}A solitary cloud{% endfigure %}
+{% figure beachy-head-8.jpg landscape %}
+A solitary cloud
+{% endfigure %}
 
 At the busy pub we fought off wasps (trapping some in glasses) to eat our sugary desserts before heading home, this time going through New Haven, Seaford and via Brighton Marina.
 

--- a/source/_posts/cadaques-spain.md
+++ b/source/_posts/cadaques-spain.md
@@ -13,7 +13,9 @@ page: 1
 
 From Brighton Station and the usual decrepit First Capital Connect trains, then Gatwick Airport and proficient EasyJet flight to Barcelona, then taxi to Estacio del Nord, and a 2h45 Sarfa bus north, through winding pyrenean roads, down to the coastal town of Cadaqués.
 
-{% figure spain-cadaques-barcelona-21.jpg landscape %}Cadaqués{% endfigure %}
+{% figure spain-cadaques-barcelona-21.jpg landscape %}
+Cadaqués
+{% endfigure %}
 
 Cadaques just oozes serenity, waves wash against small beaches and coves, scooters whiz along the one-way beach roads whilst golden brown Spaniards light up and coolly puff their smoke into the air.
 
@@ -21,7 +23,9 @@ The town and cathedral sit pretty at the foot of towering mountains, the sun bak
 
 Boats litter the bay, the wind clanging ropes against their metal masts, amongst the sound of kids sunbathing on jetties and French tourists’ camera shutters, snapping views of the cathedral Santa Maria.
 
-{% figure spain-cadaques-barcelona-30.jpg portrait %}Terracotta rooftops of Cadaqués{% endfigure %}
+{% figure spain-cadaques-barcelona-30.jpg portrait %}
+Terracotta rooftops of Cadaqués
+{% endfigure %}
 
 ## Hotel Sol Ixent
 

--- a/source/_posts/cadaques-spain/2.md
+++ b/source/_posts/cadaques-spain/2.md
@@ -11,11 +11,15 @@ Continental breakfast brought few surprises, and we gorged ourselves on croissan
 
 With back packs stuffed full of sun cream, towels, change of clothes and other heavy stuff Sam might need but probably won’t use, the whole of Cadaqués beckoned. The coastal walk from east to west revealed its treasures - dirt paths and rocky walkways, through cacti, to hidden beaches and rocky outcrops where you can sit and paddle, then around to the old town and the gorgeous views on approach.
 
-{% figure spain-cadaques-barcelona-11.jpg landscape %}Panorama of Cadaqués and mountains{% endfigure %}
+{% figure spain-cadaques-barcelona-11.jpg landscape %}
+Panorama of Cadaqués and mountains
+{% endfigure %}
 
 The back roads are thin and labyrinthine, similar to [Molyvos](/2008/09/two-weeks-in-molyvos-in-lesbos-greece/), and its apparent why scooters are popular. Purple vines grow up the whitewashed walls towards the deep blue sky above.
 
-{% figure spain-cadaques-barcelona-25.jpg portrait %}Narrow streets of Cadaqués{% endfigure %}
+{% figure spain-cadaques-barcelona-25.jpg portrait %}
+Narrow streets of Cadaqués
+{% endfigure %}
 
 For a cheap lunch we had the €12 set menu at Es Taronger, including wine.
 
@@ -32,7 +36,9 @@ All that walking was sweat inducing, and an ice cold pool soon put sort to that.
 
 In our evening dress, we passed a huge mechanical dragon, being slayed by a conquistador (as you do!) - a converted car with built in fireworks.
 
-{% figure spain-cadaques-barcelona-35.jpg portrait %}Samantha ready for a romantic evening meal{% endfigure %}
+{% figure spain-cadaques-barcelona-35.jpg portrait %}
+Samantha ready for a romantic evening meal
+{% endfigure %}
 
 In the high ceiling’d and overly lit Restaurant, es Baluard, recommended by the Lonely Planet, we settled with white wine for the evening.
 
@@ -45,4 +51,6 @@ In the high ceiling’d and overly lit Restaurant, es Baluard, recommended by th
 
 Digging into the spider crab paella with industrial strength pliers, we spent an hour stabbing and scraping at the tastiest bits, hidden deep inside the legs. Sam only hit the wall with flying crab shards the once, the rest landed on my plate. Whilst the crab was tasty, we didn’t eat it fast enough and the rice was soon cold. The rich hot chocolaty desserts were fantastic.
 
-{% figure spain-cadaques-barcelona-40.jpg portrait original %}Spider crab remains{% endfigure %}
+{% figure spain-cadaques-barcelona-40.jpg portrait original %}
+Spider crab remains
+{% endfigure %}

--- a/source/_posts/cadaques-spain/3.md
+++ b/source/_posts/cadaques-spain/3.md
@@ -14,11 +14,15 @@ In town again, we ate tapas at Nord Est, a smart looking blue bar in the east of
 * Potato omelette/tortilla with bread and tomato spread
 {% endmenu %}
 
-{% figure spain-cadaques-barcelona-46.jpg landscape %}Roasted aubergine, olives and onion on toast{% endfigure %}
+{% figure spain-cadaques-barcelona-46.jpg landscape %}
+Roasted aubergine, olives and onion on toast
+{% endfigure %}
 
 Passing the placards of Dali’s paintings, pointing out the landmarks (often amongst melting clocks), we walked across the town to the west side of the bay, with yet more beaches and secret hideaways.
 
-{% figure spain-cadaques-barcelona-47.jpg portrait %}Our reproduction of [Dali’s Port Alguer](http://www.salvador-dali.org/museus/teatre-museu-dali/the-collection/161/port-alguer) painting{% endfigure %}
+{% figure spain-cadaques-barcelona-47.jpg portrait %}
+Our reproduction of [Dali’s Port Alguer](http://www.salvador-dali.org/museus/teatre-museu-dali/the-collection/161/port-alguer) painting
+{% endfigure %}
 
 At the far-end there is a small island with an old concrete bridge, the gate was marked as private but that was largely ignored. The cow-paths took us to the rocky summit, where we carved out a place to sleep, snack and read, sharing chapter five of “One day”, whilst tour boats chugged past below. The king of the mountain bliss, with all its calming soundscapes, could only be interrupted by the occasional sharp stone digging into our backs, as we shuffled to get more comfortable.
 
@@ -36,7 +40,9 @@ With each dish that passed us, Sam’s face lit up with an “Oooh” expression
 * Raspberry cheesecake
 {% endmenu %}
 
-{% figure spain-cadaques-barcelona-56.jpg landscape %}Samantha at Can Tito, admiring the passing plates of food{% endfigure %}
+{% figure spain-cadaques-barcelona-56.jpg landscape %}
+Samantha at Can Tito, admiring the passing plates of food
+{% endfigure %}
 
 The food was divine, and as we jointly filleted the Pelaia, Sam struck up some banter with our French neighbours on the table next to ours. Soon we were trying mouthfuls of their very tasty Arroz Negro, “c’est particular”. Delicious.
 

--- a/source/_posts/cadaques-spain/4.md
+++ b/source/_posts/cadaques-spain/4.md
@@ -9,23 +9,35 @@ page: 4
 
 After breakfast and the escapade of finding Sam’s black cardigan we set out with picnic in tow, towards Port Lligat and Casa Dali--you need to book ahead, and our hotel receptionist grudgingly did so for us. An hour early, we trekked along the coastline until we could go no further, a rocky outcrop blocking our path.  Beneath us lay a beautiful secluded little cove, with a bit of sand and perfect paddling water.
 
-{% figure spain-cadaques-barcelona-66.jpg landscape %}Samantha on our coastal hike to Port Lligat{% endfigure %}
+{% figure spain-cadaques-barcelona-66.jpg landscape %}
+Samantha on our coastal hike to Port Lligat
+{% endfigure %}
 
-{% figure spain-cadaques-barcelona-63.jpg portrait %}Secluded cove near to Casa Dali{% endfigure %}
+{% figure spain-cadaques-barcelona-63.jpg portrait %}
+Secluded cove near to Casa Dali
+{% endfigure %}
 
 The one time I didn’t have swimming shorts or suitable shoes we wanted to swim, and in my attempt to paddle I slipped on the mossy rock falling flat on my bum and soaking both shorts and underwear. Phone and wallet survived, miraculously untouched. “The rocks are slippy”, Sam warned, clothes already sopping. As I dried off, we dangled our toes in the cool sea and watched boats head out with their diving parties.
 
 Back at Dali’s house, ticket in hand, we explored the crazy yet ingenious rooms that the surrealist once lived in. A polar bear with rifle greats you at the entrance, stuffed swans fly above the dining area and everything is not quite normal. Little cages poke out from the wall--no longer chirping with locusts, whilst mirrors cleverly manipulate the light. The workshop houses unfinished pieces, and the red oboe room has perfect acoustics. Gala’s collection of photos and magazines still cover a cupboard-ed room, whilst their separate beds lie made in the bedroom. As crazy and outlandish as this famous house is, it’s real, there are no placards explaining things; attention has been paid to keep this place as close to how it was as possible.
 
-{% figure spain-cadaques-barcelona-76.jpg portrait %}Samantha and a rifle wielding polar bear lamp, at Casa Dali{% endfigure %}
+{% figure spain-cadaques-barcelona-76.jpg portrait %}
+Samantha and a rifle wielding polar bear lamp, at Casa Dali
+{% endfigure %}
 
-{% figure spain-cadaques-barcelona-81.jpg landscape %}Perfectly placed mirrors for manipulating light{% endfigure %}
+{% figure spain-cadaques-barcelona-81.jpg landscape %}
+Perfectly placed mirrors for manipulating light
+{% endfigure %}
 
 Outside the weirdness continues, as we explore the areas where Dali entertained his guests. An outdoor dining area complete with rhino head, a giant egg on a room with cemented and broken piano, a tyre themed swimming pool with reclining Michelin men, and an old telephone box in the corner. Through the strangeness, titbits of his genius appear, and we grasp a fraction of his overwhelming fascination in everything.
 
-{% figure spain-cadaques-barcelona-86.jpg landscape %}Iconic egg on the roof of Dali’s house{% endfigure %}
+{% figure spain-cadaques-barcelona-86.jpg landscape %}
+Iconic egg on the roof of Dali’s house
+{% endfigure %}
 
-{% figure spain-cadaques-barcelona-91.jpg portrait %}Pink lips sofa and Pirelli tyres{% endfigure %}
+{% figure spain-cadaques-barcelona-91.jpg portrait %}
+Pink lips sofa and Pirelli tyres
+{% endfigure %}
 
 Picnic time! At the top of the hill, we sliced our saucisson, smeared president cheese over baguette and covered our fingers in melted chocolate from dip pots.
 
@@ -41,11 +53,17 @@ That evening our food was all the more dignified, going back to Cadaqués and th
 * Chocolate cheesecake
 {% endmenu %}
 
-{% figure spain-cadaques-barcelona-107.jpg portrait %}Samantha with our tuna fish and mango carpaccio, at Casa Nun{% endfigure %}
+{% figure spain-cadaques-barcelona-107.jpg portrait %}
+Samantha with our tuna fish and mango carpaccio, at Casa Nun
+{% endfigure %}
 
-{% figure spain-cadaques-barcelona-114.jpg landscape %}Paul and cheesecake{% endfigure %}
+{% figure spain-cadaques-barcelona-114.jpg landscape %}
+Paul and cheesecake
+{% endfigure %}
 
-{% figure spain-cadaques-barcelona-111.jpg portrait %}Samantha at Casa Nun, the window looks out onto the bay{% endfigure %}
+{% figure spain-cadaques-barcelona-111.jpg portrait %}
+Samantha at Casa Nun, the window looks out onto the bay
+{% endfigure %}
 
 The mango and tuna carpaccio peculiarly worked wonderfully, and the salty fresh sardines were of course delicious. My duck breast and pear was perfect, both meaty, tender and sweet, I’m salivating at the thought of eating it again. Sam’s grilled squid came with tentacles et al, we made sure beforehand. And chocolate cheesecake is always a pleasure.
 

--- a/source/_posts/cadaques-spain/5.md
+++ b/source/_posts/cadaques-spain/5.md
@@ -7,27 +7,39 @@ page: 5
 
 ## Private bathing
 
-{% figure spain-cadaques-barcelona-121.jpg portrait %}Let’s go explore{% endfigure %}
+{% figure spain-cadaques-barcelona-121.jpg portrait %}
+Let’s go explore
+{% endfigure %}
 
 Our last day, and we explored the town’s backstreets, picking up a couple of souvenirs en route, getting lost and then finding ourselves near Port Lligat.
 
 After an all too short and ill prepared dip in a secluded bay, we sought to find another place to enjoy the sea and sunbathe in private. Our first discovery, over some towering rocks and down to a concealed spot, had jagged stone, crashing waves and one too many sea anemones. We upped and headed north, back towards Dali’s house. Quite by accident, we stumbled on a perfect sandy beach, small rippling waves and no one in sight, views of Dali's house in the distance.
 
-{% figure spain-cadaques-barcelona-123.jpg portrait %}Secluded bay{% endfigure %}
+{% figure spain-cadaques-barcelona-123.jpg portrait %}
+Secluded bay
+{% endfigure %}
 
-{% figure spain-cadaques-barcelona-128.jpg portrait %}Dali’s house in the distance{% endfigure %}
+{% figure spain-cadaques-barcelona-128.jpg portrait %}
+Dali’s house in the distance
+{% endfigure %}
 
 We swam out to sea, or in my case, walked as far as I could, swam a little bit, then turned back, struggling to cope with my red flip flops which sank into the sand beneath. Sam made her way out to the boats, and a small jetty. We enjoyed another infamous cheese and sausage picnic, using a perfectly placed rock as a table, sarong acting as tablecloth. All very civilised. I skimmed stones, Sam took pictures and we avoided a throbbing purple jellyfish.
 
-{% figure spain-cadaques-barcelona-137.jpg landscape %}Purple jellyfish{% endfigure %}
+{% figure spain-cadaques-barcelona-137.jpg landscape %}
+Purple jellyfish
+{% endfigure %}
 
 ## Can Tito (again)
 
 For our last night in Cadaqués, we returned to our favourite eatery, Can Tito. On our way, we stopped for pictures together at all the scenic points.
 
-{% figure spain-cadaques-barcelona-3.jpg landscape %}Posing with the framed view of Cadaqués{% endfigure %}
+{% figure spain-cadaques-barcelona-3.jpg landscape %}
+Posing with the framed view of Cadaqués
+{% endfigure %}
 
-{% figure spain-cadaques-barcelona-102.jpg portrait %}Cadaques at dusk{% endfigure %}
+{% figure spain-cadaques-barcelona-102.jpg portrait %}
+Cadaques at dusk
+{% endfigure %}
 
 The town was busy tonight, with a triathlon taking place and all the weekend visitors arriving, the restaurant was busy too, though we’d already planned what we were ordering:
 
@@ -40,8 +52,12 @@ The town was busy tonight, with a triathlon taking place and all the weekend vis
 
 Sat in the same seats as before, we again enjoyed wonderful food. The squid croquettes were a perfect bite-sized sample of the Arroz Negro flavour and the paella balanced sea food and rice excellently. Sam thanked the chef personally, and we rounded off our evening with another heavenly cheesecake.
 
-{% figure spain-cadaques-barcelona-142.jpg landscape %}Samantha and our delicious paella at Can Tito{% endfigure %}
+{% figure spain-cadaques-barcelona-142.jpg landscape %}
+Samantha and our delicious paella at Can Tito
+{% endfigure %}
 
 For the last time, slightly drunk again, we walked back along the coast, past the tall pink house, past the kids up late having parties and the romantically entwined couples, the bayside cafes, the jetties and rocking boats with weird statue on the corner (not a Dali), through the unlit roads using my iPhone as a torch, under the milky way, bats looping around street lights, to the hotel. Up the stairs, along the echoing tiled hallway, to our room.
 
-{% figure spain-cadaques-barcelona-39.jpg landscape %}Cadaques at night{% endfigure %}
+{% figure spain-cadaques-barcelona-39.jpg landscape %}
+Cadaques at night
+{% endfigure %}

--- a/source/_posts/chengdu-china.md
+++ b/source/_posts/chengdu-china.md
@@ -20,7 +20,9 @@ Our hotel was situated in an affluent touristy part of town — Qintai road; a r
 
 But it wasn’t without character and it wasn’t _bad_. The staff were friendly and helpful, the food was homely and tasty — we enjoyed eating here, the location (although touristy) was right next to the city parks. And the place has some personality; all the hotel rooms border an old courtyard (where food is served), and it evokes a bit of the grandeur of a traditional Chinese mansion house; even if it does need a bit of love and attention.
 
-{% figure china-chengdu-015.jpg landscape %}Wenjun Mansion Hotel{% endfigure %}
+{% figure china-chengdu-015.jpg landscape %}
+Wenjun Mansion Hotel
+{% endfigure %}
 
 That night we explored Qintai road, and in the dark we found the poorly lit people’s park. Despite the lack of lighting (in the UK you might expect a dark city park to be dangerous), the place was still filled with people; groups practising dancing or tai chi, dimly lit from the glow of the city.
 
@@ -28,19 +30,27 @@ That night we explored Qintai road, and in the dark we found the poorly lit peop
 
 The reason we came to Chengdu at all was to see the [Giant Pandas](http://en.wikipedia.org/wiki/Giant_panda). Pandas are a quintessential part of China, and in Sichuan every shop seems to sell some form of panda paraphernalia. Tourists walk about in furry panda jumpers, panda coats and goofy panda hats. At the non-profit [Chengdu base](http://www.panda.org.cn/english/) there are over 80 pandas, mostly bred through artificial insemination. The base focuses on captive breeding, studying panda reproduction with the aims of preventing extinction, but it isn’t breeding and rearing pandas to release back into the wild.
 
-{% figure china-chengdu-017.jpg landscape %}Two-year old Giant panda, on our second consecutive visit to the base{% endfigure %}
+{% figure china-chengdu-017.jpg landscape %}
+Two-year old Giant panda, on our second consecutive visit to the base
+{% endfigure %}
 
 The base opens at 7:30am, and we left early with a small group from the hotel, to get there before all the tour groups. Panda feeding is at 9am and we didn’t want to miss that. The entrance to the park is an abstract concrete panda, and there’s golf buggies which whisk you around if you need it — on more than one occasion we were told the Chinese don’t like to walk; and to be honest this park is small enough to not need a buggy. Our drivers marched us towards the panda enclosures; too early for some, the eldest pandas were still asleep in their concrete rooms, or groggy and waiting for breakfast.
 
 “Come, come — pandas feeding” our driver said; we rushed around to find the Giant Panda cub enclosure where eight cubs, all about two years old, were casually gorging themselves on bamboo. So many pandas in one place, this must be one of the few places in the world that there is such a congregation. Nom nom nom, they ate in all sorts of poses your mother would advise against; spread-eagled on the floor one chewed the stalks lying down, bamboo remains spread across her furry chest. Beyond lies another enclosure, where the one-year olds were hanging about in the treetops, clumsily resting in the foliage, never at risk of falling.
 
-{% figure china-chengdu-013.jpg landscape %}One year-old panda in the treetops{% endfigure %}
+{% figure china-chengdu-013.jpg landscape %}
+One year-old panda in the treetops
+{% endfigure %}
 
 We’d come to Chengdu at one of the best times of the year. The youngest cubs were born about a month ago and in the “Sunshine delivery house” we queued to see staff feeding the cuddliest cutest of earth’s creatures with pipettes. All were born after artificial insemination. In the north of the park there are more panda houses, often reserved for pregnant pandas, they’re more spacious and luxurious. Though all the pens are large, with plenty of trees and space for the pandas to move about in, not that they do much moving — it’s rare to spot one of the docile pandas doing anything but eating and sleeping. At the “Moonlight delivery house” we found another baby, not more than a foot long, sleeping in a wooden cot.
 
-{% figure china-chengdu-012.jpg landscape %}One month old panda at Sunshine delivery house{% endfigure %}
+{% figure china-chengdu-012.jpg landscape %}
+One month old panda at Sunshine delivery house
+{% endfigure %}
 
-{% figure china-chengdu-011.jpg landscape %}Adult giant panda on the move{% endfigure %}
+{% figure china-chengdu-011.jpg landscape %}
+Adult giant panda on the move
+{% endfigure %}
 
 It’s amazing that these giant pandas aren’t extinct. They are solitary animals that rarely like to breed, when they do they rear only one cub and often don’t know how to treat this cub when its born. They predominantly eat bamboo, which gives them precious little energy; so little that they need to spend all day eating and have the inclination to do nothing else. (Bamboo itself is a peculiar plant, flowering once in 30 years and then dying). It’s amazing they find each other to breed in the first place. Then on top of this there’s the destruction of their essential habitat; the bamboo forests. How and why did an animal with ferocious origins, sharp claws and dangerous teeth become so placid?
 
@@ -48,16 +58,22 @@ It’s amazing that these giant pandas aren’t extinct. They are solitary anima
 
 The Chengdu research base houses and breeds [Red Pandas](http://en.wikipedia.org/wiki/Red_panda) too (also known as red cat-bears or lesser pandas — they aren’t closely related to the Giant panda). There’s less than 10,000 of these gorgeous bears left in the wild. Through a metal gate we passed into the Red panda enclosure, where you can walk freely amongst the animals, if you can spot them. From the slippery boardwalk we saw one high up in a tree, sleeping, then another doing the same. All of a sudden there was a kerfuffle from behind me and one of the pandas ran from behind me, brushed by my shorts, and continued along the path. Up ahead was a feeding platform, where more were enjoying a papaya feast.
 
-{% figure china-chengdu-010.jpg landscape %}[Red panda](https://500px.com/photo/85825149/red-panda-by-paul-hayes) looking up from his morning stroll{% endfigure %}
+{% figure china-chengdu-010.jpg landscape %}
+[Red panda](https://500px.com/photo/85825149/red-panda-by-paul-hayes) looking up from his morning stroll
+{% endfigure %}
 
 ### Time to go?
 
 Having seen everything, our drivers tried to rush us all back to the cars to return back to the hotel. But it was only 10:30. Our group staged a coup and we all stuck around in the park a little longer, agreeing to meet them later. Returning to the two-year old Giant panda cubs was worth it alone. They’d finished eating, had a bit of sleep and were now active and playful. Of course now there were many crowds, and we had to jostle to the front, but soon it felt like we were at the theatre. Two of the cubs were fooling around with each other, falling over backwards, pouncing on each other, wrestling; each calamity was met with a roar of laughter from the audience. It felt like a rare thing to see.
 
-{% figure china-chengdu-009.jpg landscape %}Great mates — the adorable and playful giant pandas{% endfigure %}
+{% figure china-chengdu-009.jpg landscape %}
+Great mates — the adorable and playful giant pandas
+{% endfigure %}
 
 ### Another visit
 
 We didn’t have much to do the following morning in Chengdu, and after feeling a little rushed around the park we decided to come back one more time, we’d do the park in our own time and try and get some good pictures. Unfortunately the sky was more heavy and overcast and didn’t make for many good photos. Still, it was worth coming back just to see the pandas again, after all we’d come a long way.
 
-{% figure china-chengdu-021.jpg landscape %}Paul and a giant panda (obligatory t-shirt picture){% endfigure %}
+{% figure china-chengdu-021.jpg landscape %}
+Paul and a giant panda (obligatory t-shirt picture)
+{% endfigure %}

--- a/source/_posts/chengdu-china/2.md
+++ b/source/_posts/chengdu-china/2.md
@@ -20,23 +20,35 @@ We hadn’t planned this course ourselves, we’d booked it as part of our whole
 
 Today we’d be cooking four classic Sichuan recipes: [Gongbao chicken](http://en.wikipedia.org/wiki/Kung_Pao_chicken) (or Kung Pao, Kung po, 宫保雞丁), [Mapo Tofu](http://en.wikipedia.org/wiki/Mapo_doufu) (or Mapo doufu, 麻婆豆腐), [Twice cooked pork](http://en.wikipedia.org/wiki/Twice_cooked_pork) (Huí Guō Ròu, 回鍋肉) and Chengdu [dandan noodles](http://en.wikipedia.org/wiki/Dandan_noodles) (dandanmian, 担担面).
 
-{% figure china-chengdu-008.jpg landscape %}Cooking Mapo tofu{% endfigure %}
+{% figure china-chengdu-008.jpg landscape %}
+Cooking Mapo tofu
+{% endfigure %}
 
 For each dish we prepared the ingredients together; learning that slicing the root ginger without peeling it first is fine, discovering “lettuce cubes” which I think were cubes of [luffa](http://en.wikipedia.org/wiki/Luffa) — it’s just like cucumber really, and realising that of course every Sichuan dish has some soy sauce in it, if not chillies, cornstarch, sugar and salt too. When that dish’s ingredients were ready Sam would show us how to cook them then each of us would have a go, before sitting down to eat our food with a hot glass of whole-leaf jasmine tea.
 
-{% figure china-chengdu-003.jpg landscape %}Cooking Gongbao chicken{% endfigure %}
+{% figure china-chengdu-003.jpg landscape %}
+Cooking Gongbao chicken
+{% endfigure %}
 
 Mapo Tofu, our first dish was scrumptious — especially given that we tend to not like tofu. Its boiled tofu which is added to toasted minced pork along with ginger and garlic, followed by a homemade chilli bean paste, some spring onions and a sichuan peppercorn powder. Possibly the best tofu we’ve ever eaten, definitely the best we’ve ever cooked. Next, Gongbao chicken is a dish with cubed chicken pieces fried together with cucumber, spring onions, ginger, garlic, dried chillies and famous Sichuan peppercorns. Soy sauce and vinegar are added at the end, along with pre-prepared crispy fried peanuts. Twice cooked pork is delightfully simple; (fatty!) pork boiled, cooled then sliced and fried. Its fried with large green chillies and extra chilli paste, with a sprinkling of sugar. We watched Sam cook the last dish, dandan noodles with minced pork, more ginger and chillies. As said, it’s simple, fast and tasty.
 
-{% figure china-chengdu-005.jpg landscape %}Dandan noodles{% endfigure %}
+{% figure china-chengdu-005.jpg landscape %}
+Dandan noodles
+{% endfigure %}
 
 We picked up a lot of useful tips along the way too. When you cook the pork for twice cooked pork, we used chopsticks to see when it was ready. We learnt how to make really tasty fried peanuts; skin on nuts slow cooked in cold oil on a low heat until they begin to ‘pop’ then let them cool — when you want to eat them you quickly fry them up and they go nice and crispy (also good with salt and chilli powder!). When cooking large spicy green chillies you can dry fry them beforehand to reduce the spiciness and make them a bit sweeter; you can also add sugar and salt to these to make “tiger skin pepper” (the backs go a streaky black). There’s also a saying about Chinese cuisine; in the north the food is salty, in the south its sweet, in the east its sour and in the west, here in Sichuan, its spicy. “Ooh, too spicy”, Sam coughed as he ate a dish he’d prepared — sometimes its even too spicy for the locals.
 
-{% figure china-chengdu-002.jpg portrait %}Sam, our chef{% endfigure %}
+{% figure china-chengdu-002.jpg portrait %}
+Sam, our chef
+{% endfigure %}
 
-{% figure china-chengdu-006.jpg portrait %}Samantha and her twice cooked pork{% endfigure %}
+{% figure china-chengdu-006.jpg portrait %}
+Samantha and her twice cooked pork
+{% endfigure %}
 
-{% figure china-chengdu-007.jpg landscape %}Spicy twice cooked pork{% endfigure %}
+{% figure china-chengdu-007.jpg landscape %}
+Spicy twice cooked pork
+{% endfigure %}
 
 ## Tea in Chengdu
 
@@ -48,14 +60,20 @@ In the evening we had a small meal of crispy barbecued pork ribs and a pizza, be
 
 ## A quiet day in Chengdu
 
-{% figure china-chengdu-016.jpg landscape %}A second visit to see the giant pandas{% endfigure %}
+{% figure china-chengdu-016.jpg landscape %}
+A second visit to see the giant pandas
+{% endfigure %}
 
 After our second visit to the pandas in the morning we didn’t do much with the day. Most of Chengdu’s activities are a drive out of town, so we packed our bags, I wrote this blog a bit and Samantha explored the people’s park some more. I missed out on that, as she saw how the park was used on a Sunday; families were there together enjoying tea, ladies were singing bad opera, old men were arguing about art, a man was painting calligraphy on the pavement with water, people were playing games, and a workshop was showing children how to paint bamboo and learn calligraphy — something that inspired Samantha to learn too in [Yangshuo](/2014/09/yangshuo-china/2/).
 
 For lunch we stayed in the hotel, and we tried a restaurant made twice-cooked pork (now so much more appealing!) along with some special fried rice and spicy shrimp (which was missing some promised beef).
 
-{% figure china-chengdu-022.jpg square %}Tasty spicy shrimp served at Wenjun Mansion Hotel{% endfigure %}
+{% figure china-chengdu-022.jpg square %}
+Tasty spicy shrimp served at Wenjun Mansion Hotel
+{% endfigure %}
 
 Around 6pm we said our goodbyes to other couples we’d met at the hotel; a couple of other Rickshaw travellers who were heading home now, and a British couple who were fascinated with wildlife and had been to an exclusive sunbear sanctuary because of their charity contributions. Next stop, a relaxing stay in the natural wonder that is [Yangshuo](/2014/09/yangshuo-china/).
 
-{% figure china-chengdu-019.jpg landscape %}Qintai road in Chengdu{% endfigure %}
+{% figure china-chengdu-019.jpg landscape %}
+Qintai road in Chengdu
+{% endfigure %}

--- a/source/_posts/hanoi-and-halong-bay-vietnam.md
+++ b/source/_posts/hanoi-and-halong-bay-vietnam.md
@@ -19,7 +19,9 @@ The sleeper from Dong Hoi to Hanoi took about 12 hours, we left at 11pm and got 
 
 Coming into Hanoi we'd had our breakfast, for Sam that was a pot noodle, for me a giant apple; Sam read the Lonely Planet's guide to Hanoi, and I tried to relax with my white earphones and music.
 
-{% figure hanoi-halong-bay--002.jpg landscape %}Samantha reading about Hanoi on the sleeper train{% endfigure %}
+{% figure hanoi-halong-bay--002.jpg landscape %}
+Samantha reading about Hanoi on the sleeper train
+{% endfigure %}
 
 Hanoi is known for its scam taxis; taxis with an insanely high meter rate, one that will treble before you've left the station. Lindsey, the girl we'd taken the Hoi An cooking course with, had exactly this problem; at 3am she'd arrived in Hanoi and her taxi tried to charge her extortionate rates. We were naturally paranoid, but needn't have worried; our hotel met us on the platform and led us through the busy station exit safely. “Taxi? You need a taxi? Taxi to your hotel?”, we must've said no a hundred times. We threw our heavy red and blue backpacks into the boot of the car and set off.
 
@@ -29,7 +31,9 @@ Hanoi is insane, that was my first impression. A busy, crazy place where motorcy
 
 We were staying at Charming Hotel, note, that's not Charming Hotel 2, that's the sequel. It's down Yen Thai St, a narrow alleyway for bikes only; a quintessential Hanoi side street teaming with life, it's own micro community amongst the craziness of the capital city. The hotel was nestled between some food stalls and a porcelain painting shop for kids.
 
-{% figure hanoi-halong-bay--001.jpg landscape %}Our modest room in Hanoi{% endfigure %}
+{% figure hanoi-halong-bay--001.jpg landscape %}
+Our modest room in Hanoi
+{% endfigure %}
 
 Our room was modest, if a little old, it had the essentials — a toilet, a bed, wifi, breakfast, and we paid a little more for a room with a window, “city room” it was called. The staff were lovely and always wanting to help, a team always waiting in the lobby.
 
@@ -41,15 +45,21 @@ The shops are small, thin and narrow again like most of the houses (see: obscure
 
 We set out to follow the Lonely Planet walking tour, which started by Hanoi's renowned Hoan Kiem lake, though we got sidetracked. For almost an hour, strolling through the streets and around the lake no one hassled us. A first. Was everyone sleeping? A lovely teenage girl did stop and say hello to us by the lake, I was being all defensive, but she was genuinely practicing her English, the sales pitch never came and she wished us a pleasant holiday. When we mentioned Halong Bay her eyes lit up, she had some prepared sentences ready.
 
-{% figure hanoi-halong-bay--004.jpg landscape %}Samantha on Hoan Kiem lake{% endfigure %}
+{% figure hanoi-halong-bay--004.jpg landscape %}
+Samantha on Hoan Kiem lake
+{% endfigure %}
 
 Standing at the foot of the lake, Sam shared with me the story of Cu Rua, the lake's legendary giant turtle. Cu Rua is the last surviving lake turtle, a mere 200kg, 2m long and 100 years old. Locals believe the turtle to be sacred; he is one of only three of this freshwater turtle species left. He wasn't coming out to see us today.
 
 To the north of the lake, on an island, sits Ngoc Son temple, reached by an arching red wooden bridge. Beneath lanterns hanging from an ornate wooden roof men played mahjong. Inside, beyond the plastic fruit and standard temple dedication affairs, lies a bronze plated stuffed turtle, one of Hanoi's ancient turtles. Outside a couple played badminton by the Martyr's Monument, a dedication to those that died for Vietnam's independence.
 
-{% figure hanoi-halong-bay--007.jpg landscape %}A bronze plated giant stuffed turtle, legend of the lake{% endfigure %}
+{% figure hanoi-halong-bay--007.jpg landscape %}
+A bronze plated giant stuffed turtle, legend of the lake
+{% endfigure %}
 
-{% figure hanoi-halong-bay--006.jpg portrait %}Playing Mahjong at Ngoc Son temple{% endfigure %}
+{% figure hanoi-halong-bay--006.jpg portrait %}
+Playing Mahjong at Ngoc Son temple
+{% endfigure %}
 
 ## Streets of Hanoi
 
@@ -61,10 +71,16 @@ We crossed the road back and forth a few times, quickly becoming masters of the 
 
 At 6:30pm we were back at the water puppet theatre for a performance described by the Lonely Planet as, “Punch and Judy in a pool”. Water puppetry, or roi nuoc, is a traditional art form dating back a thousand years, emerging from flooded rice paddies. Set against live traditional music, puppets move about the water surface, controlled by hidden poles in murky water. Sam enjoyed the hour long show, but I couldn't find the appeal, it wasn't particularly graceful.
 
-{% figure hanoi-halong-bay--011.jpg landscape %}Water puppet theatre in Hanoi{% endfigure %}
+{% figure hanoi-halong-bay--011.jpg landscape %}
+Water puppet theatre in Hanoi
+{% endfigure %}
 
 In night time Hanoi we meandered towards Madame Hien, housed in an old villa and specialising in elegant street food. Sam opted for the five course taster menu. My soft-shelled crab starter, as might be expected, was delicious.
 
-{% figure hanoi-halong-bay--014.jpg landscape %}Soft shelled crab at Madame Hien's{% endfigure %}
+{% figure hanoi-halong-bay--014.jpg landscape %}
+Soft shelled crab at Madame Hien's
+{% endfigure %}
 
-{% figure hanoi-halong-bay--013.jpg landscape %}Hanoi at night{% endfigure %}
+{% figure hanoi-halong-bay--013.jpg landscape %}
+Hanoi at night
+{% endfigure %}

--- a/source/_posts/hanoi-and-halong-bay-vietnam/2.md
+++ b/source/_posts/hanoi-and-halong-bay-vietnam/2.md
@@ -31,15 +31,21 @@ The boat raises anchor and we're off, Ha points to the map and shows us where we
 
 We were in room two, and our key was adorned with a large wooden dolphin. From the narrow corridor we entered, we had a double bed with beautiful Vietnamese linen (which we then tried to find and buy in Hanoi, but without much luck), storage cupboards, air conditioning and two windows that look out across the bay. We even had a private bathroom, with shower. Sam was most excited about the bathroom porthole, “it's a proper porthole, it even opens”.
 
-{% figure hanoi-halong-bay--016.jpg landscape %}Samantha in our room, on the Prince III{% endfigure %}
+{% figure hanoi-halong-bay--016.jpg landscape %}
+Samantha in our room, on the Prince III
+{% endfigure %}
 
 Time for lunch, and we gathered in the bar area. Food, all inclusive, was served on shared platters; chicken, cucumber and sesame salad, huge king prawns, pippis with chilli, and so on. All very tasty and plentiful. Halida beer was our preferred drinks choice, and, at times, it was drunk so fast the cans stopped being chilled.
 
 We sailed for about an hour, on calm waters, the sky a little overcast. We sat up top on wooden outdoor furniture, and with my iPad I wrote about our cave trip. Trekking through a cave is notoriously difficult to describe. This was perfectly relaxing, no cares in the world, a beautiful changing landscape and a cool breeze. Limestone peaks would pass by, occasionally revealing, through a small peek hole, a secret lagoon. There were remnants of caves too, and huge outdoor stalactites. The waves brushed against the foot of the peaks, gently eroding them, and cutting away at the bottom, so as to leave them leaning precariously.
 
-{% figure hanoi-halong-bay--019.jpg landscape %}Sailing through Halong Bay on the Prince III{% endfigure %}
+{% figure hanoi-halong-bay--019.jpg landscape %}
+Sailing through Halong Bay on the Prince III
+{% endfigure %}
 
-{% figure hanoi-halong-bay--017.jpg landscape %}Sam procrastinating on the boat{% endfigure %}
+{% figure hanoi-halong-bay--017.jpg landscape %}
+Sam procrastinating on the boat
+{% endfigure %}
 
 Soon there were no other boats in sight, and the mainland was hidden from us. Just the gentle chug of the boat, splashing of the waves, a few coves and bays and the occasional tiny deserted beach.
 
@@ -49,7 +55,9 @@ Time for a little physical exertion, and another opportunity to go kayaking. In 
 
 The route took us out and around H. Cap La. South east, then north, towards the open sea, and back around, along the edges of H. Ran. As inefficient as we were, our arms ached and, apart from the odd collision, mostly watched the group from behind. We stopped to watch a large Oriental Pied Hornbill in the treetops, as he danced about the foliage. We continued around to the boat, manoeuvred into position and made it in the end, about an hour of kayaking all in all, and quite enough for me.
 
-{% figure hanoi-halong-bay--023.jpg landscape %}Kayaking around H. Cap La{% endfigure %}
+{% figure hanoi-halong-bay--023.jpg landscape %}
+Kayaking around H. Cap La
+{% endfigure %}
 
 We anchored there for the night, relaxed and prepared for dinner on the top deck, with Sam in her newly bought oriental Hoi An dress. More prawns and chicken salad; the differences between meals were subtle, but tasty nonetheless. I washed it down with a black russian cocktail.
 
@@ -57,4 +65,6 @@ A storm was rumbling out in the distance, and the night sky, black and cloudy wi
 
 With Richard and Rochelle we saw out the night with a game of hearts and some Halida beers. Sam managed to get the highest score possible, 125, very impressive, though she was none too happy.
 
-{% figure hanoi-halong-bay--025.jpg landscape %}Goodnight{% endfigure %}
+{% figure hanoi-halong-bay--025.jpg landscape %}
+Goodnight
+{% endfigure %}

--- a/source/_posts/hanoi-and-halong-bay-vietnam/3.md
+++ b/source/_posts/hanoi-and-halong-bay-vietnam/3.md
@@ -11,15 +11,21 @@ I'm not entirely sure how I did this, but at 5:30am I accidentally woke up, roll
 
 At 8am we had breakfast. A lovely chicken pho followed by fried eggs and toast. Yummy. From the bay we headed south, to Vung Vieng fishing village, an hours journey. We passed the time by relaxing, I wrote by the bar, and Sam spoke to Ha about his family, and the many days he spends away from them. Above us Black Kites swooped, looking for their next prey. The mountains quietly rolled by, elegant and serene. Blissful, unavoidable relaxation.
 
-{% figure hanoi-halong-bay--028.jpg landscape %}Chicken Pho for breakfast{% endfigure %}
+{% figure hanoi-halong-bay--028.jpg landscape %}
+Chicken Pho for breakfast
+{% endfigure %}
 
-{% figure hanoi-halong-bay--030.jpg landscape %}Good morning Bai Tu Long Bay, you quiet peaceful place{% endfigure %}
+{% figure hanoi-halong-bay--030.jpg landscape %}
+Good morning Bai Tu Long Bay, you quiet peaceful place
+{% endfigure %}
 
 At the fishing village we clambered onto the blue boat we tow everywhere and were ported to a small harbour. Two by two we boarded our own wooden row boats with hat adorning rower. No physical exertion required today.
 
 The village resides within a natural bay, sheltered in all directions from strong sea winds and whatever tropical storm might come their way. Houses, which looked fairly new, were turquoise wooden shacks with orange metal rooftops, tied together on floating blue barrels. They were mostly one room, the odd couple had an annex, all with a wooden boat parked out front. Washing was hung outside, an old Manchester United top billowed in the breeze. Each house had its own TV aerial and a CRT television, though I couldn't fathom where the power came from. The Vietnamese flag flew proudly from their rooftops, as it also did from our boat's mast.
 
-{% figure hanoi-halong-bay--033.jpg landscape %}Exploring a fishing village by row boat{% endfigure %}
+{% figure hanoi-halong-bay--033.jpg landscape %}
+Exploring a fishing village by row boat
+{% endfigure %}
 
 Ha showed us that they keep pet dogs, dogs they respect (and don't eat!), though they seemed to be running around on small floating platforms and we wondered how they'd get any exercise.
 
@@ -27,19 +33,29 @@ We docked in the centre of town; some fisheries, a school, a small hall cum muse
 
 Back on the row boat we left the village, to visit a stupendous limestone arch at Hon Vung Ha. A picture perfect paradise. We circled this ancient passageway and finished our circuit with a stop at an oyster farm.
 
-{% figure hanoi-halong-bay--035.jpg landscape %}Sam and the fishing village{% endfigure %}
+{% figure hanoi-halong-bay--035.jpg landscape %}
+Sam and the fishing village
+{% endfigure %}
 
-{% figure hanoi-halong-bay--036.jpg landscape %}Picture perfect paradise{% endfigure %}
+{% figure hanoi-halong-bay--036.jpg landscape %}
+Picture perfect paradise
+{% endfigure %}
 
-{% figure hanoi-halong-bay--038.jpg landscape %}Paul and our rower{% endfigure %}
+{% figure hanoi-halong-bay--038.jpg landscape %}
+Paul and our rower
+{% endfigure %}
 
 ## Oyster farm
 
 A smartly dressed guide greeted us and explained how they grow and farm pearls. We watched closely as a girl plied open an oyster, held it open with clamps and inserted a small impurity and ball, before closing it up again. These seeded oysters are left for many years, 30% will yield a pearl, but only 10% will yield one good enough to sell. The girl with the tweezers and clamps seeds up to 600 oysters per day. From one end of the process to the other, a two year old oyster was waiting to be opened. We again watched as this oyster was prised open, as tweezers hunted about the gooey entrails a glistening silver pearl emerged. But it wasn't perfectly spherical, and the colour was inconsistent, it couldn't be sold she told us. The workshop backed onto a shop, complete with earrings, bracelets, necklaces and so on.
 
-{% figure hanoi-halong-bay--041.jpg portrait %}Inserting impurities into an oyster, at the oyster farm{% endfigure %}
+{% figure hanoi-halong-bay--041.jpg portrait %}
+Inserting impurities into an oyster, at the oyster farm
+{% endfigure %}
 
-{% figure hanoi-halong-bay--042.jpg landscape %}A small pearl within a farmed oyster{% endfigure %}
+{% figure hanoi-halong-bay--042.jpg landscape %}
+A small pearl within a farmed oyster
+{% endfigure %}
 
 ## Beach BBQ
 
@@ -47,19 +63,29 @@ We tipped our rowers and returned to our big white boat on the sea. Our next sto
 
 At our beach, a thin strip of sand beneath a towering rock, parasols and tables were waiting. As our crew cooked lunch, we swum in the warm shallow sea, and bathed on the soft pure sand. More unadulterated relaxation. I picked up hermit crabs with my feet, explored nearby rock pools, and discovered a tower of discarded oyster shells. We were on this beach for hours, a shower and change of clothes just over there on our boat, no cares in the world.
 
-{% figure hanoi-halong-bay--044.jpg landscape %}Samantha and our boat, on our deserted island{% endfigure %}
+{% figure hanoi-halong-bay--044.jpg landscape %}
+Samantha and our boat, on our deserted island
+{% endfigure %}
 
-{% figure hanoi-halong-bay--051.jpg landscape %}The beach at Thienh Can Son{% endfigure %}
+{% figure hanoi-halong-bay--051.jpg landscape %}
+The beach at Thienh Can Son
+{% endfigure %}
 
 Lunch beckoned, lovely grilled king prawns, beef, pork and chicken, and washed down with cold Halida lager. To walk off our food we trekked up the hill, following a steep path to the Thienh Can Son cave entrance. Yes, another cave on our holiday, you might mistakenly think we're some sort of cave fanatic. I expected a small cavern, but it opened out into many rooms, rooms a family had once lived in. They'd been evicted by the government, Ha explained, no doubt to make way for bumbling tourists like us, though Ha said it was because they'd damaged the cave.
 
-{% figure hanoi-halong-bay--053.jpg portrait %}Our boat, from Thienh Can Son cave{% endfigure %}
+{% figure hanoi-halong-bay--053.jpg portrait %}
+Our boat, from Thienh Can Son cave
+{% endfigure %}
 
-{% figure hanoi-halong-bay--055.jpg landscape %}Another cave, Thienh Can Son cave{% endfigure %}
+{% figure hanoi-halong-bay--055.jpg landscape %}
+Another cave, Thienh Can Son cave
+{% endfigure %}
 
 On the beach once more, and another opportunity to go kayaking. I passed it up, so Sam rowed off into the distance with Ha, and I slept on the beach. A lap around the nearby island, with a guide to do all the hard work. Our crew had their downtime, and I watched them play football on the sand with oars setup as goal posts.
 
-{% figure hanoi-halong-bay--058.jpg landscape %}Samantha and Ha, returning from their short kayaking trip{% endfigure %}
+{% figure hanoi-halong-bay--058.jpg landscape %}
+Samantha and Ha, returning from their short kayaking trip
+{% endfigure %}
 
 A few other boats started to arrive at “our beach”, as we dubbed it. And in the distance a storm was brewing. Time to go then; but not before a swimming race back to the boat. Because of the storm, and chance of some rough winds, we returned to the sheltered bay we'd stopped at the night before, and anchored for the evening.
 
@@ -67,12 +93,18 @@ A few other boats started to arrive at “our beach”, as we dubbed it. And in 
 
 Our final evening meal was served in the bar, and amidst the usual salads and prawns the crew brought out intricately carved food; two storks dancing on potatoes, a rose carved into a butternut squash, and a replica of our boat made from a watermelon and carrots, sails and all. Our chef gave us a demonstration too, and from the narrow corridor he flambeed prawns amidst a cloud of steam.
 
-{% figure hanoi-halong-bay--060.jpg portrait %}Chef, flambeeing prawns{% endfigure %}
+{% figure hanoi-halong-bay--060.jpg portrait %}
+Chef, flambeeing prawns
+{% endfigure %}
 
-{% figure hanoi-halong-bay--062.jpg portrait %}The Prince III, carved out of vegetables{% endfigure %}
+{% figure hanoi-halong-bay--062.jpg portrait %}
+The Prince III, carved out of vegetables
+{% endfigure %}
 
 This was almost the end of our short trip, and our crew came to say their thank yous, even singing for us; apparently a song from a popular Vietnamese talent show. Ha asked if we could sing something back, but we failed to find a song, and the moment descended into awkwardness.
 
 To round out the night we sat up top with some drinks and shared music, taking turns to plug iPhones into a set of portable speakers. The bay was quiet and dark, with only the gentle noise of waves stroking the rocks, and the light of boats anchored nearby. From the speakers we played Sigur Ros, Eddie Vedder and Birdy and I found that old Richard had fantastic taste. A lovely evening, I didn't want it to end.
 
-{% figure hanoi-halong-bay--063.jpg landscape %}The last night with our new friends, passengers of the Prince III{% endfigure %}
+{% figure hanoi-halong-bay--063.jpg landscape %}
+The last night with our new friends, passengers of the Prince III
+{% endfigure %}

--- a/source/_posts/hanoi-and-halong-bay-vietnam/4.md
+++ b/source/_posts/hanoi-and-halong-bay-vietnam/4.md
@@ -7,11 +7,17 @@ page: 4
 
 Knowing the time that dawn would happen, Sam set an alarm to wake us at 5:20am. I can't say I was too happy about this, but the sunrise was simply spectacular. Sam got dressed and took the camera out to get some shots. I merely rolled over and watched from my bed, capturing stills with my phone. The orange, red and purple was deeper than before, and the more I watched the better it became.
 
-{% figure hanoi-halong-bay--066.jpg landscape %}Halong Bay at dawn{% endfigure %}
+{% figure hanoi-halong-bay--066.jpg landscape %}
+Halong Bay at dawn
+{% endfigure %}
 
-{% figure hanoi-halong-bay--067.jpg landscape %}Halong Bay at dawn{% endfigure %}
+{% figure hanoi-halong-bay--067.jpg landscape %}
+Halong Bay at dawn
+{% endfigure %}
 
-{% figure hanoi-halong-bay--070.jpg landscape %}Halong Bay and the Dragon Pearl boat at dawn{% endfigure %}
+{% figure hanoi-halong-bay--070.jpg landscape %}
+Halong Bay and the Dragon Pearl boat at dawn
+{% endfigure %}
 
 I'm not a morning person, especially this early, and I was soon fast asleep again. But at 7am Sam was up and out, taking a morning swim around the boat. Breakfast this morning was lighter, and without my staple pho. We talked about dawn with the other couples, none of them had seen it, some had woken at 6am and deemed, “no sunrise this morning”, but were astounded when they saw our pictures.
 
@@ -19,7 +25,9 @@ I'm not a morning person, especially this early, and I was soon fast asleep agai
 
 Our itinerary was short; we were headed back to the harbour for midday. We tidied our rooms, checked out and settled our drinks bills, with one last meal ordered a la carte. We had a few last moments to relax and take in the scenery of Bai Tu Long bay, although today the rain was lashing down and it really was dreary.
 
-{% figure hanoi-halong-bay--072.jpg portrait %}Richard, watching the beautiful views go by{% endfigure %}
+{% figure hanoi-halong-bay--072.jpg portrait %}
+Richard, watching the beautiful views go by
+{% endfigure %}
 
 Once more, we had an opportunity to thank our crew (and tip them), and then it was time to go. We donned complimentary ponchos and clambered aboard the small blue boat in the rain, with its wet plastic seats, and chugged slowly over to the jetty where our trip really did end. We said our goodbyes and boarded the mini bus for the 4 hour long, arduous journey back to Hanoi.
 
@@ -39,6 +47,8 @@ The opening cocktails were scrumptious. A far east caipirinha made with sake, le
 
 Sam's desire to eat soft shelled crab was thwarted again, as the starter was unavailable. An apple, scallop and vermicelli fried cake was a tasty alternative, and I tucked into a clam and lemongrass concoction. For mains I devoured a huge fried Red Snapper fish (deboned for me on Sam's request), but it was garnished with a very bitter fresh herb and lacked any sauces. Samantha had a crab and vermicelli noodle main, which she enjoyed.
 
-{% figure hanoi-halong-bay--074.jpg landscape %}Clam and Lemongrass starter at Ly Club{% endfigure %}
+{% figure hanoi-halong-bay--074.jpg landscape %}
+Clam and Lemongrass starter at Ly Club
+{% endfigure %}
 
 All in all the food was good, but it didn't quite meet the standards we expected, or the price tag. We asked the restaurant to call us a taxi home, and we were whisked through Saturday night Hanoi, past the lake and many dressed up and scantily clad Hanoians out for the night. But we called it a night, and quickly fell asleep at our hotel. I left the iPad open on the desk, connected to the wifi it was ever so slowly backing up our recent swathe of Vietnam pictures.

--- a/source/_posts/hanoi-and-halong-bay-vietnam/5.md
+++ b/source/_posts/hanoi-and-halong-bay-vietnam/5.md
@@ -15,21 +15,29 @@ The Lonely Planet described what we were missing. Even a Google Image search doe
 
 The mausoleum is meant to be lotus shaped, and I can see how that might be the case, but its rigid cuboid marbleness dominates, resembling the mausoleums of other famous communists; most notably Lenin. And this was all against his desires to have a simple cremation.
 
-{% figure hanoi-halong-bay--075.jpg landscape %}Ho Chi Minh's mausoleum{% endfigure %}
+{% figure hanoi-halong-bay--075.jpg landscape %}
+Ho Chi Minh's mausoleum
+{% endfigure %}
 
 ## Ho Chi Minh museum
 
 At least that wasn't all there was to do here. Instead we visited the Ho Chi Minh museum, via the “One Pillar Pagoda” (built in 1054 but destroyed by the French in 1954 and subsequently rebuilt). The museum itself is a grand affair, a bold white edifice that oozes communism; engraved with the hammer and sickle and flying the Vietnamese flag proudly.
 
-{% figure hanoi-halong-bay--081.jpg portrait %}Ho Chi Minh museum{% endfigure %}
+{% figure hanoi-halong-bay--081.jpg portrait %}
+Ho Chi Minh museum
+{% endfigure %}
 
 Inside we checked our bags through security and began looking around. The first exhibit was a temporary one and it showcased modern Vietnam and Laos relations. Hmm, everything is in Vietnamese, who are these people? Perhaps we need a guide. We enquired, and waited 20 minutes for an English speaking guide, and then gave up. Luckily enough, beyond the first floor, the main body of the museum is in English too.
 
 In the foyer a bronze Ho Chi Minh statue greeted us. An elderly guy, led by what I presume were his sons, jostled to stand proudly beneath it and have his photo taken. The museum is circular, and we quietly wandered in a clockwise direction learning about Ho Chi Minh's early life, his many names, his many guises, his imprisonments and the following appeals in Hong Kong. Many copies of his letters are on show, and the stirring appeal to the Vietnamese people, written in English, was a fascinating read. “To the revolution…” it begun. Powerful, forceful writing in one of the five languages he could speak.
 
-{% figure hanoi-halong-bay--077.jpg landscape %}Bronze statue of Ho Chi Minh{% endfigure %}
+{% figure hanoi-halong-bay--077.jpg landscape %}
+Bronze statue of Ho Chi Minh
+{% endfigure %}
 
-{% figure hanoi-halong-bay--078.jpg landscape %}To the revolution...{% endfigure %}
+{% figure hanoi-halong-bay--078.jpg landscape %}
+To the revolution...
+{% endfigure %}
 
 Exhibits included samples from his cave dwelling where the revolution was devised and extracts from his prison diary. As we wander around, he grows up, becomes prominent, overthrows the French, unites the country, and begins the fight against the American invasion, dying before he could see his country united once more. It reminded me of earlier discussions about the war in Phong Nha and a suggestion that the Americans had fought idealistically against communism, whilst the Vietnamese fought for nationalism.
 
@@ -43,9 +51,13 @@ It's a four storey building with lime green walls, downstairs there's a delicate
 
 Did I mention the food yet? Well, I should have, because it's fantastic. Some of the best food we had in all of Vietnam. Smoothies and iced coffee accompanied stir fried duck and Sam's scrumptious bamboo beef, a meal she still hasn't stopped raving about. For dessert the mango cheeses (sic) cake was too eye-catching to pass up.
 
-{% figure hanoi-halong-bay--082.jpg landscape %}Beef in bamboo, at Koto{% endfigure %}
+{% figure hanoi-halong-bay--082.jpg landscape %}
+Beef in bamboo, at Koto
+{% endfigure %}
 
-{% figure hanoi-halong-bay--084.jpg portrait %}Iced Vietnamese coffee at Koto{% endfigure %}
+{% figure hanoi-halong-bay--084.jpg portrait %}
+Iced Vietnamese coffee at Koto
+{% endfigure %}
 
 ## Temple of Literature
 
@@ -53,19 +65,27 @@ Leaving the air-conditioned haven of KOTO, we once again embraced Hanoi's street
 
 From the great portico, we appeared within an enclosed garden. To the left and right were ponds bearing lotus plants, and brilliant complicated topiary, guarded with ugly red tape. Beneath the first covered building we hid from the sun, already sweltering, the sweat running down my back. A placard explained the history of this ancient Vietnamese architecture. It all remind me very much of the Hue citadel.
 
-{% figure hanoi-halong-bay--087.jpg landscape %}Dragons at the Temple of Literature{% endfigure %}
+{% figure hanoi-halong-bay--087.jpg landscape %}
+Dragons at the Temple of Literature
+{% endfigure %}
 
 Beyond lay another garden, and through another the Khue Van pavilion was a large pond, surrounded by 82 stelae, each different and dedicated to an early scholar. What's a stelae? In this case it's a large stone slab with Chinese text, sitting atop a tortoise, one of Vietnam's holy creatures; they show everlasting respect to talent. Around the pond were well tended flowers, where tiny birds played.
 
 In another courtyard rooms were now souvenir shops, and a red roofed temple housed a bronze stork and tortoise. Beautiful Vietnamese girls in fantastic dresses wandered about the temples, closely followed by their photographers, and watched by crooning old men. No doubt the photos were for a special occasion, but only a couple were obviously weddings. Hidden alleyways on the left and right led the way to the final temple.
 
-{% figure hanoi-halong-bay--086.jpg landscape %}Paul in the courtyard at the Temple of Literature{% endfigure %}
+{% figure hanoi-halong-bay--086.jpg landscape %}
+Paul in the courtyard at the Temple of Literature
+{% endfigure %}
 
-{% figure hanoi-halong-bay--096.jpg landscape %}Posing for wedding photos{% endfigure %}
+{% figure hanoi-halong-bay--096.jpg landscape %}
+Posing for wedding photos
+{% endfigure %}
 
 This two floored temple was filled with the sounds of traditional music, and upstairs three statues of former kings basked in red light. Our favourite aspect? The huge fans that kept us cool, and momentarily stopped the hot sweats. Subtly, trying to remain respectful, I directed the cool breeze up my shirt. Ahh, bliss.
 
-{% figure hanoi-halong-bay--094.jpg landscape %}Keeping cool by the fan{% endfigure %}
+{% figure hanoi-halong-bay--094.jpg landscape %}
+Keeping cool by the fan
+{% endfigure %}
 
 ## Shopping in Hanoi
 
@@ -79,4 +99,6 @@ Eager for more shopping, we found Hanoi's night market, a single long street fil
 
 I left Sam to do a little more shopping while I sought a restaurant for dinner. We chose Green Mango, small, chic and clearly only frequented by foreigners. A guard sat outside. I downed a whisky and honey cocktail waiting for Sam to arrive. My meal was fairly average, but Sam loved her spring rolls. With my carbonara pizza in a doggy bag, we called it a night.
 
-{% figure hanoi-halong-bay--097.jpg landscape %}Spring roll starter at Green Mango{% endfigure %}
+{% figure hanoi-halong-bay--097.jpg landscape %}
+Spring roll starter at Green Mango
+{% endfigure %}

--- a/source/_posts/hanoi-and-halong-bay-vietnam/6.md
+++ b/source/_posts/hanoi-and-halong-bay-vietnam/6.md
@@ -11,18 +11,26 @@ As might be expected, most of the morning was spent packing. Sam worked her magi
 
 We used the Lonely Planet's coffee suggestions to find a hidden coffee shop, Cafe Pho Co. Along 'linen street', through a linen shop, out the back into a courtyard, it felt like we were intruding on someone's home; it probably was someone's home, but we certainly weren't intruding. A four storey apartment, certain parts were dedicated to the cafe. Just as we looked lost a girl approached us with a menu, we ordered and she motioned for us to go up the stairs. Two flights of stairs, and a metal spiral staircase later, we were sitting on traditional blue plastic seats with views out across Hoam Kiem lake. Sam bravely ordered an egg white coffee, which was interesting, but not my cup of tea. Pun intended.
 
-{% figure hanoi-halong-bay--099.jpg landscape %}Coffee at Cafe Pho Co, egg white coffee on the left{% endfigure %}
+{% figure hanoi-halong-bay--099.jpg landscape %}
+Coffee at Cafe Pho Co, egg white coffee on the left
+{% endfigure %}
 
 We were still on the lookout for the duvet cover we'd seen on our boat, and linen street seemed like a good place to look. We left many a shopkeeper believing they were about to make a sale, but nothing was quite right.
 
 Still hungry for food, we stopped at our favourite Joma for a drink and snack. I devoured a tuna melt and tried the interesting 'London fog' tea, earl grey with vanilla. Alas, Sam didn't want to rest and do nothing. We had more things to buy!
 
-{% figure hanoi-halong-bay--101.jpg landscape %}A typical old Hanoi street{% endfigure %}
+{% figure hanoi-halong-bay--101.jpg landscape %}
+A typical old Hanoi street
+{% endfigure %}
 
-{% figure hanoi-halong-bay--103.jpg landscape %}A street vendor, selling cleaning products as she goes{% endfigure %}
+{% figure hanoi-halong-bay--103.jpg landscape %}
+A street vendor, selling cleaning products as she goes
+{% endfigure %}
 
 Shopping once more, we found chopsticks and a box, another table runner, and some quite excellent Vietnamese propaganda posters, “Vietnam — the hidden charm” one proclaims. Our final stop was Huong Mai, a coffee store with twenty varieties of coffee bean in plastic tubs, like a children's sweet shop. Over the course of an hour we tried four different beans and left with bags of Culi, Moka and Kopi Lumak (Weasel coffee).
 
-{% figure hanoi-halong-bay--105.jpg portrait %}Huong Mai coffee menu{% endfigure %}
+{% figure hanoi-halong-bay--105.jpg portrait %}
+Huong Mai coffee menu
+{% endfigure %}
 
 At the hotel we packed our new purchases, with Mary Poppins like abilities, donned our walking boots for the flight and took the 3pm taxi to Hanoi airport. Goodbye crazy motorcyclists, crazy roads, frenetic Hanoi, charming Vietnam; you've been phenomenal.

--- a/source/_posts/hoi-an-vietnam.md
+++ b/source/_posts/hoi-an-vietnam.md
@@ -16,7 +16,9 @@ page: 1
 
 To Vietnam, from Brighton. One train, three flights and a taxi transfer, over 24 hours. With Emirates, we flew from Gatwick to Dubai, we spotted the world's tallest building from the airport, and then on, to Saigon, and a very tight connection to Da Nang, which included our visa applications. We arrived in Hoi An, and our hotel, at midnight, and we relished a shower and a comfortable bed.
 
-{% figure hoi-an-113.jpg landscape %}Our comfortable bed at Life Heritage Resort{% endfigure %}
+{% figure hoi-an-113.jpg landscape %}
+Our comfortable bed at Life Heritage Resort
+{% endfigure %}
 
 ## Life Heritage Resort
 
@@ -26,9 +28,13 @@ The travelling took its toll, three flights a train and a taxi and we were exhau
 
 Dainty, we had our breakfast, the usual coffee and fruit juices, the more exotic fruits — mango, dragonfruit, pineapple, some noodles (I love noodles for breakfast) and various mini breads. We sat on the Senses restaurant balcony and overlooked the river. A motor boat chugged past, followed by a man in a pyramidal straw hat, rowing his small thin wooden boat. Calm, wonderful.
 
-{% figure hoi-an-115.jpg landscape %}Our view from breakfast{% endfigure %}
+{% figure hoi-an-115.jpg landscape %}
+Our view from breakfast
+{% endfigure %}
 
-{% figure hoi-an-116.jpg landscape %}Breakfast - Noodles, Egg and Dragonfruit{% endfigure %}
+{% figure hoi-an-116.jpg landscape %}
+Breakfast - Noodles, Egg and Dragonfruit
+{% endfigure %}
 
 The skies were clear, a relief after all the weather forecasts that suggested constant storms and downpours. It is of course the start of the rainy season. And Hoi An is known to suffer badly, the river often rising 1m, and more recently, 2m causing havoc with the bohemian town. The humidity is however overbearing, a constant sauna, the only break being our dry air-con, whirring away to keep our room comfy at 25C. I'm not sure how we'll cope without it later in the holiday.
 
@@ -42,11 +48,17 @@ Moving slowly onwards, smiling at the shopkeepers urging me into their stores, b
 
 Only a small town, the roads are utterly ridiculous. As one guide put it, the road markings are decorative. People mostly stick to one side of the road, mostly, it's more guidance. At cross roads you blindly drive through, don't stop whatever you do, but beep your horn to let everyone know you're coming. Red scooters, black motorbikes, everyone wearing a small helmet, it all seems to just work, the meandering is never ending, it just ebbs and flows. Cars passing bikes, passing scooters, dodging cyclists, avoiding pedestrians who are walking around street dealers; four levels deep overtaking on a road that is wide enough for two cars. I couldn't help but smile, this was insane.
 
-{% figure hoi-an-119.jpg landscape %}Bridge in Hoi An{% endfigure %}
+{% figure hoi-an-119.jpg landscape %}
+Bridge in Hoi An
+{% endfigure %}
 
-{% figure hoi-an-123.jpg portrait %}A local and her motorbike{% endfigure %}
+{% figure hoi-an-123.jpg portrait %}
+A local and her motorbike
+{% endfigure %}
 
-{% figure hoi-an-127.jpg landscape %}Motorbikes and tailors{% endfigure %}
+{% figure hoi-an-127.jpg landscape %}
+Motorbikes and tailors
+{% endfigure %}
 
 I did a small lap of the old town, enough to take in my surroundings, to absorb the heat, to build up a sweat and to happily return to the hotel's pool to cool off. “How old are you? 15?” the bar attendant asked, aghast at my real age, and surprised I was married.
 
@@ -54,7 +66,9 @@ Sam emerged from her slumber and we chillaxed by the stone shallow pool, with it
 
 Storm clouds grew in the distance, the rumble of thunder got louder, and closer, an ever threatening presence. But the rain never came, it passed us by, the sun stayed out and we remained in the pool.
 
-{% figure hoi-an-130.jpg landscape %}Poolside snacks - spring rolls, beef and prawns{% endfigure %}
+{% figure hoi-an-130.jpg landscape %}
+Poolside snacks - spring rolls, beef and prawns
+{% endfigure %}
 
 ## Evening in Hoi An
 
@@ -62,13 +76,17 @@ That evening, a Sunday night, we headed out into town, this time together. The e
 
 Passing the market place on the way into town, old women sat in the road, their fresh fish sitting in upturned lids and baskets. Live shrimp hopped from one basket to another, amidst piles of fresh fruit. The smell of durian in the air, pungent and unmistakeable. Bikes whizzed by, pulling across in front of us to buy 30,000 VND of this, or that, noodles, vegetables, meat, and so on.
 
-{% figure hoi-an-132.jpg portrait %}A purple evening in Hoi An{% endfigure %}
+{% figure hoi-an-132.jpg portrait %}
+A purple evening in Hoi An
+{% endfigure %}
 
 On the skyline another storm was brewing, and this one was certainly heading right for us. We explored the little Japanese bridge at the far end of town, again, with red lanterns and pretty lights. The atmosphere was buzzing, a camera crew were waiting, and there were chairs lining the river. Something was going to happen but we had no idea what. And we wouldn't find out either.
 
 Earlier that night, when I'd suggested perhaps we should take the wet weather gear, Sam casually replied, “No, we'll just get wet”. Oh did she rue those words. As the heavens opened and the deluge began, we hopped from shop to shop hoping to find the restaurant we were looking for. Not quite sure how the road map married up to the mish-mash of mini streets and paths we were exploring.
 
-{% figure hoi-an-135.jpg landscape %}An evening on the river in Hoi An, as the rain starts{% endfigure %}
+{% figure hoi-an-135.jpg landscape %}
+An evening on the river in Hoi An, as the rain starts
+{% endfigure %}
 
 ## Morning Glory restaurant
 
@@ -80,9 +98,13 @@ Feeling almost full, clearly our appetite hadn't yet adapted to the climate, wat
 
 A smokey aubergine dish with sticky rice, the smokey flavour matched the flavouring used in bacon crisps, and I took an instant dislike to it. The dish was tasty, just not to my tastes. The second dish was the venerable Vietnamese Pho, beef with fresh herbs in a soupy broth. Really quite delicious. Lovely.
 
-{% figure hoi-an-136.jpg landscape %}An open kitchen at Morning Glory{% endfigure %}
+{% figure hoi-an-136.jpg landscape %}
+An open kitchen at Morning Glory
+{% endfigure %}
 
-{% figure hoi-an-140.jpg landscape %}Our first authentic Vietnamese Pho{% endfigure %}
+{% figure hoi-an-140.jpg landscape %}
+Our first authentic Vietnamese Pho
+{% endfigure %}
 
 ## Cocktails at Q
 
@@ -90,20 +112,30 @@ We couldn't eat any more, but the rain kept pouring. We got the bill and paid ve
 
 A whiskey based Saigon Express for me and a chocolate daiquiri for Sam, accompanied with dragonfruit crisps, which, strangely, we could eat now. As the drinks went down and the chillout soundtrack played, the rain paused and we explored night time Hoi An again.
 
-{% figure hoi-an-141.jpg landscape %}A Saigon Express cocktail at Q Bar{% endfigure %}
+{% figure hoi-an-141.jpg landscape %}
+A Saigon Express cocktail at Q Bar
+{% endfigure %}
 
-{% figure hoi-an-142.jpg landscape %}It's wet out{% endfigure %}
+{% figure hoi-an-142.jpg landscape %}
+It's wet out
+{% endfigure %}
 
 Back towards the Japanese bridge, where the rain had rudely interrupted us, and there was a concert in full swing. On stage a guy dressed as Pikachu was rapping, there was much jumping, shouting and light flashing, in the sky and on the stage.
 
 We crossed over the river and watched from afar, taking pictures of Hoi An at night, looking beautiful with its lanterns all reflecting in the water. On the bridge swathes of tourists; western, chinese, vietnamese alike, took their photos alongside the lanterns and the views. A warm, relaxing and safe atmosphere.
 
-{% figure hoi-an-146.jpg landscape %}Lanterns in Hoi An{% endfigure %}
+{% figure hoi-an-146.jpg landscape %}
+Lanterns in Hoi An
+{% endfigure %}
 
-{% figure hoi-an-148.jpg portrait original %}A child selling lanterns, sitting with the faeries{% endfigure %}
+{% figure hoi-an-148.jpg portrait original %}
+A child selling lanterns, sitting with the faeries
+{% endfigure %}
 
 The sky threatened again, and not wishing to become drenched once more, we headed back. The skies opened just as we got to our hotel, perfect timing.
 
 Before bed we nipped about the hotel, snapping photos of the heavy rain and the large toads that now occupied the paths.
 
-{% figure hoi-an-151.jpg landscape %}Grumpy moustache toad{% endfigure %}
+{% figure hoi-an-151.jpg landscape %}
+Grumpy moustache toad
+{% endfigure %}

--- a/source/_posts/hoi-an-vietnam/2.md
+++ b/source/_posts/hoi-an-vietnam/2.md
@@ -17,13 +17,17 @@ But our journey was without any hairy moments, and beyond the initial terror, it
 
 With bikes parked under a shelter, a compulsory 10,000 VND charge, we collapsed on the shaded sand, beneath towering coconut trees. Of course we checked there were no dangerous, ripening coconuts set to fall on us.
 
-{% figure hoi-an-152.jpg landscape %}Cua Dai beach{% endfigure %}
+{% figure hoi-an-152.jpg landscape %}
+Cua Dai beach
+{% endfigure %}
 
 The sand beyond this shaded retreat was roasting, sandals were the only option. Up the coast, to the north, you could see Da Nang and the day's storm clouds forming over the mountains. The sea was calm, but the waves large enough to surf on, crashing into the coast with great force. Force enough to strip me of my sandals and almost my shorts, I held onto both, and, as a weak swimmer, opted for only mild paddling from thereon.
 
 We chilled beneath the coconut leaves for an hour or so, before retreating to the nearby Hoi An beach resort, a luxury hotel for a spot of food and a cheeky dip in their pool. A serene setting alongside the river, we watched as men fished with great orange nets. Still somewhat delicate, or just dehydrated, we stuck to simple western salads and fresh mango juice. (Oh the mangos, the succulent tasty mangos!)
 
-{% figure hoi-an-158.jpg landscape %}Fishing next to Hoi An beach resort{% endfigure %}
+{% figure hoi-an-158.jpg landscape %}
+Fishing next to Hoi An beach resort
+{% endfigure %}
 
 Freshened up, glowing slightly red from the sun, we hopped back on the bikes and took the scenic route home, south towards Cam Thanh. We cycled past a small local school, where the gates were being painted pink, past rice paddies, through small villages, alongside scant oxen, and mini corn harvesters, and past an out of the way but rather large graveyard, with modern looking gravestones.
 
@@ -33,11 +37,17 @@ With another storm cloud looming, we cycled back along Tran Nhan Tong. With a bi
 
 That evening Sam wandered out in to Hoi An to purchase some made to measure dresses and coats at fabulous prices. I meanwhile meandered around taking photos, using the tripod to capture some night shots.
 
-{% figure hoi-an-161.jpg landscape %}Hoi An market{% endfigure %}
+{% figure hoi-an-161.jpg landscape %}
+Hoi An market
+{% endfigure %}
 
-{% figure hoi-an-160.jpg landscape %}Fresh fish at the market{% endfigure %}
+{% figure hoi-an-160.jpg landscape %}
+Fresh fish at the market
+{% endfigure %}
 
-{% figure hoi-an-162.jpg landscape %}Buying this evening's dinner{% endfigure %}
+{% figure hoi-an-162.jpg landscape %}
+Buying this evening's dinner
+{% endfigure %}
 
 Despite bumping into each other twice on our own little missions, we reconvened at the bridge to go for dinner at Mango Mango, a highly recommended restaurant that fused western and vietnamese dishes.
 
@@ -45,12 +55,18 @@ There was a hard sell on the 800,000 five course set menu, we instead opted for 
 
 Despite the rave reviews we were disappointed by the meal. The portion sizes were way off, when the starter appeared it was greeted with, “that's a starter?”. I couldn't possibly have eaten both the starter and main, and being a starter, I left some of it in anticipation of the later duck course. Sadly this didn't taste great, was huge, and in the hot humid heat I really didn't fancy the stew they served up. Ah well. The french folks next to us seamed to enjoy their meals much more. (I do believe Sam is now suffering, a day later, from the after effects of this).
 
-{% figure hoi-an-167.jpg portrait %}A table with a view at Mango Mango{% endfigure %}
+{% figure hoi-an-167.jpg portrait %}
+A table with a view at Mango Mango
+{% endfigure %}
 
-{% figure hoi-an-170.jpg landscape %}Leg of duck confit{% endfigure %}
+{% figure hoi-an-170.jpg landscape %}
+Leg of duck confit
+{% endfigure %}
 
 Another night, another downpour, but this time we came prepared, with huge golf umbrellas. And once more I relaxed in Q with a mojito, Sam elsewhere arranging her clothe purchases.
 
 The streets turned to rivers and in the dark humid wet we skipped home, umbrellas keeping us mostly dry.
 
-{% figure hoi-an-171.jpg landscape %}Lanterns at Q Bar{% endfigure %}
+{% figure hoi-an-171.jpg landscape %}
+Lanterns at Q Bar
+{% endfigure %}

--- a/source/_posts/hoi-an-vietnam/3.md
+++ b/source/_posts/hoi-an-vietnam/3.md
@@ -15,11 +15,15 @@ At the Hai Cam cafe in old town Hoi An for 8am, we joined Lindsey from Chicago f
 
 Tra Que is basically a large herb farm where no pesticides are used. Susan picked out the thai basil, with its aniseed flavouring; lemon basil, which was very lemony; row after row of spring onion; tall lemongrass; vietnamese mint, very peppery; sweet potatoes, the leaves can be used in salad; papaya trees, small but with large fruits; water spinach with enormous leaves; and some rogue 'English' mint, the mint we already know, and the type used in mojitos.
 
-{% figure hoi-an-174.jpg landscape %}Tra Que herb garden{% endfigure %}
+{% figure hoi-an-174.jpg landscape %}
+Tra Que herb garden
+{% endfigure %}
 
 We stopped at a family home for some refreshment. Complimentary water, ginger, sugar and small dark translucent vietnam basil seeds, it looked like frog spawn, and before telling us what it was, Susan joked that's what it actually was. We finished up with some lessons in banana leaf jewellery.
 
-{% figure hoi-an-176.jpg portrait %}Frog spawn drink{% endfigure %}
+{% figure hoi-an-176.jpg portrait %}
+Frog spawn drink
+{% endfigure %}
 
 ### Market tour
 
@@ -35,15 +39,25 @@ We had just a couple more things to pick up for the cooking. Some more herbs, so
 
 Sam picked up a weird looking vegetable, “Bitter melon”, Susan told us. We tried a bit, eugh, yes, that's bitter alright, but more like a pepper. A really bitter pepper.
 
-{% figure hoi-an-178.jpg landscape %}Freshly caught squid{% endfigure %}
+{% figure hoi-an-178.jpg landscape %}
+Freshly caught squid
+{% endfigure %}
 
-{% figure hoi-an-187.jpg landscape %}Susan posing with a banana flower{% endfigure %}
+{% figure hoi-an-187.jpg landscape %}
+Susan posing with a banana flower
+{% endfigure %}
 
-{% figure hoi-an-191.jpg landscape %}A bitter melon{% endfigure %}
+{% figure hoi-an-191.jpg landscape %}
+A bitter melon
+{% endfigure %}
 
-{% figure hoi-an-182.jpg landscape %}Green oranges{% endfigure %}
+{% figure hoi-an-182.jpg landscape %}
+Green oranges
+{% endfigure %}
 
-{% figure hoi-an-181.jpg portrait %}Buying fresh fruit{% endfigure %}
+{% figure hoi-an-181.jpg portrait %}
+Buying fresh fruit
+{% endfigure %}
 
 ### Cooking beef pho
 
@@ -61,9 +75,13 @@ We'd leave that broth cooking for a long while. Next we prepared some chilli, su
 
 Pho also needs rice noodles. We were shown how to make a rice noodle mix; soaking rice in water until translucent and then rigorously blending to form a thick but smooth white mixture. We spread this mixture thinly and evenly over muslin stretched across a pan of boiling water. One Vietnamese minute later and we had our cooked mixture. Skewering carefully with a bamboo stick, we lifted the noodle from the cooking drum onto a plate, carefully folding as instructed. A little bit of oil, and some lengthways slicing and we each had our noodles! Easy, interesting and exciting.
 
-{% figure hoi-an-200.jpg portrait %}Making rice noodles{% endfigure %}
+{% figure hoi-an-200.jpg portrait %}
+Making rice noodles
+{% endfigure %}
 
-{% figure hoi-an-202.jpg landscape %}Rice noodles nearly ready{% endfigure %}
+{% figure hoi-an-202.jpg landscape %}
+Rice noodles nearly ready
+{% endfigure %}
 
 While cooking, we snacked on the spare rice noodle circles, placed within a crunchy sesame seed rice cake and dipped in a chilli sauce.
 
@@ -71,17 +89,23 @@ While cooking, we snacked on the spare rice noodle circles, placed within a crun
 
 The appetiser dish was lemongrass shrimp. With a wooden pestle and mortar we ground up lemongrass, chilli, shallots, sugar, salt and pepper. Then we mixed in the uncooked shrimps and wrapped carefully in several layers of banana leaf, all ready to be barbecued. Really easy and simply scrumptious, we will be making this a lot!
 
-{% figure hoi-an-203.jpg landscape %}Lemongrass Shrimp{% endfigure %}
+{% figure hoi-an-203.jpg landscape %}
+Lemongrass Shrimp
+{% endfigure %}
 
 ### Clay pot fish
 
 On to the next dish, clay pot fish, or mackerel with fresh dill and turmeric. We split the tasks on this one, I ground up the turmeric, and ran the risk of staining my clothes, Sam chopped the mackerel into 1cm cubes and Lindsey chopped up the dill (which comes from north Vietnam where it's cooler). With the smashed up turmeric we again added salt, sugar, pepper, and the usual, before cooking in oil. I stirred the oil continuously until it came to the boil, then added a few cups of water the fish and the dill, and left it to cook on the gas hob. It became quite stew like, and the chef later garnished with nuts before serving
 
-{% figure hoi-an-207.jpg landscape %}Prepairing claypot fish{% endfigure %}
+{% figure hoi-an-207.jpg landscape %}
+Prepairing claypot fish
+{% endfigure %}
 
 By now our Pho broth was cooked up and ready to eat. Pouring the broth over our thinly sliced beef cooked it instantly. We combined it with our noodles and a variety of fresh herbs we'd picked earlier in the day. It's the fresh herbs that make it special, such a powerful fresh flavour. We put chillies on top and washed it all down with Tiger beer.
 
-{% figure hoi-an-211.jpg landscape %}Our beef Pho{% endfigure %}
+{% figure hoi-an-211.jpg landscape %}
+Our beef Pho
+{% endfigure %}
 
 ### Chicken salad
 
@@ -93,15 +117,23 @@ The chefs went away and cooked this while we relaxed by/in the pool. We drunk ou
 
 We gathered around the table to eat our now ready salad, mountains of delicious food. Once again, we picked from a variety of herbs to garnish our salad and build its flavour. A useful exercise, though we made the mistake of not snapping the water spinach stalks.
 
-{% figure hoi-an-212.jpg landscape %}Banana flower salad{% endfigure %}
+{% figure hoi-an-212.jpg landscape %}
+Banana flower salad
+{% endfigure %}
 
-{% figure hoi-an-213.jpg landscape %}Samantha, Me, Susan and Lindsey{% endfigure %}
+{% figure hoi-an-213.jpg landscape %}
+Samantha, Me, Susan and Lindsey
+{% endfigure %}
 
 With the day edging on, the clouds began to appear, build up and look threatening. We moved to the main restaurant to eat our final dish, the fish in clay pot, and to pick up aprons, recipes and tidbit utensils.
 
-{% figure hoi-an-214.jpg landscape %}Fish and dill, with rice{% endfigure %}
+{% figure hoi-an-214.jpg landscape %}
+Fish and dill, with rice
+{% endfigure %}
 
-{% figure hoi-an-215.jpg landscape %}Water lilies at Red Bridge cooking school{% endfigure %}
+{% figure hoi-an-215.jpg landscape %}
+Water lilies at Red Bridge cooking school
+{% endfigure %}
 
 With the sky ready to rain down on us, we skipped the boat ride back home and took the minibus back, changing into our wet weathers on the way. We said goodbye to Lindsey, and I left Sam to revisit all the clothing shops to pickup her orders, try things on and make adjustments.
 
@@ -115,7 +147,9 @@ Our final night in Hoi An, we were ready to move on. But this town really is lov
 
 We took in the sights once more, and ticked the boxes that hadn't been ticked: the small market over the bridge in An Hoi; crossing the Japanese bridge and visiting that part of town; buying stylish trinkets. For once it wasn't raining, the moon and the stars were out whilst a storm in the distance occasionally dazzled us with a light show.
 
-{% figure hoi-an-217.jpg landscape %}Lanterns on the bridge{% endfigure %}
+{% figure hoi-an-217.jpg landscape %}
+Lanterns on the bridge
+{% endfigure %}
 
 ### Cargo Club restaurant
 
@@ -129,4 +163,6 @@ We wandered the streets back to the Life Heritage Resort on the edge of town, pa
 
 Goodbye Hoi An, you're too charming.
 
-{% figure hoi-an-218.jpg landscape %}Lanterns hanging from a banyan tree{% endfigure %}
+{% figure hoi-an-218.jpg landscape %}
+Lanterns hanging from a banyan tree
+{% endfigure %}

--- a/source/_posts/honeymoon-epilogue-the-journey-home.md
+++ b/source/_posts/honeymoon-epilogue-the-journey-home.md
@@ -24,7 +24,9 @@ After hanging around amongst thousands of mosquitos waiting for the check-in des
 
 We took the 8:25am Air Asia flight to the familiar Suvarnabhumi airport in Bangkok, touching down an hour later.
 
-{% figure honeymoon-247.jpg landscape %}Suvarnabhumi airport, Bangkok{% endfigure %}
+{% figure honeymoon-247.jpg landscape %}
+Suvarnabhumi airport, Bangkok
+{% endfigure %}
 
 One last pad thai and mango shake before we leave and then onto our 12:25pm flight home. 11 hours to Heathrow, London.
 
@@ -42,11 +44,15 @@ The next task: getting home. Paris would have been easy - trains, ferries, etc.,
 
 At the airport no-one really knew what to do. Some people went through passport control by mistake, the rest of us were guided by staff around in circles a couple of times--up and down escalators before finding us a departure lounge. A Thai airways representative will be with you shortly.
 
-{% figure honeymoon-251.jpg landscape %}Stuck in Frankfurt{% endfigure %}
+{% figure honeymoon-251.jpg landscape %}
+Stuck in Frankfurt
+{% endfigure %}
 
 Two hours later and we had no representative and no more information. We listened to savvy travellers organising trains or car rentals, we wanted to stick with them, but whilst Sam was grabbing provisions they made a dash for it.
 
-{% figure honeymoon-253.jpg portrait %}No news, no-one’s going anywhere{% endfigure %}
+{% figure honeymoon-253.jpg portrait %}
+No news, no-one’s going anywhere
+{% endfigure %}
 
 On our own again we heard the Lufthansa spokeswoman give us the first tidbits of information. “Everything that could have gone wrong has gone wrong”. A lighting conference meant that all hotels were booked up and that we’d most likely be staying on Frankfurt airport’s floors. At 10am tomorrow in C13 we will give you more information, food will arrive shortly. If you do go, please leave your luggage here so we don’t have to check them through security again.
 
@@ -58,4 +64,6 @@ Frankfurt’s neon skyline looked gorgeous against a crisp clear night.
 
 The hotel was a poor IBIS imitation, two singles were pushed together badly to make a double, there was no complimentary shampoo and above all, no tea or coffee! Instead we gobbled up the duty free Toblerone. At least we had a bed and relative comfort.
 
-{% figure honeymoon-255.jpg landscape %}A room for the night{% endfigure %}
+{% figure honeymoon-255.jpg landscape %}
+A room for the night
+{% endfigure %}

--- a/source/_posts/honeymoon-epilogue-the-journey-home/2.md
+++ b/source/_posts/honeymoon-epilogue-the-journey-home/2.md
@@ -17,11 +17,17 @@ On arrival we questioned where to go. “C13? Thai Airways - they are calling fo
 
 From a room with comfy leather chairs, power supplies and newspapers we were escorted to a corridor featuring a hard concrete floor and a broken escalator. This is where you’ll stay, we’ll get your food now. Coke, an apple and a marmalade sandwich. Those on the stranded Chinese flight had 30 euro meal vouchers.
 
-{% figure honeymoon-258.jpg landscape %}Airport beds{% endfigure %}
+{% figure honeymoon-258.jpg landscape %}
+Airport beds
+{% endfigure %}
 
-{% figure honeymoon-257.jpg landscape %}Waiting in a corridor{% endfigure %}
+{% figure honeymoon-257.jpg landscape %}
+Waiting in a corridor
+{% endfigure %}
 
-{% figure honeymoon-260.jpg landscape %}Cancelled{% endfigure %}
+{% figure honeymoon-260.jpg landscape %}
+Cancelled
+{% endfigure %}
 
 ## We can't stay here
 
@@ -69,13 +75,17 @@ Then into France, past hills of wind turbines, the sun set was clear, crisp and 
 
 In the Champagne region we stopped for food. My burger wasn’t cooked, it was red right through, I left feeling queasy, but nothing came of it. Typical that the worst chance of food poisoning, after being in Thailand for so long, came from a diner in France.
 
-{% figure honeymoon-261.jpg landscape %}Driving to Dieppe{% endfigure %}
+{% figure honeymoon-261.jpg landscape %}
+Driving to Dieppe
+{% endfigure %}
 
 Two petrol stops and we reached Dieppe four hours early at 2am, and we made it there ahead of the four that left an hour or so before us. With time to kill, we sat in the small cold waiting room and watched the latest Star Trek movie on a small laptop screen, with the volume up loud enough to annoy anyone trying to sleep (especially those sleeping on the pool table).
 
 Sam put on all the clothes she could to beat the cold -- shorts over trousers, three t-shirts, a jumper, a summer hat, a sarong, two pairs of socks. An assorted collection of summer clothes.
 
-{% figure honeymoon-263.jpg portrait %}Samantha, and her many layers{% endfigure %}
+{% figure honeymoon-263.jpg portrait %}
+Samantha, and her many layers
+{% endfigure %}
 
 ## Home stretch
 
@@ -85,9 +95,13 @@ The ferry itself was much bigger than expected, with two restaurants, many floor
 
 Those hours flew by as we laughed and joked with our new friends. Waving bye to France, we drank tea and coffee, ate fresh French croissants and watched the sun rise. We talked about weddings and hilarious speeches, university, jobs, our time out in Thailand and Songkran experiences. At times we laughed so much we cried and we celebrated the sight of England’s coastline. We were all so relieved to be almost home.
 
-{% figure honeymoon-269.jpg landscape %}Having fun on the home stretch{% endfigure %}
+{% figure honeymoon-269.jpg landscape %}
+Having fun on the home stretch
+{% endfigure %}
 
-{% figure honeymoon-267.jpg landscape %}Almost home{% endfigure %}
+{% figure honeymoon-267.jpg landscape %}
+Almost home
+{% endfigure %}
 
 England welcomed us with clear blue skies and a warm sun. Amanda was in New Haven to pick us up (20 mins from Brighton) (“Is that your sister?”). We said our farewells, so happy to have enjoyed the last four hours of our extended honeymoon.
 

--- a/source/_posts/honeymoon-part-1-phuket-thailand.md
+++ b/source/_posts/honeymoon-part-1-phuket-thailand.md
@@ -21,7 +21,9 @@ After an overnight stay at the Heathrow IBIS, a bus to the terminal, check-in an
 
 The location of our honeymoon was kept a tight lipped secret until the last moments; Sam believed we were headed for Japan.
 
-{% figure honeymoon-36.jpg landscape %}Reading our Thailand guide, on the outbound flight{% endfigure %}
+{% figure honeymoon-36.jpg landscape %}
+Reading our Thailand guide, on the outbound flight
+{% endfigure %}
 
 The 10 hour flight passed smoothly, and I wrote up our wedding day, much like this. Connect 4, some films and food passed the time.
 
@@ -33,18 +35,28 @@ The 1h30 Phuket flight felt instant, asleep on take off, awake on landing (with 
 
 Greeted with an iced tea, complete with star of anise and cooling face flannel, we checked in. The Pearl’s decoration and theme was a seamless fusion of metal sculpture, tin mining, wood, tools and luxury, all with an obsessive attention to detail.
 
-{% figure honeymoon-50.jpg portrait %}Indigo Pearl reception{% endfigure %}
+{% figure honeymoon-50.jpg portrait %}
+Indigo Pearl reception
+{% endfigure %}
 
-{% figure honeymoon-51.jpg landscape %}Luxurious Indigo Pearl{% endfigure %}
+{% figure honeymoon-51.jpg landscape %}
+Luxurious Indigo Pearl
+{% endfigure %}
 
 After a shower at the fitness centre (and a bug the size of my hand), our room was ready. WOW, the room was incredible. Lotus flowers sat on the super king sized bed, and the hotel’s theme continued; toilet roll holders were shaped like giant bolts, huge wooden sliding doors separated the bed and bathrooms, a large window into the bathroom from the bedroom was intriguing and there was a delicious yet subtle oriental smell of Jasmine and Champaka.
 
-{% figure honeymoon-37.jpg landscape %}Our room at Indigo Pearl{% endfigure %}
+{% figure honeymoon-37.jpg landscape %}
+Our room at Indigo Pearl
+{% endfigure %}
 
 Sleeping from 3pm until 5pm, we awoke starving. Too sleepy to venture out, we ordered room service. A serving of chicken satay, prawns in coconut, deep fried soft shelled crab and some quesadillas shortly arrived, it all looked and tasted gorgeous. The ever smiling and helpful Indigo Pearl staff had a surprise for us; complimentary exotic fruit platter, heart shaped chocolate desserts and a bottle of Champagne. Our jaws almost hit the floor.
 
-{% figure honeymoon-40.jpg landscape %}The best soft shelled crab we’ll ever eat{% endfigure %}
+{% figure honeymoon-40.jpg landscape %}
+The best soft shelled crab we’ll ever eat
+{% endfigure %}
 
-{% figure honeymoon-42.jpg landscape %}Complimentary dessert and champagne for our honeymoon{% endfigure %}
+{% figure honeymoon-42.jpg landscape %}
+Complimentary dessert and champagne for our honeymoon
+{% endfigure %}
 
 Perfectly sated and in paradise, we fell asleep to the thundering down pour of a tropical storm, and an air conditioner turned up full.

--- a/source/_posts/honeymoon-part-1-phuket-thailand/2.md
+++ b/source/_posts/honeymoon-part-1-phuket-thailand/2.md
@@ -9,17 +9,25 @@ page: 2
 
 13 hours later, 8am, and we were over any jet lag and ready for breakfast. Cereal, croissants, full English were all at the buffet, as expected. But there was also exotic jams (mango, pineapple, banana), beautiful fresh guava, papaya, water melon; lemongrass, mango and orange juices that tasted other worldly; eggs cooked however you wanted, cakes, freshly made waffles, pancakes, spicy Thai noodles, cheeses wrapped in banana leaves to keep them fresh, flavoured breads, salads and sautéed potatoes. And tea and coffee, of course.
 
-{% figure honeymoon-57.jpg portrait %}Samantha at the breakfast table{% endfigure %}
+{% figure honeymoon-57.jpg portrait %}
+Samantha at the breakfast table
+{% endfigure %}
 
-{% figure honeymoon-58.jpg landscape %}Industrial and multi-purpose Indigo Pearl cutlery{% endfigure %}
+{% figure honeymoon-58.jpg landscape %}
+Industrial and multi-purpose Indigo Pearl cutlery
+{% endfigure %}
 
 Having tried a bit of everything, we headed to the beach to check out our surroundings. Walking down the smooth sandy Nai Yang shore, we dipped our toes in the sea and found a wooden shanty dwelling with a couple of eateries and parasols to rent.
 
 Back at the hotel we spent the day by the pool, with its infinity ledge, jacuzzi, sun bathing spots (in the water) and built-in bar. The fresh juices, cocktails and shakes here are divine.
 
-{% figure honeymoon-43.jpg landscape %}The adult’s pool{% endfigure %}
+{% figure honeymoon-43.jpg landscape %}
+The adult’s pool
+{% endfigure %}
 
-{% figure honeymoon-44.jpg landscape %}Samantha finding out the stone edges of the pool are a bit hot{% endfigure %}
+{% figure honeymoon-44.jpg landscape %}
+Samantha finding out the stone edges of the pool are a bit hot
+{% endfigure %}
 
 ***
 
@@ -33,6 +41,10 @@ Come evening, post burger/mango and aubergine salad, we realised our sun lotioni
 
 Shoes off before entering (a Thai custom), we were seated with a view of the distant storm. Opting for the three course set menu we shared prawn crackers, green curry beef with lemongrass, soups with ginger and banana in coconut milk.
 
-{% figure honeymoon-53.jpg landscape %}Black Ginger at Indigo Pearl{% endfigure %}
+{% figure honeymoon-53.jpg landscape %}
+Black Ginger at Indigo Pearl
+{% endfigure %}
 
-{% figure honeymoon-54.jpg portrait %}Entrance to Black Ginger{% endfigure %}
+{% figure honeymoon-54.jpg portrait %}
+Entrance to Black Ginger
+{% endfigure %}

--- a/source/_posts/honeymoon-part-1-phuket-thailand/3.md
+++ b/source/_posts/honeymoon-part-1-phuket-thailand/3.md
@@ -15,8 +15,12 @@ Adamas looks out across the Nai Yang bay, a beautiful sea vista greets you when 
 
 The car rental was a Toyota Yaris, and I had to get used to driving an automatic. Phuket’s roads are well laid, and easy to drive. The difficult bit comes in dealing with the peculiar actions of other drivers and copious mopeds and bikes - often with 2 or 3 (or even a dog) riding along. Bikes with side cars would swerve out, without indication, and trucks carrying 20 people on the back would undertake if you weren’t breaking the speed limits. Down the unnecessarily winding road with hidden speed bumps, we arrived at Adamas, with a small sigh of relief.
 
-{% figure honeymoon-60.jpg portrait %}Our bedroom at Adamas{% endfigure %}
+{% figure honeymoon-60.jpg portrait %}
+Our bedroom at Adamas
+{% endfigure %}
 
 We chilled out in the lounge with a cocktail served in a pineapple, being sure to cover ourselves with anti-bug spray beforehand. After a spot of snooker, we had food at the bar, a tasty pad thai served in an egg net with prawns and ground nuts and Salmon with garlic and black pepper.
 
-{% figure honeymoon-63.jpg landscape %}Pineapple cocktails{% endfigure %}
+{% figure honeymoon-63.jpg landscape %}
+Pineapple cocktails
+{% endfigure %}

--- a/source/_posts/honeymoon-part-1-phuket-thailand/4.md
+++ b/source/_posts/honeymoon-part-1-phuket-thailand/4.md
@@ -9,23 +9,33 @@ page: 4
 
 Friday was a day of driving and Phuket exploration. Setting off early we hit the main roads at rush hour, complete with swarms of motorcyclists. A quick stop at the boat lagoon to check out the available tour options and to book Saturday’s day trip, then driving further south to Wat Chalong, our first temple experience.
 
-{% figure honeymoon-67.jpg portrait %}Wat Chalong, Phuket{% endfigure %}
+{% figure honeymoon-67.jpg portrait %}
+Wat Chalong, Phuket
+{% endfigure %}
 
 Hats and shoes off before going in, the ornate buildings with golden Buddha images were a cool sanctuary from the heat. Locals sat in a mermaid position, bowing towards the figures, burning incense and occasionally letting off firecrackers. Coconuts were on sale for 25B and stalls sold cheap clothes and ornaments. We avoided the hole in the ground toilets and returned to the air conditioned car, smartly parked under a tree in the shade.
 
-{% figure honeymoon-68.jpg landscape %}Girl praying inside Wat Chalong{% endfigure %}
+{% figure honeymoon-68.jpg landscape %}
+Girl praying inside Wat Chalong
+{% endfigure %}
 
-{% figure honeymoon-70.jpg landscape %}Coconuts, 25B each{% endfigure %}
+{% figure honeymoon-70.jpg landscape %}
+Coconuts, 25B each
+{% endfigure %}
 
 ## Big Buddha
 
 Back onto Phuket’s roads, a couple of U-turns and up a winding hill, we travelled to the Big Buddha. A 20 year old building project that puts an enormous statute atop of Phuket’s largest hill.
 
-{% figure honeymoon-71.jpg portrait %}Big Buddha, under construction{% endfigure %}
+{% figure honeymoon-71.jpg portrait %}
+Big Buddha, under construction
+{% endfigure %}
 
 At the top, in the midday sun, without any shadow, we took our photos, made a donation and read about the history. Huge sculptures sat around the base of the Buddha, waiting to be hoisted into place, the eyes went in in December.
 
-{% figure honeymoon-72.jpg portrait %}View from Big Buddha{% endfigure %}
+{% figure honeymoon-72.jpg portrait %}
+View from Big Buddha
+{% endfigure %}
 
 Part way down the hill we stopped at a small shack for lunch. It had a fantastic view of Karon beach. Coke, chicken with cashew nuts and a red curry with peanuts and chicken were our choices. Sam took some moments to snap flowers on the hillside, and a gecko that came down from the tree, before we made our way south.
 
@@ -33,15 +43,21 @@ Part way down the hill we stopped at a small shack for lunch. It had a fantastic
 
 Following the Lonely Planet guide, we found the recommended Kok Chang elephant safari. For 1000B each we enjoyed a one hour trek into the forest, to the top of the hill on the back of a charming elephant. The elephant’s hairs were itchy against my legs and on the way back down keeping balance and staying on was a bit of a challenge, although it felt much more sturdy and safe than riding a horse. The elephant’s mahout stopped half way and took some great shots of us.
 
-{% figure honeymoon-1.jpg landscape %}Paul and Sam on an elephant{% endfigure %}
+{% figure honeymoon-1.jpg landscape %}
+Paul and Sam on an elephant
+{% endfigure %}
 
-{% figure honeymoon-3.jpg landscape %}The elephant hairs were itchy{% endfigure %}
+{% figure honeymoon-3.jpg landscape %}
+The elephant hairs were itchy
+{% endfigure %}
 
 ## Leam Promthep cape
 
 We continued south to Leam Promthep cape, the southernmost point of the island, for the much praised sunset. Passing shops with BBQ’d squid and numerous fruits, and after helping green shirted Thai children with their English assignment (“What country you from? What’s your favourite Thai food? What’s different between your country and Thailand? -- I had my answers at the ready, by the sixth time of asking), we sat on the sea front wall to catch a glimpse of the sun disappearing behind a cloud. No beautiful sunset today.
 
-{% figure honeymoon-76.jpg landscape %}Paul at Leam Promthep cape{% endfigure %}
+{% figure honeymoon-76.jpg landscape %}
+Paul at Leam Promthep cape
+{% endfigure %}
 
 ## Lost in a thunderstorm
 
@@ -51,6 +67,8 @@ We were aiming for a restaurant at Bang Tao, but got thoroughly lost, to the poi
 
 With a refreshing watermelon shake, (really very yummy!), we ate cuttlefish with calamari, and sea bream in a yellow curry. Our vietnamese spring rolls were scrumptious.
 
-{% figure honeymoon-79.jpg portrait %}Paul at Baan Suan Layan{% endfigure %}
+{% figure honeymoon-79.jpg portrait %}
+Paul at Baan Suan Layan
+{% endfigure %}
 
 Home via the winding over-hill route, past Nai Thon beach, we slept well, thoroughly exhausted.

--- a/source/_posts/honeymoon-part-1-phuket-thailand/5.md
+++ b/source/_posts/honeymoon-part-1-phuket-thailand/5.md
@@ -11,27 +11,41 @@ Saturday, we were awake at 6am, ready for our Phuket Adventure pickup at 7:45am.
 
 After dusting off the wet sand, back on the boat we made the one hour journey north to Phang Nga and its astounding limestone formations and caves. Darting around the towering islands there were eagles and iguanas, canoeists and copious stalactites. The whole time we sat back, necks arced, head looking up in wonder.
 
-{% figure honeymoon-82.jpg landscape %}Phang Nga landscape{% endfigure %}
+{% figure honeymoon-82.jpg landscape %}
+Phang Nga landscape
+{% endfigure %}
 
-{% figure honeymoon-84.jpg landscape %}Beautiful Phang Nga{% endfigure %}
+{% figure honeymoon-84.jpg landscape %}
+Beautiful Phang Nga
+{% endfigure %}
 
-{% figure honeymoon-81.jpg landscape %}Phang Nga and kayaks{% endfigure %}
+{% figure honeymoon-81.jpg landscape %}
+Phang Nga and kayaks
+{% endfigure %}
 
 ### Koh Panyi, Kho Tapu
 
 For lunch we stopped at the floating muslim town (Koh Panyi island), which survives on tourism. “Like Venice”, they said, but not really. The heat was frazzling and we kept to the shade as we wandered the streets. Women carried monkeys  in babies clothing, dried seafood was for sale by the bucket-load and children pushed postcards at us. Buy, buy, buy. We ate fish, curry, salad, chicken and soup before hopping off again to “James Bond island” (from “The Man with the Golden Gun”), otherwise known as Kho Tapu.
 
-{% figure honeymoon-5.jpg portrait original %}Sam and Paul at James Bond island{% endfigure %}
+{% figure honeymoon-5.jpg portrait original %}
+Sam and Paul at James Bond island
+{% endfigure %}
 
-{% figure honeymoon-7.jpg portrait original %}Paul on a quieter part of James Bond island{% endfigure %}
+{% figure honeymoon-7.jpg portrait original %}
+Paul on a quieter part of James Bond island
+{% endfigure %}
 
-{% figure honeymoon-88.jpg portrait %}The entrance to [Scaramanga’s ‘funhouse’](http://en.wikipedia.org/wiki/Francisco_Scaramanga){% endfigure %}
+{% figure honeymoon-88.jpg portrait %}
+The entrance to [Scaramanga’s ‘funhouse’](http://en.wikipedia.org/wiki/Francisco_Scaramanga)
+{% endfigure %}
 
 The picturesque and now famous formations were accompanied by the usual tourist kitsch; key chains et al. And as an Englishman, that bears no resemblance to James Bond, many Thais wanted their picture taken with me, which was odd. Crossing sandy shores and wading through the sea a bit, we found a trail that took us round to another part of the island, quiet, secluded and beautiful.
 
 The final stop on the boat was another beach island, for swimming etc, although thick clouds moved in and the day’s storm wasn’t far off. We sped through heavy rain and no one felt like bathing by the sea. Instead we took a quick walk around the island, kicking about some old coconut shells, before being whisked back to the Phuket mainland.
 
-{% figure honeymoon-91.jpg landscape %}A storm is coming{% endfigure %}
+{% figure honeymoon-91.jpg landscape %}
+A storm is coming
+{% endfigure %}
 
 ## Lotus Restaurant, Bang Tao
 
@@ -41,12 +55,20 @@ The entrance takes you past tanks of fish, lobsters, crabs, shrimps, mantis shri
 
 Mango and watermelon shakes were followed with chicken in pandanus leaves and shrimp cakes. For mains we HAD to have something fresh; I pointed at the Red snapper tank and fished out my main course, Sam chose to have a blue crab, grabbed by our waiter (it almost got away when it was weighed). The fish came in a tamarind sauce and the crab with a salad, on the side we shared pad thai and prawns. Yum yum yum.
 
-{% figure honeymoon-94.jpg portrait %}Sam catching dinner at Lotus Restaurant{% endfigure %}
+{% figure honeymoon-94.jpg portrait %}
+Sam catching dinner at Lotus Restaurant
+{% endfigure %}
 
-{% figure honeymoon-95.jpg landscape %}Blue crab{% endfigure %}
+{% figure honeymoon-95.jpg landscape %}
+Blue crab
+{% endfigure %}
 
-{% figure honeymoon-99.jpg landscape %}Lotus Restaurant on Bang Tao beach{% endfigure %}
+{% figure honeymoon-99.jpg landscape %}
+Lotus Restaurant on Bang Tao beach
+{% endfigure %}
 
 We closed the night with another stroll along the beach, dipping our toes in the sea, and watching the spectacular fireworks, “please step back, I make big firework”.
 
-{% figure honeymoon-98.jpg portrait %}“please step back, I make big firework”{% endfigure %}
+{% figure honeymoon-98.jpg portrait %}
+“please step back, I make big firework”
+{% endfigure %}

--- a/source/_posts/honeymoon-part-1-phuket-thailand/6.md
+++ b/source/_posts/honeymoon-part-1-phuket-thailand/6.md
@@ -11,22 +11,34 @@ Easter Sunday was a day of rest and the big Indigo Pearl rose brunch. Free flowi
 
 There was fine cheese and cured ham; thirty types of sushi, takoyaki (Japanese dumplings with octopus), sashimi picked from the fish--including a great big Tuna; lobster, mantis shrimp, oysters and crab; miniature dishes of beef and asparagus, squid, roasted butternut squash, feta cheese, mixed seafood and others; a barbecue where you choose what you’d like cooked, including three types of steak, lamb chop, sausage, corn on the cob, salmon, squid, king prawns and fish of the day; indian curry selection; vegetable and roast selection; a hog roast with mustard and dressings; roasted lamb ribs; hoisin duck and anything you wanted stir fried or curried; complimentary starters from the chef; desserts of all varieties, 15 flavours of ice cream, cheesecake, chocolate cake, easter egg; waffles and pancakes freshly made; fresh fruit including mango and dragon fruit, thick smoothies, chocolate pots; and tea and coffee.
 
-{% figure honeymoon-101.jpg portrait %}Decadent Easter buffet at Indigo Pearl{% endfigure %}
+{% figure honeymoon-101.jpg portrait %}
+Decadent Easter buffet at Indigo Pearl
+{% endfigure %}
 
-{% figure honeymoon-109.jpg landscape %}A little bit of everything{% endfigure %}
+{% figure honeymoon-109.jpg landscape %}
+A little bit of everything
+{% endfigure %}
 
-{% figure honeymoon-108.jpg landscape %}Seafood buffet{% endfigure %}
+{% figure honeymoon-108.jpg landscape %}
+Seafood buffet
+{% endfigure %}
 
-{% figure honeymoon-112.jpg landscape %}Desserts too{% endfigure %}
+{% figure honeymoon-112.jpg landscape %}
+Desserts too
+{% endfigure %}
 
 It was all presented on magnificent ice sculptures of swans and elephants, with extremely attentive, friendly and helpful staff - always with a smile on their face, even carrying your food laden plate back to the table for you.
 
 Whilst our bellies got over their fullness (Sam must have eaten enough for a week!), we relaxed to the live music with a view of the pool, covers of Lady Gaga to Dire Straits wafted by as we sat in slumber, occasionally applauding the band for their excellent renditions.
 
-{% figure honeymoon-11.jpg portrait original %}Paul finishing up with a coffee{% endfigure %}
+{% figure honeymoon-11.jpg portrait original %}
+Paul finishing up with a coffee
+{% endfigure %}
 
 A slow walk back to the beach, sand in our toes, water occasionally hitting them. We chilled out by the pool, ordered a light evening meal at the bar (Sam’s seafood salad was hilariously huge), and chillaxed.
 
 The night time pool dip lead to some mosquito bites, inevitable really.
 
-{% figure honeymoon-12.jpg landscape %}Night time pool dip{% endfigure %}
+{% figure honeymoon-12.jpg landscape %}
+Night time pool dip
+{% endfigure %}

--- a/source/_posts/honeymoon-part-1-phuket-thailand/7.md
+++ b/source/_posts/honeymoon-part-1-phuket-thailand/7.md
@@ -13,15 +13,23 @@ Our destination was the quiet, Sa Nang Manora forest. We left the Yaris in the s
 
 Past waterfalls, we hiked through the forest; lizards scuttling up trees; cobwebs got caught in our faces and bugs surrounded us; we crossed precarious wooden bridges (aka fallen trees), and climbed small rock faces as the trail took us deep into the forest. No one else around for miles.
 
-{% figure honeymoon-114.jpg landscape %}Waterfall in Sa Nang Manora forest{% endfigure %}
+{% figure honeymoon-114.jpg landscape %}
+Waterfall in Sa Nang Manora forest
+{% endfigure %}
 
-{% figure honeymoon-117.jpg portrait %}Hiking through the forest{% endfigure %}
+{% figure honeymoon-117.jpg portrait %}
+Hiking through the forest
+{% endfigure %}
 
 We passed numerous water caves, and coves in the limestone housing  bats; butterflies amazed us with their size and colour, and random wild flowers poked out from nowhere.
 
-{% figure honeymoon-118.jpg portrait %}Paul looking into a water cave{% endfigure %}
+{% figure honeymoon-118.jpg portrait %}
+Paul looking into a water cave
+{% endfigure %}
 
-{% figure honeymoon-119.jpg landscape %}Big rock{% endfigure %}
+{% figure honeymoon-119.jpg landscape %}
+Big rock
+{% endfigure %}
 
 We trekked for about three hours, stopping in a large cave for snacks; croissants saved from breakfast, now nicely warm in the heat. Without enough food, we turned back and did the walk in double time, speeding onwards at the request of our bellies.
 
@@ -29,13 +37,17 @@ Back at the car park, there were now locals swimming amongst waterfalls, and str
 
 All from some entertaining thai locals that didn’t believe I was 25 and married. Crispy thin pancakes with luminous fruit sauces ended our purchases.
 
-{% figure honeymoon-123.jpg landscape %}Crispy thin pancakes{% endfigure %}
+{% figure honeymoon-123.jpg landscape %}
+Crispy thin pancakes
+{% endfigure %}
 
 ## Driving back
 
 Back on the road, through the gate on wheels, pulled back by a charming boy, clearly very proud of his role, we headed back, stopping anywhere that took our fancy. Oh to be in an air conditioned vehicle!
 
-{% figure honeymoon-124.jpg landscape %}Driving back via Phang Nga town{% endfigure %}
+{% figure honeymoon-124.jpg landscape %}
+Driving back via Phang Nga town
+{% endfigure %}
 
 It was good to get well away from the tourist world, and meet some locals not trying to sell us a boat ride. We followed signs for another waterfall, it turned out to be man-made and much less impressive, although it did afford us some lovely views. Next stop, or more like U-turn and dash, was Phang Nga bay, where touts were so eager to sell us their James Bond island trips they’d jump in front of the car. We didn’t stop.
 
@@ -49,16 +61,24 @@ To celebrate our last night in the luscious and tropical Phuket, we drove to the
 
 We ate seven courses and spent a small fortune. Pistachio and asparagus soup; breads and dipping oils; three types of scallop; three types of veal; three types of salmon (including smoked with jackfruit and another wrapped in leaves on a bed of squid ink risotto); raspberry sorbets to cleanse our pallets and three types of pineapple (including with rice wrapped in a pancake, delicious!) and topped off with chocolate ganaches.
 
-{% figure honeymoon-125.jpg landscape %}Three types of salmon{% endfigure %}
+{% figure honeymoon-125.jpg landscape %}
+Three types of salmon
+{% endfigure %}
 
 We sat with a view across the lake and briefly watched how the other half lived.
 
 Before going home, we pulled up at the beachfront, to watch and photograph the awesome storm. Long shutter times and crossed fingers didn’t result in much.
 
-{% figure honeymoon-127.jpg landscape %}Paul and our Toyota Yaris{% endfigure %}
+{% figure honeymoon-127.jpg landscape %}
+Paul and our Toyota Yaris
+{% endfigure %}
 
-{% figure honeymoon-126.jpg portrait %}Lightning storm off the coast{% endfigure %}
+{% figure honeymoon-126.jpg portrait %}
+Lightning storm off the coast
+{% endfigure %}
 
 Our time in Phuket was over, but our honeymoon was moving onto [part 2, Chiang Mai](/2010/06/honeymoon-part-2-chiang-mai-thailand/).
 
-{% figure honeymoon-129.jpg landscape %}Phang Nga from the sky{% endfigure %}
+{% figure honeymoon-129.jpg landscape %}
+Phang Nga from the sky
+{% endfigure %}

--- a/source/_posts/honeymoon-part-2-chiang-mai-thailand.md
+++ b/source/_posts/honeymoon-part-2-chiang-mai-thailand.md
@@ -19,9 +19,13 @@ Part one of our holiday was over, we checked out, returned the rental and took a
 
 With a complimentary airport transfer we arrived at Rimping Village, our next port of call. Unlike the previous resorts, this was a small, personal and homely place -- all rooms overlook the pool, and the grounds are dominated by a grand Banyan tree. We traded in luxury for warmth, friendliness and new friends. We loved it, the guests and the staff.
 
-{% figure honeymoon-130.jpg landscape %}Rimping Village welcomes us honeymooners{% endfigure %}
+{% figure honeymoon-130.jpg landscape %}
+Rimping Village welcomes us honeymooners
+{% endfigure %}
 
-{% figure honeymoon-152.jpg landscape %}Rimping Village and pool{% endfigure %}
+{% figure honeymoon-152.jpg landscape %}
+Rimping Village and pool
+{% endfigure %}
 
 ## Dusty Chiang Mai
 

--- a/source/_posts/honeymoon-part-2-chiang-mai-thailand/2.md
+++ b/source/_posts/honeymoon-part-2-chiang-mai-thailand/2.md
@@ -9,37 +9,61 @@ page: 2
 
 Day 2 and it was time to explore. We took a tuk-tuk to the centre of the old town and started a walking tour of the “Wats” (temples). Leaving early to avoid the heat, we covered [Wat Phra Singh](http://en.wikipedia.org/wiki/Wat_Phra_Singh), [Wat Chedi Luang](http://en.wikipedia.org/wiki/Wat_Chedi_Luang), Wat Phan Tao and [Wat Chiang Man](http://en.wikipedia.org/wiki/Wat_Chiang_Man). Monks cleaned the courtyards or just bandied together as a group of lads. Each temple had a different characters and we watched as people came and bowed to Buddha images, burnt incense or left donations. One monk was receiving a massage, others gave lessons or spread water over those bowed, as a blessing of sorts. Lotus and orchids decorated the statues.
 
-{% figure honeymoon-132.jpg landscape %}Samantha reading our Thailand guide in a temple{% endfigure %}
+{% figure honeymoon-132.jpg landscape %}
+Samantha reading our Thailand guide in a temple
+{% endfigure %}
 
-{% figure honeymoon-134.jpg portrait %}[Wat Chedi Luang](http://en.wikipedia.org/wiki/Wat_Chedi_Luang) interior{% endfigure %}
+{% figure honeymoon-134.jpg portrait %}
+[Wat Chedi Luang](http://en.wikipedia.org/wiki/Wat_Chedi_Luang) interior
+{% endfigure %}
 
-{% figure honeymoon-136.jpg portrait %}[Wat Chedi Luang](http://en.wikipedia.org/wiki/Wat_Chedi_Luang) ruins{% endfigure %}
+{% figure honeymoon-136.jpg portrait %}
+[Wat Chedi Luang](http://en.wikipedia.org/wiki/Wat_Chedi_Luang) ruins
+{% endfigure %}
 
-{% figure honeymoon-137.jpg landscape %}Tired tuk-tuk driver{% endfigure %}
+{% figure honeymoon-137.jpg landscape %}
+Tired tuk-tuk driver
+{% endfigure %}
 
-{% figure honeymoon-140.jpg portrait %}Take off your shoes before entering{% endfigure %}
+{% figure honeymoon-140.jpg portrait %}
+Take off your shoes before entering
+{% endfigure %}
 
-{% figure honeymoon-143.jpg portrait %}[Wat Chiang Man](http://en.wikipedia.org/wiki/Wat_Chiang_Man) interior{% endfigure %}
+{% figure honeymoon-143.jpg portrait %}
+[Wat Chiang Man](http://en.wikipedia.org/wiki/Wat_Chiang_Man) interior
+{% endfigure %}
 
-{% figure honeymoon-146.jpg landscape %}Golden dragon at [Wat Phra Singh](http://en.wikipedia.org/wiki/Wat_Phra_Singh){% endfigure %}
+{% figure honeymoon-146.jpg landscape %}
+Golden dragon at [Wat Phra Singh](http://en.wikipedia.org/wiki/Wat_Phra_Singh)
+{% endfigure %}
 
-{% figure honeymoon-148.jpg landscape %}Where next Sam?{% endfigure %}
+{% figure honeymoon-148.jpg landscape %}
+Where next Sam?
+{% endfigure %}
 
 Outside you could pay to release birds from cages, “pay to free them”, and they’ll go and catch more with a cash incentive. They wouldn’t let me take their picture.
 
 The 40C heat left us sweaty and desperate for chilled drinks, we ran the gauntlet of tuk-tuks, mopeds and trucks to get to “Chocolate Fact”, an air-conditioned cafeteria that makes an excellent Mango Frappe. Relaxing on the leather sofas, we waited until we were almost cool enough to have goose-pimples, before stepping out into the sauna.
 
-{% figure honeymoon-141.jpg landscape %}Hazy streets of Chiang Mai{% endfigure %}
+{% figure honeymoon-141.jpg landscape %}
+Hazy streets of Chiang Mai
+{% endfigure %}
 
-{% figure honeymoon-15.jpg portrait original %}Paul cooling down at Chocolate Fact{% endfigure %}
+{% figure honeymoon-15.jpg portrait original %}
+Paul cooling down at Chocolate Fact
+{% endfigure %}
 
 ## Miss Songkran 2010
 
 At the Chiang Mai city arts and cultural centre our legs couldn’t take a museum wander, we instead watched a bus load of formally dressed Thai women place flowers at the three kings monument before posing for photos. They couldn’t wear heels on the monument’s steps, and it was amusing watching them unstrap their six inch heels. They were part of Miss Songkran 2010, each was thin and unnaturally pale (there’s a strange culture of skin whitening products), but all very dignified.
 
-{% figure honeymoon-149.jpg landscape %}Miss Songkran 2010{% endfigure %}
+{% figure honeymoon-149.jpg landscape %}
+Miss Songkran 2010
+{% endfigure %}
 
-{% figure honeymoon-150.jpg landscape %}No heels allowed on the monument{% endfigure %}
+{% figure honeymoon-150.jpg landscape %}
+No heels allowed on the monument
+{% endfigure %}
 
 A quick nip around the corner and we had our cheapest meal of the holiday. Two cokes, chicken and rice, pork satays, chilli dip and a very tasty peanut sauce. All for the pricey 85B, or about £1.50.
 

--- a/source/_posts/honeymoon-part-2-chiang-mai-thailand/3.md
+++ b/source/_posts/honeymoon-part-2-chiang-mai-thailand/3.md
@@ -9,18 +9,30 @@ The heat really was overwhelming, a dry heat, no wind and a constant haze over t
 
 Swimming, playing with the inflatables, drinking fruit shakes, planning our week and talking with other guests about their adventures and plans; that formed the majority of the day. Sam talked about her new-found snorkelling skills (and troubles), to some divers, learnt a lot about elephants and mahouts and heard about a good but heavy going cooking school.
 
-{% figure honeymoon-153.jpg portrait %}Banyan tree at Rimping Village{% endfigure %}
+{% figure honeymoon-153.jpg portrait %}
+Banyan tree at Rimping Village
+{% endfigure %}
 
-{% figure honeymoon-155.jpg landscape %}Sam at Rimping Village{% endfigure %}
+{% figure honeymoon-155.jpg landscape %}
+Sam at Rimping Village
+{% endfigure %}
 
 ## A Lanna experience
 
 That night we booked a Lanna experience, food, traditional dance and a hotel pick-up, sounded great. At the complex we passed vegetable carvers and were seated next to a large stage. Almost immediately our food arrived, northern hors d’oeuvres with free refills, tasty and good value for our baht. Whilst we were eating the show began, a poor PA system got a bit confused and we had two audio streams for a while, but that sorted itself out. The Thai Lanna dancers performed finger-nail dances, knife dances, traditional battle dances and so on, though all of it felt overtly kitschy, and at a pretty poor standard. The slightly cheesy narration didn’t help. Our evening was saved by Sam going on stage and attempting to reproduce the complicated hand movements, a moment I’ve captured on video.
 
-{% figure honeymoon-157.jpg portrait %}Vegetable carving{% endfigure %}
+{% figure honeymoon-157.jpg portrait %}
+Vegetable carving
+{% endfigure %}
 
-{% figure honeymoon-158.jpg portrait %}Sam and our feast{% endfigure %}
+{% figure honeymoon-158.jpg portrait %}
+Sam and our feast
+{% endfigure %}
 
-{% figure honeymoon-159.jpg landscape %}Traditional dancer{% endfigure %}
+{% figure honeymoon-159.jpg landscape %}
+Traditional dancer
+{% endfigure %}
 
-{% figure honeymoon-161.jpg landscape %}Sam dancing on stage{% endfigure %}
+{% figure honeymoon-161.jpg landscape %}
+Sam dancing on stage
+{% endfigure %}

--- a/source/_posts/honeymoon-part-2-chiang-mai-thailand/4.md
+++ b/source/_posts/honeymoon-part-2-chiang-mai-thailand/4.md
@@ -9,9 +9,13 @@ page: 4
 
 Friday took us to the Chiang Mai Thai cooking school, for an introduction to Thai ingredients and the preparation of six dishes. From our 9am hotel pick-up we travelled out to the country for our class. We each had a cooking station with gas burner, chopping board, knife, wok, bin and bowls of ingredients. In the kitchen we learnt about each dish, hear how to prepare the ingredients, watch the dish being cooked and return to have a go of our own, with help as required.
 
-{% figure honeymoon-166.jpg portrait %}Learning how to prepare ingredients{% endfigure %}
+{% figure honeymoon-166.jpg portrait %}
+Learning how to prepare ingredients
+{% endfigure %}
 
-{% figure honeymoon-163.jpg landscape %}Cooking our first meal at Chiang Mai cooking school{% endfigure %}
+{% figure honeymoon-163.jpg landscape %}
+Cooking our first meal at Chiang Mai cooking school
+{% endfigure %}
 
 ### Spicy and sour soup
 
@@ -23,17 +27,23 @@ I briefly lost the taste/use of my tongue as I chomped through a very small, VER
 
 Next up was fish cakes, with fish sauce, and a selection of bicarbonate soda, chilli sauce, palm sugar, etc, which we deep fried.
 
-{% figure honeymoon-17.jpg landscape %}Queuing to deep fry{% endfigure %}
+{% figure honeymoon-17.jpg landscape %}
+Queuing to deep fry
+{% endfigure %}
 
 ### Thai green curry
 
 For our main course we created a green chicken curry, with a small and large egg plant and more kaffir lime leaves. Again we chose how spicy to make it. Accompanying the curry was the dish I most wanted to learn, pad thai; noodles, egg, various sauces for flavouring, dried shrimps, garlic and tofu. I loved making this, it was easy and delicious (and I did it better than Sam).
 
-{% figure honeymoon-19.jpg landscape %}Paul’s thai green curry and pad thai{% endfigure %}
+{% figure honeymoon-19.jpg landscape %}
+Paul’s thai green curry and pad thai
+{% endfigure %}
 
 In the afternoon, all a little stuffed from eating so much, we cooked water chestnuts in coconut milk and a minced chicken dish.
 
-{% figure honeymoon-23.jpg portrait original %}Paul cooking chestnuts in coconut milk{% endfigure %}
+{% figure honeymoon-23.jpg portrait original %}
+Paul cooking chestnuts in coconut milk
+{% endfigure %}
 
 About 20 of us took the course, and over the day we got to know most of them, especially over food; a nice Australian couple on their honeymoon after a three day hindu wedding, a Brazilian that works in London that will now be in Laos or beyond, an English ex-pat and friend, up from Bangkok. There was a lot of bonding and it was sad to say bye at the end of the day.
 

--- a/source/_posts/honeymoon-part-2-chiang-mai-thailand/5.md
+++ b/source/_posts/honeymoon-part-2-chiang-mai-thailand/5.md
@@ -7,9 +7,13 @@ page: 5
 
 On Saturday we were up early. Poached eggs on bread for breakfast again (we realised we were eating way too much egg, and it was having side effects), with coffee and the weird milk, croissants, and even spicy stir fry if you wanted it.
 
-{% figure honeymoon-233.jpg portrait %}Rimping Village breakfast spread{% endfigure %}
+{% figure honeymoon-233.jpg portrait %}
+Rimping Village breakfast spread
+{% endfigure %}
 
-{% figure honeymoon-234.jpg landscape %}Breakfast at Rimping Village{% endfigure %}
+{% figure honeymoon-234.jpg landscape %}
+Breakfast at Rimping Village
+{% endfigure %}
 
 ## Doi Suthep and the Winter palace
 
@@ -19,25 +23,41 @@ In winter there’s normally an astonishing view across the city, the haze meant
 
 We went to the palace first, “Phra tamnak phu phing”, where my shorts weren’t suiting and I had to don a pair of 3/4 lengths over the top, nicely striped in red and white. The gardens specialised in cool weather flowers, most of which we were quite used to and not overly interested in. Most paths had “do not enter” signs all over them and the water fountain show was devoid of water.
 
-{% figure honeymoon-171.jpg landscape %}No entry{% endfigure %}
+{% figure honeymoon-171.jpg landscape %}
+No entry
+{% endfigure %}
 
-{% figure honeymoon-169.jpg landscape %}Sam in the Winter palace gardens{% endfigure %}
+{% figure honeymoon-169.jpg landscape %}
+Sam in the Winter palace gardens
+{% endfigure %}
 
-{% figure honeymoon-172.jpg landscape %}Sam under a Banyan tree{% endfigure %}
+{% figure honeymoon-172.jpg landscape %}
+Sam under a Banyan tree
+{% endfigure %}
 
 Down the mountain a bit, we went to the hill side temple, Doi Suthep, complete with covered cable car to take you to the top. This temple felt more like a tourist trap, photo touts covered the temple grounds, flower offerings were on sale - 10B to place them on a shrine, only to have them picked up and sold to another customer 5 mins later. The entrance was strewn with market stalls and groups of children performing traditional dance.
 
 We walked around the chedi, clockwise as we were meant to, and headed back. Before leaving altogether, we stopped at a Jade factory recommended by our driver. Quite clearly a front for people trying to sell expensive jade jewellery, we watched their video, had their free drinks and promptly left. I’m sure our driver would have received commission.
 
-{% figure honeymoon-174.jpg portrait %}Paul eating watermelon at Doi Suthep{% endfigure %}
+{% figure honeymoon-174.jpg portrait %}
+Paul eating watermelon at Doi Suthep
+{% endfigure %}
 
-{% figure honeymoon-179.jpg landscape %}A monk at Doi Suthep{% endfigure %}
+{% figure honeymoon-179.jpg landscape %}
+A monk at Doi Suthep
+{% endfigure %}
 
-{% figure honeymoon-183.jpg landscape %}Childen performing traditional dance{% endfigure %}
+{% figure honeymoon-183.jpg landscape %}
+Childen performing traditional dance
+{% endfigure %}
 
-{% figure honeymoon-186.jpg portrait %}The steps down from Doi Suthep{% endfigure %}
+{% figure honeymoon-186.jpg portrait %}
+The steps down from Doi Suthep
+{% endfigure %}
 
-{% figure honeymoon-188.jpg landscape %}Fruit stall outside the temple{% endfigure %}
+{% figure honeymoon-188.jpg landscape %}
+Fruit stall outside the temple
+{% endfigure %}
 
 ## Flower market
 
@@ -49,8 +69,12 @@ Inside the little road shacks people worked hard on complicated flower arrangeme
 
 That evening we ate at the lovely looking “Whole Earth restaurant”, a thai-indian place with red parasols and a large wooden building at the centre, with outdoor balcony seating. Take off your shoes before entering.
 
-{% figure honeymoon-191.jpg portrait %}Dinner at Whole Earth restaurant{% endfigure %}
+{% figure honeymoon-191.jpg portrait %}
+Dinner at Whole Earth restaurant
+{% endfigure %}
 
 For starters we had the tempura shrimp with other battered veggies, mini corn and even broccoli. Very tasty. For mains we shared an indian vegetable curry alongside a deep fried sea bass with sweet and sour sauce. Scrumptious and filling.
 
-{% figure honeymoon-192.jpg portrait %}Scooter on Chiang Mai’s iron bridge{% endfigure %}
+{% figure honeymoon-192.jpg portrait %}
+Scooter on Chiang Mai’s iron bridge
+{% endfigure %}

--- a/source/_posts/honeymoon-part-2-chiang-mai-thailand/6.md
+++ b/source/_posts/honeymoon-part-2-chiang-mai-thailand/6.md
@@ -9,25 +9,43 @@ page: 6
 
 On Sunday we headed back to the flower market, and travelled a bit further to the main food market, Talat Warorot, with the intention of taking lots of cool photos.
 
-{% figure honeymoon-193.jpg landscape %}The flower market{% endfigure %}
+{% figure honeymoon-193.jpg landscape %}
+The flower market
+{% endfigure %}
 
-{% figure honeymoon-197.jpg landscape %}Fish on sale at Talat Warorot{% endfigure %}
+{% figure honeymoon-197.jpg landscape %}
+Fish on sale at Talat Warorot
+{% endfigure %}
 
 It felt like you could buy anything here, stalls piled high with every type of fruit, flower, vegetable, fish, rice and seafood. Open BBQs grilled whole squid, long curly sausages were paraded, chicken and meat joints laid out for all to see (freshness was in doubt), pink dragon fruit kept catching the eye, inside shelves were piled with different types of tea, sweets, fake flowers and even fireworks. Whole tables were devoted to super soakers, water guns for Songkran. Some kids were already in the water fighting spirit, spraying passers by.
 
-{% figure honeymoon-199.jpg landscape %}Hungry boy wants one of those{% endfigure %}
+{% figure honeymoon-199.jpg landscape %}
+Hungry boy wants one of those
+{% endfigure %}
 
-{% figure honeymoon-201.jpg landscape %}Sam trying to choose which fake flowers to bring home{% endfigure %}
+{% figure honeymoon-201.jpg landscape %}
+Sam trying to choose which fake flowers to bring home
+{% endfigure %}
 
-{% figure honeymoon-203.jpg landscape %}Street-cooked chicken{% endfigure %}
+{% figure honeymoon-203.jpg landscape %}
+Street-cooked chicken
+{% endfigure %}
 
-{% figure honeymoon-204.jpg landscape %}Street food{% endfigure %}
+{% figure honeymoon-204.jpg landscape %}
+Street food
+{% endfigure %}
 
-{% figure honeymoon-206.jpg landscape %}Crispy dried sea-food{% endfigure %}
+{% figure honeymoon-206.jpg landscape %}
+Crispy dried sea-food
+{% endfigure %}
 
-{% figure honeymoon-209.jpg landscape %}Puppy wants to help sell flowers{% endfigure %}
+{% figure honeymoon-209.jpg landscape %}
+Puppy wants to help sell flowers
+{% endfigure %}
 
-{% figure honeymoon-208.jpg portrait %}Flowers, 5B each{% endfigure %}
+{% figure honeymoon-208.jpg portrait %}
+Flowers, 5B each
+{% endfigure %}
 
 From 12-3pm we were back at the pool, a common afternoon activity by now, the heat so intense it was impossible to do anything else.
 
@@ -43,6 +61,8 @@ Leaving the hotel later than planned, we got a tuk-tuk into town for the Sunday 
 
 The street food was particularly good and we tried noodles for 15B and an indian vegetable and chicken samosa. The products on sale were also better, more wide ranging and cheaper than at the night market.
 
-{% figure honeymoon-24.jpg portrait original %}Vegetable and chicken samosa{% endfigure %}
+{% figure honeymoon-24.jpg portrait original %}
+Vegetable and chicken samosa
+{% endfigure %}
 
 With Songkran approaching the market was far more busy than normal, it got so busy it was impossible to stop and look at the homemade crafts, carvings, t-shirts or jewellery, or any stall. When we found a suitable exit we ducked out and went home, all marketed out.

--- a/source/_posts/honeymoon-part-2-chiang-mai-thailand/7.md
+++ b/source/_posts/honeymoon-part-2-chiang-mai-thailand/7.md
@@ -11,9 +11,13 @@ On Monday we decided to get out of town on a day trip, whilst the traffic let us
 
 On the major roads, lined up on either side, were groups of kids, families and teens with barrels full of water, water guns and buckets, soaking every car, moped and truck that came past. Our taxi was water tight and our driver unfazed.
 
-{% figure honeymoon-212.jpg landscape %}Teens with water filled buckets for soaking passers by, it’s almost Songkran{% endfigure %}
+{% figure honeymoon-212.jpg landscape %}
+Teens with water filled buckets for soaking passers by, it’s almost Songkran
+{% endfigure %}
 
-{% figure honeymoon-213.jpg landscape %}Drive-by soaking{% endfigure %}
+{% figure honeymoon-213.jpg landscape %}
+Drive-by soaking
+{% endfigure %}
 
 To the tunes of Rhinestone Cowboy and The Young Ones, we sped south through “HOT”, to the mountains which slowly emerged from the haze. Up we climbed for 30 mins, winding around, ears popping every so often.
 
@@ -21,11 +25,17 @@ To the tunes of Rhinestone Cowboy and The Young Ones, we sped south through “H
 
 At the summit, the highest point in Thailand, it was a cool 25C, apparently perfect for birds and bird watching. On the Ang Thon nature trail we kept quiet, hoping to spot something nearby. Movement and the odd fluorescent dash of colour caught our eye as we spotted Yellow-bellied fantails, Green-tailed sunbirds and a brave Chestnut-tailed Minla that kindly posed for photos.
 
-{% figure honeymoon-215.jpg landscape %}The highest spot in Thailand{% endfigure %}
+{% figure honeymoon-215.jpg landscape %}
+The highest spot in Thailand
+{% endfigure %}
 
-{% figure honeymoon-217.jpg portrait %}Ang Thon nature trail{% endfigure %}
+{% figure honeymoon-217.jpg portrait %}
+Ang Thon nature trail
+{% endfigure %}
 
-{% figure honeymoon-218.jpg landscape %}Chestnut-tailed Minla{% endfigure %}
+{% figure honeymoon-218.jpg landscape %}
+Chestnut-tailed Minla
+{% endfigure %}
 
 At the cafe we sampled locally grown Arabica coffee, whilst sharing stories with a family from Bangkok, up north for Songkran.
 
@@ -33,32 +43,50 @@ At the cafe we sampled locally grown Arabica coffee, whilst sharing stories with
 
 Further down the mountain were two towers dedicated to the King and Queen for their 80th birthdays. With spicy minced beef in our bellies, we perused the gardens and structures, taking note of the fantastic mountain peaks poking out of the hazy horizon. We posed for photos amongst the snap dragons and cabbages, and the cute little pond crossing.
 
-{% figure honeymoon-220.jpg landscape %}Girl amongst the snapdragons{% endfigure %}
+{% figure honeymoon-220.jpg landscape %}
+Girl amongst the snapdragons
+{% endfigure %}
 
-{% figure honeymoon-221.jpg landscape %}View from royal towers{% endfigure %}
+{% figure honeymoon-221.jpg landscape %}
+View from royal towers
+{% endfigure %}
 
-{% figure honeymoon-222.jpg portrait %}Samantha and the royal towers{% endfigure %}
+{% figure honeymoon-222.jpg portrait %}
+Samantha and the royal towers
+{% endfigure %}
 
 ### Waterfall
 
 Further down the mountain we made one final stop at a signposted waterfall, a roaring drop with viewpoints and large pools to bathe in, despite the no swimming signs.
 
-{% figure honeymoon-224.jpg portrait %}Stopping by a waterfall on the way home{% endfigure %}
+{% figure honeymoon-224.jpg portrait %}
+Stopping by a waterfall on the way home
+{% endfigure %}
 
-{% figure honeymoon-226.jpg portrait original %}Sam and Paul by the waterfall{% endfigure %}
+{% figure honeymoon-226.jpg portrait original %}
+Sam and Paul by the waterfall
+{% endfigure %}
 
 On the way back we had more of the country-rock soundtrack and Songkran car soakings. By now the groups had perfected their bucket aims and we watched as most targets were drenched with perfectly launched throws.
 
-{% figure honeymoon-231.jpg landscape %}The taxi getting soaked on the way home{% endfigure %}
+{% figure honeymoon-231.jpg landscape %}
+The taxi getting soaked on the way home
+{% endfigure %}
 
-{% figure honeymoon-232.jpg landscape %}You got us{% endfigure %}
+{% figure honeymoon-232.jpg landscape %}
+You got us
+{% endfigure %}
 
 ## The Good View restaurant
 
 That evening we ate at “The Good View”, along the river. Inside the décor had been filled with buckets, and our Mai Tai cocktails were the same; a wedge of pineapple on the side of a bright yellow bucket filled with alcohol. A band at the back played Elton John covers whilst we ate our mains. Deep fried and spicy serpent head fish with a mango salad and rice served in a pineapple.
 
-{% figure honeymoon-25.jpg portrait original %}Cocktails in buckets at The Good View restaurant{% endfigure %}
+{% figure honeymoon-25.jpg portrait original %}
+Cocktails in buckets at The Good View restaurant
+{% endfigure %}
 
-{% figure honeymoon-26.jpg portrait original %}Spicy serpent head fish{% endfigure %}
+{% figure honeymoon-26.jpg portrait original %}
+Spicy serpent head fish
+{% endfigure %}
 
 Back at the hotel we ordered our favourite fruit shakes and spent the rest of the evening chatting with the restaurant and reception staff, Mr Tommy et al. Everything from Chiang Mai festivities to peculiar Hindu traditions with people dressed like dementors from Harry Potter.

--- a/source/_posts/honeymoon-part-2-chiang-mai-thailand/8.md
+++ b/source/_posts/honeymoon-part-2-chiang-mai-thailand/8.md
@@ -14,7 +14,9 @@ Have some fun
 
 We were up early, packing for our room move, turned out we didn’t have to go anywhere and could stay in the same room. Sam got a taxi at 9am to go for an out of town one on one vegetable carving session. She learnt how to carve carrots into leaves, tomatoes into roses, cucumbers into lotuses and guava and watermelon into pretty structures. Meanwhile, I worked hard at the pool, perfecting my sunbathing techniques.
 
-{% figure honeymoon-29.jpg landscape %}Samantha and her carved vegetables{% endfigure %}
+{% figure honeymoon-29.jpg landscape %}
+Samantha and her carved vegetables
+{% endfigure %}
 
 ### Water gun toting citizens
 
@@ -22,7 +24,9 @@ At 3pm we ventured into the city, ensuring any belongings we took with us were w
 
 The Nawara bridge was closed to traffic and lined with bucket wielding, water gun toting Thais of all ages. Sprinklers were mounted on both sides of the bridge, creating an archway of water into the city. Welcome to the water festival.
 
-{% figure honeymoon-30.jpg portrait original %}Songkran parade{% endfigure %}
+{% figure honeymoon-30.jpg portrait original %}
+Songkran parade
+{% endfigure %}
 
 Crossing the bridge, bone dry, we were obvious targets. In the traditional manner, wide-grinned Thais poured water over our shoulders and wished us a happy new year, we reciprocated.
 
@@ -40,7 +44,9 @@ A permanent grin was attached to our faces (and everyone else’s), with the pur
 
 We reached the edge of the old city. Enter the music stages, the pumping music, the pubs and food stalls, the party atmosphere, and most importantly of all, the Chiang Mai moat - an unlimited water supply. Here the water fight went up a notch. Water guns were supersized.
 
-{% figure honeymoon-31.jpg landscape original %}Sam, drenched and with water cannon{% endfigure %}
+{% figure honeymoon-31.jpg landscape original %}
+Sam, drenched and with water cannon
+{% endfigure %}
 
 Groups lined the moat, throwing buckets in, pulling them out full and launching them at anyone. The roads were still open, adding to the chaos, as all vehicles were fair game. Trucks with barrels on the back and groups with buckets or pistols had mammoth battles with moat dwellers, mopeds weaving between trucks would be carrying passengers on the back firing their water soakers into the air.
 
@@ -60,4 +66,6 @@ We danced and played and laughed until the sun went down; clear skies over the C
 
 We sat in Ratana’s kitchen, dripping wet, making puddles on the floor. Nothing like some chicken noodles, spicy beef and jasmine rice to refuel on.
 
-{% figure honeymoon-34.jpg landscape %}Sam and Paul with Songkran armory{% endfigure %}
+{% figure honeymoon-34.jpg landscape %}
+Sam and Paul with Songkran armory
+{% endfigure %}

--- a/source/_posts/honeymoon-part-2-chiang-mai-thailand/9.md
+++ b/source/_posts/honeymoon-part-2-chiang-mai-thailand/9.md
@@ -9,11 +9,15 @@ page: 9
 
 Wednesday was much the same, day two of Songkran and the water festival continued.
 
-{% figure honeymoon-239.jpg landscape %}Paul, ready for Songkran day two{% endfigure %}
+{% figure honeymoon-239.jpg landscape %}
+Paul, ready for Songkran day two
+{% endfigure %}
 
 Post-breakfast swimming, relaxing and a little bit of sleeping. Our honeymoon in Thailand was almost over. Our first taste of Asia had been incredible; from the tropical fruits, islands and beaches to the spicy curries, tuk-tuks and friendly hotel staff. We had paradise, bliss, adventure and a little bit of magic.
 
-{% figure honeymoon-238.jpg portrait %}Sam and her water pack{% endfigure %}
+{% figure honeymoon-238.jpg portrait %}
+Sam and her water pack
+{% endfigure %}
 
 Heading out into the city one last time, we prepared for more water fighting madness. We threw buckets of water over trucks with perfect accuracy (or narrowly missing by several foot), reloaded with ice cold water, discarded water guns like Neo and got utterly and completely drenched. Donning straw/banana leaf hats we made our last few attacks and walking back to the hotel (squelch, squelch), our hearts were contented.
 
@@ -23,14 +27,24 @@ At the night market we made our final purchases - mango wood carvings, food and 
 
 Then it was time to say good bye. Goodbye Chiang Mai with your Wats and moat; bye bye Rimping Village, bye Mr Tommy, with your great big smile; bye to the restaurant staff that knew our orders, prepared with a smile and even shared recipes; bye bye reception where we shared stories, made friends and learnt a bit of culture; bye bye guests and friends.
 
-{% figure honeymoon-243.jpg portrait %}Mr Tommy  at Rimping Village{% endfigure %}
+{% figure honeymoon-243.jpg portrait %}
+Mr Tommy  at Rimping Village
+{% endfigure %}
 
-{% figure honeymoon-236.jpg portrait %}Friendly restaurant staff{% endfigure %}
+{% figure honeymoon-236.jpg portrait %}
+Friendly restaurant staff
+{% endfigure %}
 
-{% figure honeymoon-237.jpg portrait %}Goodbye Rimping Village{% endfigure %}
+{% figure honeymoon-237.jpg portrait %}
+Goodbye Rimping Village
+{% endfigure %}
 
-{% figure honeymoon-242.jpg portrait %}Rimping Village’s lovely receptionists{% endfigure %}
+{% figure honeymoon-242.jpg portrait %}
+Rimping Village’s lovely receptionists
+{% endfigure %}
 
 Bye bye lizards, mosquitos, jasmine, lotus plants, rice and noodles. Bye bye Thailand, with all your charm and beauty. We’ll be back.
 
-{% figure honeymoon-244.jpg landscape %}We’ve finished our watermelon and mango shakes, it’s time to go{% endfigure %}
+{% figure honeymoon-244.jpg landscape %}
+We’ve finished our watermelon and mango shakes, it’s time to go
+{% endfigure %}

--- a/source/_posts/hong-kong-china.md
+++ b/source/_posts/hong-kong-china.md
@@ -21,7 +21,9 @@ While waiting for the Guangzhou flight we had the good fortune of bumping into o
 
 The flight arrived in Guangzhou on time, we said our farewells to Emmie and Jan and took the air-conditioned car into town. The humid heat of the tropical south hit us as we exited the airport, nowhere else in China had it been this hot and humid. Of course there was a traffic jam, and the drive took an hour, but we arrived at the station early enough for Roger and I to pursue an earlier train ticket, though our efforts were in vain (couldn’t find the ticket desk, then we queued in the wrong queue, and then it was too late). So we whiled away the time on the top floor of the station at E-taste; on the scale of “restaurants in train stations” it’s one of the best.
 
-{% figure china-hong-kong-006.jpg landscape %}Trying to change our train tickets, without much success{% endfigure %}
+{% figure china-hong-kong-006.jpg landscape %}
+Trying to change our train tickets, without much success
+{% endfigure %}
 
 The train to Hong Kong takes about 2 hours. Crossing the border my phone buzzed with excitement; free roaming data with 3, and no more ‘great firewall’, the phone drained all its juice doing everything it had struggled to do for the last three weeks. It also meant we could track our location as we travelled through the New Territories and into Kowloon, outside the buildings grew taller and denser. Through passport control, out of the station and over the road and we’d reached our hotel.
 
@@ -29,7 +31,9 @@ The train to Hong Kong takes about 2 hours. Crossing the border my phone buzzed 
 
 [Harbour Plaza Metropolis](http://www.tripadvisor.co.uk/Hotel_Review-g294217-d305854-Reviews-Harbour_Plaza_Metropolis-Hong_Kong.html) is lightyears away from [LiQing guesthouse](/2014/09/longsheng-rice-terraces-china/); a spangly modern hotel with perfectly polished reception, speedy lifts and dazzling lights, found amidst a shopping mall. Our room was on the 17th floor and looked south to Kowloon and Hong Kong Island. All the plug sockets were British and the shower was big enough for two.
 
-{% figure china-hong-kong-001.jpg landscape %}View of Hong Kong island from our room at Harbour Plaza Metropolis{% endfigure %}
+{% figure china-hong-kong-001.jpg landscape %}
+View of Hong Kong island from our room at Harbour Plaza Metropolis
+{% endfigure %}
 
 This was the first hotel in three weeks of travel with a swimming pool, and despite having just one free day in Hong Kong we’d be making the most of it. On the top floor, where the best views are, is a private lounge that you need to pay extra to access (although Samantha managed to sneak some early-morning dawn shots from there before the place properly opened). Breakfast wasn’t included and it’s pricey, 150HKD each (about £15), but not wanting to traipse around looking for a cafe on our last day of holiday, we’d indulge here too.
 
@@ -41,8 +45,14 @@ In the cooler night time we set out with tripods and cameras. A gig was going on
 
 Stopping just before the Star ferry port we setup our tripods and gazed out at the extraordinary Asian skyline in all its neon luminescent glory. Red sailed tourist-galleons sailed by, and the sky was clear. Nowhere else in the world looks quite like this.
 
-{% figure china-hong-kong-005.jpg landscape %}Samantha, a tripod and the Hong Kong skyline{% endfigure %}
+{% figure china-hong-kong-005.jpg landscape %}
+Samantha, a tripod and the Hong Kong skyline
+{% endfigure %}
 
-{% figure china-hong-kong-007.jpg landscape %}Classic Hong Kong skyline, as seen from Kowloon{% endfigure %}
+{% figure china-hong-kong-007.jpg landscape %}
+Classic Hong Kong skyline, as seen from Kowloon
+{% endfigure %}
 
-{% figure china-hong-kong-003.jpg landscape %}A long exposure of Hong Kong as an old red-sailed galleon passes close by{% endfigure %}
+{% figure china-hong-kong-003.jpg landscape %}
+A long exposure of Hong Kong as an old red-sailed galleon passes close by
+{% endfigure %}

--- a/source/_posts/hong-kong-china/2.md
+++ b/source/_posts/hong-kong-china/2.md
@@ -15,7 +15,9 @@ page: 2
 
 Sam awoke at some awful early hour of the morning to find the sunlight catching the skyscrapers beautifully, I stayed in bed while she zipped about the hotel trying to find the best vantage point, one that wouldn’t be through some grubby hotel windows; the executive rooftop lounge worked.
 
-{% figure china-hong-kong-day-2-001.jpg landscape %}Hong Kong island at dawn{% endfigure %}
+{% figure china-hong-kong-day-2-001.jpg landscape %}
+Hong Kong island at dawn
+{% endfigure %}
 
 ## Half-day relaxing
 
@@ -25,15 +27,23 @@ Despite having just a single full day in Hong Kong to explore the city’s offer
 
 We had only one aim for the day, which was to cross over to Hong Kong island and checkout Victoria Peak at sundown — and to take pictures, of course. We begun on the Avenue of Stars, and crossed over to Central on the easy star ferry, only 10HKD each (£1). From the ferry we meandered south, along the covered walkways which bypass the busy roads below. At the Apple store hordes were queuing for the iPhone 6, and we passed people in the overpass with boxes of them, presumably to sell on at a profit. Quite by mistake we found ourselves stuck inside an Armani mall; Armani suits, shoes, children’s clothes, even flowers. Stuck in this hellish luxury labyrinth, we desperately asked at the help desk for a way out.
 
-{% figure china-hong-kong-day-2-002.jpg landscape %}Queues at the Apple store for the iPhone 6{% endfigure %}
+{% figure china-hong-kong-day-2-002.jpg landscape %}
+Queues at the Apple store for the iPhone 6
+{% endfigure %}
 
-{% figure china-hong-kong-day-2-003.jpg landscape %}Central, Hong Kong{% endfigure %}
+{% figure china-hong-kong-day-2-003.jpg landscape %}
+Central, Hong Kong
+{% endfigure %}
 
-{% figure china-hong-kong-day-2-004.jpg landscape %}Trams of Hong Kong, by the HSBC building{% endfigure %}
+{% figure china-hong-kong-day-2-004.jpg landscape %}
+Trams of Hong Kong, by the HSBC building
+{% endfigure %}
 
 The Lonely Planet guide recommended Norman Foster’s HSBC building, but on a weekend it shuts at midday and its innards were being renovated for HSBC’s 150th anniversary. We gawked at the outside and continued up the hill towards the peak tram station where we stopped at Pacific Coffee for ice cold (brain-freeze) passion fruit and mocha espresso drinks. Far too early to go up to the peak, we explored the nearby Hong Kong park and its perfect ponds, and the small [Flagstaff House museum of tea-ware](https://foursquare.com/v/flagstaff-house-museum-of-tea-ware-%E8%8C%B6%E5%85%B7%E6%96%87%E7%89%A9%E9%A4%A8/4b0588d5f964a52024dc22e3) (which inevitably brought up the same old arguments about whether we should be buying an ornate Chinese tea set). For lunch we found [The Petit Café](https://foursquare.com/v/the-petit-caf%C3%A9/4df1d786d1649c8a28dc03f3), a perfect takeaway delicatessen with wholesome salads, brie panini and homemade quiche; something we’d never have discovered without Foursquare and free roaming.
 
-{% figure china-hong-kong-day-2-005.jpg landscape %}"Courting" sculpture in Hong Kong park{% endfigure %}
+{% figure china-hong-kong-day-2-005.jpg landscape %}
+"Courting" sculpture in Hong Kong park
+{% endfigure %}
 
 ## Victoria peak
 
@@ -43,23 +53,35 @@ Hong Kong is all about shopping, and this peak park area is no exception, at the
 
 An old tram near the station has free maps of the area, showing all the walks — where to go for viewpoints and how to walk down if you wanted to. We headed west along the quiet and lovely [Lugard  trail (盧吉道)](http://en.wikipedia.org/wiki/Lugard_Road), a circular route 400m above sea level offering fabulous panoramic views over Victoria harbour. It’s a road, sort of, too narrow for cars but some vehicles have permits to use it; but that means there’s no benches to perch on, so we sat on the concrete floor to eat our lunch (though by now it was dinner time), with views out between the railings of the International Commerce Centre and One Island East. We were joined by a puffy out of breath poodle, panting and splayed out on the floor to cool down (until we opened the salami).
 
-{% figure china-hong-kong-day-2-006.jpg square %}Preparing for sunset{% endfigure %}
+{% figure china-hong-kong-day-2-006.jpg square %}
+Preparing for sunset
+{% endfigure %}
 
 The plan was for both of us to take pictures from the peak, walkabout lens on the full size tripod and the wide angle on the gorilla pod. But the lens swap was a bit of a disaster, somehow managing to get fluff on the walkabout and on the 500D’s sensor. For a short stressful moment we thought both cameras had sensors too dirty to use. While the sun set I snapped away, exposures growing longer, skies darkening. A peculiar and inexplicable channel appeared between the clouds above the city.
 
-{% figure china-hong-kong-day-2-007.jpg landscape %}Panorama of Hong Kong at sunset, from Victoria Peak{% endfigure %}
+{% figure china-hong-kong-day-2-007.jpg landscape %}
+Panorama of Hong Kong at sunset, from Victoria Peak
+{% endfigure %}
 
-{% figure china-hong-kong-day-2-000.jpg landscape %}Hong Kong in twilight, from Victoria Peak{% endfigure %}
+{% figure china-hong-kong-day-2-000.jpg landscape %}
+Hong Kong in twilight, from Victoria Peak
+{% endfigure %}
 
 Meanwhile Sam resigned herself to not taking pictures, but made sure I’d photograph the composition she wanted. She explored Lugard road and, as Sam is quite excellent at, made friends with other people on the peak, this time a German couple who were both professional photographers, they were trying out Sony’s new mirror-less camera (“it’s a new toy”). The nighttime cityscapes were interrupted by wildlife, an inquisitive hand-sized praying mantis made an appearance which we all tried to photograph, and then we headed home.
 
-{% figure china-hong-kong-day-2-008.jpg landscape %}Praying mantis{% endfigure %}
+{% figure china-hong-kong-day-2-008.jpg landscape %}
+Praying mantis
+{% endfigure %}
 
-{% figure china-hong-kong-day-2-010.jpg landscape %}Hong Kong at night. Like a scene from Blade Runner.{% endfigure %}
+{% figure china-hong-kong-day-2-010.jpg landscape %}
+Hong Kong at night. Like a scene from Blade Runner.
+{% endfigure %}
 
 At the tram station there were insane queues of 90mins to get down the hill, and taxis were charging a ludicrous 300HKD (£30) for a 10 minute drive. We found an English couple, both medics travelling before they emigrate to New Zealand, and considered sharing a taxi; instead we all took the quiet and scenic (but now quite dark) path down the hill, using the 40 min walk as an opportunity to chat about our travels. Amidst a conversation about Vietnam’s “best bits” came sudden shrieks of terror, a porcupine, about the size of a small dog, that was merrily minding its own business was suddenly startled by us and it got a bit defensive; the rodent with its back to us raised all its quill-like spikes and shook its rattlesnake tail — which then startled most of us. None of us had seen a porcupine before but we soon left it to calm down in the dark by itself. The hill is steep but we soon arrived back in Central, the clock was approaching 10pm, our stomachs were missing out on dinner. We said goodbye to our Victoria peak companions and headed back to the hotel.
 
-{% figure china-hong-kong-day-2-009.jpg landscape %}Porcupine{% endfigure %}
+{% figure china-hong-kong-day-2-009.jpg landscape %}
+Porcupine
+{% endfigure %}
 
 On the Star ferry back we chatted to some regular visitors about how Hong Kong has changed in the last 10 years; “more and more mandarin is being spoken in the city” they said, ads are in Chinese — before it, “was all English”; more Chinese are visiting Hong Kong — “for luxury shopping and healthcare”, (women visiting from China may need a ‘routine’ pregnancy test, a Hong Kong passport is a desired thing), “there are more road accidents too”. Chinese nationals have a quota which limits how often they can come to Hong Kong we were told, the quota is higher for residents of Shenzhen and Guangzhou. Thankful for our British passports we disembarked, bought ice cream with the last of our HKD and walked back to Harbour Plaza.
 

--- a/source/_posts/hue-vietnam.md
+++ b/source/_posts/hue-vietnam.md
@@ -22,9 +22,13 @@ Soon enough it was time to go, a 40 minute taxi ride to Da Nang, a little too ho
 
 We were in the front carriage of our train, soft seats with air conditioning and a television that played Vietnamese comedy. The train followed the Hai Van peninsula north, along the gorgeous coastline.
 
-{% figure hue-304.jpg portrait %}On the train from Da Nang to Hue{% endfigure %}
+{% figure hue-304.jpg portrait %}
+On the train from Da Nang to Hue
+{% endfigure %}
 
-{% figure hue-303.jpg landscape %}Going over the Hai Van peninsula to Hue{% endfigure %}
+{% figure hue-303.jpg landscape %}
+Going over the Hai Van peninsula to Hue
+{% endfigure %}
 
 The twelve train carriages snaked left and right, up and down the mountainside. Da Nang appearing against the coastline every now and then, the odd tunnel plunging us into darkness.
 
@@ -38,7 +42,9 @@ Passing locals with our backpacks, we were greeted with smiles, the occasional l
 
 Our room was a little smaller than before, and the wifi a little patchy, but we had a balcony overlooking Perfume River, and at twilight it really was quite beautiful. The enormous flag tower stands proudly in the distance, marking the entrance to both the citadel and the imperial city.
 
-{% figure hue-307.jpg landscape %}Our room at La Residence{% endfigure %}
+{% figure hue-307.jpg landscape %}
+Our room at La Residence
+{% endfigure %}
 
 ##  Le Parfum restaurant
 
@@ -46,10 +52,14 @@ Too exhausted to venture out into the heat, we chose to eat at the hotel's rathe
 
 With some white wine and a Festival beer, we enjoyed the four elements of Hue starter, while trying to avoid any Mosquitoes. The starters was comprised of Fire: scrambled egg, scallop and Minh Mang; Earth: Grilled chicken stuffed with truffle; Wind: Green papaya with ginger salad and deep fried rice coated prawns and Water: Exotic fruits gazpacho, mango sorbet and pesto. Yumm-eeee.
 
-{% figure hue-308.jpg landscape %}The four elements of Hue starter{% endfigure %}
+{% figure hue-308.jpg landscape %}
+The four elements of Hue starter
+{% endfigure %}
 
 And our mains were simply scrumptious too. Pan Fried Mahi Mahi crusted with Vietnamese coffee, chocolate and local spices, with turmeric rice, asia pear salad and spicy lemongrass rougail and garlic emulsion. Grilled calamari with Vietnamese satay and lemongrass, pineapple fried rice, shrimp and sautéed pak choi with garlic. Delicious.
 
 And for dessert, a little risky, Durian ice cream with papaya fruit and star anise. It was sort of like a Vietnamese rhubarb crumble.
 
-{% figure hue-310.jpg landscape %}Durian ice cream with papaya fruit and star anise{% endfigure %}
+{% figure hue-310.jpg landscape %}
+Durian ice cream with papaya fruit and star anise
+{% endfigure %}

--- a/source/_posts/hue-vietnam/2.md
+++ b/source/_posts/hue-vietnam/2.md
@@ -19,7 +19,9 @@ We reached the busy white Phu Xuan bridge and crossed the river. A motorcycle st
 
 At the end of the bridge the huge 37m flag pole towered above us. We walked left, down another busy road, over a moat, through the Quang Duc gate and into the citadel, a walled city that is the heart of Hue.
 
-{% figure hue-311.jpg landscape %}Hue's enormous flag pole{% endfigure %}
+{% figure hue-311.jpg landscape %}
+Hue's enormous flag pole
+{% endfigure %}
 
 At the gate there are five cannons, representing the five elements, and at the opposite gate, Ngan, there are four, for the four seasons. We studied them, mainly as means of staying in the shade. Then, in the heat once more, we strolled in front of the imperial enclosure, along another moat. This is a fortified citadel within a citadel, and its entrance is behind the flag pole, you just have to walk the long way round to get there.
 
@@ -27,7 +29,9 @@ At the gate there are five cannons, representing the five elements, and at the o
 
 We entered through the grand Ngo Mon gate, with its billowing red Vietnamese flags. Though visitors enter through a side gate, the main opening is reserved for emperors, of which today there are none.
 
-{% figure hue-312.jpg landscape %}Ngo Mon Gate, Entrance to the imperial enclosure{% endfigure %}
+{% figure hue-312.jpg landscape %}
+Ngo Mon Gate, Entrance to the imperial enclosure
+{% endfigure %}
 
 This enclosure, and the citadel, were all built in 1802, when the then emperor, Gia Long, founded the Nguyen dynasty and the capital moved south from Hanoi to Hue. But of the 148 structures in the ornate enclosure, only 20 have survived the French and American wars, with much of the area obliterated right at the end of the American war.
 
@@ -41,7 +45,9 @@ Out the back a Samsung TV runs on a loop, showing a video which explains the lay
 
 The palace opens out onto a courtyard; sitting pretty in the middle lies a great golden dragon, both menacing and bemused, and perhaps in need of a dentist, its teeth splayed out awkwardly. On either side were old imperial offices, now tourist shops and art galleries. One room let's you dress in traditional imperial clothes and have a photo taken, for a fee. The corridors and buildings immediately beyond are being renovated, many of them completely rebuilt, with new wooden pillars and roofing just going up.
 
-{% figure hue-315.jpg landscape %}A bemused golden dragon{% endfigure %}
+{% figure hue-315.jpg landscape %}
+A bemused golden dragon
+{% endfigure %}
 
 From these new buildings we headed West, and found ourselves looking out into a grassy field where two elephants were roped up, waiting for someone to pay for a ride. The larger of the two was missing a tusk. A donkey and cart trotted by, the cart a red and golden affair. There wasn't anyone taking the ride, but given the size of this place it would probably be worthwhile. At a little hut, seemingly a restaurant, but without any food, we took pleasure in our fast melting ice lollies. Sam won a MacBook Pro, apparently.
 
@@ -51,9 +57,13 @@ We double backed and visited what once was the Forbidden City. Beyond the courty
 
 Only the galleries seemed to have survived, and much of that was newly built. Between them, and away from the sprawling grasses, some perfectly trimmed tortoise topiary has been added. Walking about the ruins, you find shards of ornate tile work, intricate decorations blown apart, scattered, amongst grass, or mud, or part buried.
 
-{% figure hue-321.jpg landscape %}Corridors being rebuilt{% endfigure %}
+{% figure hue-321.jpg landscape %}
+Corridors being rebuilt
+{% endfigure %}
 
-{% figure hue-317.jpg landscape %}Feeding the topiary tortoise{% endfigure %}
+{% figure hue-317.jpg landscape %}
+Feeding the topiary tortoise
+{% endfigure %}
 
 We kept stopping in shade to rest. It was hard going and we were hungry. We stopped by the emperor's old reading room, then beneath some trees, then beneath some stands with cool tiled floors and a light breeze.
 
@@ -61,11 +71,15 @@ We kept stopping in shade to rest. It was hard going and we were hungry. We stop
 
 We stumbled onto the rebuilt Royal theatre, a music and dance show was in mid swing, it looked good through the slit wooden panels as I sipped on my cold 7up. We decided to come back another day and watch the full show. Slightly beyond lay an area filled with scaffolding, and old building parts, marked with green numbers. Renovations in full flow.
 
-{% figure hue-320.jpg landscape %}Numbered items waiting for restoration{% endfigure %}
+{% figure hue-320.jpg landscape %}
+Numbered items waiting for restoration
+{% endfigure %}
 
 4pm now, and we were desperate for some food. Despite the size of this place, all you could buy were ice creams, and a lowly packet of crisps. We searched high and low for more food, and kept uncovering huge parts of the enclosure we hadn't seen. Eventually, amidst the gorgeous To Mieu temple complex, which we realised we weren't taking in, we decided to head back. And come back another day to finish it all off. A giant spider, waiting in the dark, on the wall of a temple, helped us make that decision.
 
-{% figure hue-323.jpg landscape %}To Mieu temple{% endfigure %}
+{% figure hue-323.jpg landscape %}
+To Mieu temple
+{% endfigure %}
 
 ## To the pool
 
@@ -75,4 +89,6 @@ Exhausted from the days trek, the heat and the sun, we took a dip in the very de
 
 Up in our room the sun was setting, and twilight across the river and the pool was lovely. In the evening we really did relax. We sat in the bar with some cocktails, planning tomorrow, reading about some tours, writing about Hoi An and listening to the bar's chill out music (from a Spotify playlist no less).
 
-{% figure hue-325.jpg landscape %}Twilight view from our room at La Residence{% endfigure %}
+{% figure hue-325.jpg landscape %}
+Twilight view from our room at La Residence
+{% endfigure %}

--- a/source/_posts/hue-vietnam/3.md
+++ b/source/_posts/hue-vietnam/3.md
@@ -19,19 +19,27 @@ Getting out of the car, we faced three flights of stairs to the top. Immediately
 
 Up the first flight of stairs, and we are in the Honour Courtyard, where lines of statues are placed, servants and armies to aid the emperor in his afterlife. Between the rows of statues lies a small building, inside, in Chinese scripture, it details how to build the mausoleum. Our guide explains the meanings the emperors gave to numbers, and the importance of colours, though most of that escapes me now.
 
-{% figure hue-328.jpg landscape %}Samantha and I, with a bearded stone man{% endfigure %}
+{% figure hue-328.jpg landscape %}
+Samantha and I, with a bearded stone man
+{% endfigure %}
 
 We climb up two more flights of stairs, to the main building, Thien Dinh, and Khai Dinh's resting place. He died in 1925. The outside is dark, concrete and gothic; but inside there's an explosion of colour, it is golden and beautiful. Sculptures of dragons climb the walls, old broken pottery is coerced into great depictions of the four seasons, with quaint cute little birds at every intersection. The back most room, where the tomb lies, is even more detailed, with deranged dragons circling the ceilings. And sitting in the centre, a life size golden statue of Khai Dinh himself, on his golden throne. Behind, a ruby blazoned sunrise.
 
 The room to the far left is understated. A bronze statue of Khai Dinh as a leader, with hand on sword, sits near to a painting of him at his writing desk. Around the edges are antique European furniture, and cupboards filled with ancient crockery.
 
-{% figure hue-330.jpg landscape %}Emperor Khai Dinh's golden statue{% endfigure %}
+{% figure hue-330.jpg landscape %}
+Emperor Khai Dinh's golden statue
+{% endfigure %}
 
-{% figure hue-331.jpg portrait %}Emperor Khai Dinh's bronze statue{% endfigure %}
+{% figure hue-331.jpg portrait %}
+Emperor Khai Dinh's bronze statue
+{% endfigure %}
 
 Stepping out of the tomb, the veranda opens up to a stunning view of the surrounding hills. In the distance, a towering modern white Buddha pokes his head out. We took our photos, though are guide never quite moved out of the way enough. His head or hand always slightly in the way.
 
-{% figure hue-334.jpg landscape %}The view from Khai Dinh's mausoleum, with Samantha (and our guide){% endfigure %}
+{% figure hue-334.jpg landscape %}
+The view from Khai Dinh's mausoleum, with Samantha (and our guide)
+{% endfigure %}
 
 ### Minh Mang’s mausoleum
 
@@ -41,29 +49,39 @@ This mausoleum is much more traditional, in a sublime natural setting; trees, pl
 
 We entered through a side entrance (another main entrance reserved only for an emperor), into a baking open courtyard with dragon and lion statues. A direct path leads from the outer wall, through three complexes, each up and down stairs, to the hill and the emperor's resting place. We proceeded through decorated arches, paved promenades and red painted pavilions, each separated with lakes and gardens.
 
-{% figure hue-340.jpg landscape %}Minh Mang's mausoleum{% endfigure %}
+{% figure hue-340.jpg landscape %}
+Minh Mang's mausoleum
+{% endfigure %}
 
 The Asian gardens were beautiful and relaxing, we could have spent all day here. Indeed, we spent a long time just sitting, watching the view, listening to the birds, and drinking cold drinks. Sat on an old red painted doorframe at the last of the pavilions, we looked out at a path which led over lotus filled ponds and beneath royal signage to the giant hill where the emperor lies and its locked gate. Above us, blue skies and fluffy white clouds.
 
-{% figure hue-343.jpg landscape %}Paul posing at Minh Mang's mausoleum (and our guide){% endfigure %}
+{% figure hue-343.jpg landscape %}
+Paul posing at Minh Mang's mausoleum (and our guide)
+{% endfigure %}
 
 ### Dragon boat
 
 Not really wanting to leave, we set off to meet our dragon boat, a garish sky blue boat with a yellow painted dragon's head. We left Minh Mang's tomb and set off up stream, back towards Hue, it took about an hour. It was a long, slow journey with not much to see. Men on boats churned the riverbed, collecting salt, or mud, or minerals, to sell. Cattle grazed by the river, and there were the occasional small villages by the water, with more moored boats than buildings. We passed a couple of other tourists along the way, and our driver tried to sell us goods, but when we showed no interest she put away the tourist tat.
 
-{% figure hue-345.jpg landscape %}The blue dragon boat{% endfigure %}
+{% figure hue-345.jpg landscape %}
+The blue dragon boat
+{% endfigure %}
 
 ### Thien Mu pagoda
 
 We arrived at the Thien Mu pagoda which overlooks Perfume River. It's 21m high, octagonal and has seven storeys. Beyond the pagoda are a couple of humble active temples with practicing monks. Inside the temple we removed our shoes and watched as others paid their respects, burning incense before a giant Buddha statue.
 
-{% figure hue-347.jpg portrait %}Thien Mu Pagoda{% endfigure %}
+{% figure hue-347.jpg portrait %}
+Thien Mu Pagoda
+{% endfigure %}
 
 We also poked out heads into some of the monk's side buildings, where they were mostly having lunch. This place is known for housing the blue Austin Westminster car that the monk Thich Quang Duc took to Saigon before his famous self immolation.
 
 At the back there's a lovely bonsai tree garden and a newly erected pagoda in memory of a recently passed senior monk. Through the fence at the very rear, in amongst all the pine trees, a huge graveyard can be seen, one of many out of town Vietnamese graves in the country.
 
-{% figure hue-348.jpg portrait %}Samantha, doing a pose{% endfigure %}
+{% figure hue-348.jpg portrait %}
+Samantha, doing a pose
+{% endfigure %}
 
 The boat took us directly back to the hotel, stopping at a jetty right next to it. In our room we ate fruit and snacks, rested and then headed out into town for dinner.
 
@@ -71,10 +89,14 @@ The boat took us directly back to the hotel, stopping at a jetty right next to i
 
 We took a taxi to the Tran Tien bridge and wandered around the park as we waited to grow hungry. A huge storm was brewing over the river. Despite this, the budding capitalist Vietnamese kept offering to sell us boat trips. I refused and gestured to the sky.
 
-{% figure hue-350.jpg landscape %}A storm over Perfume River{% endfigure %}
+{% figure hue-350.jpg landscape %}
+A storm over Perfume River
+{% endfigure %}
 
 Near the river was a large white lotus shaped restaurant, intriguing but a little too kitschy for our taste. We set about exploring the Eastern streets of Hue, shopping for snacks, tweezers and other odds and ends. Down a small side alley we found a recommended restaurant, one of Lonely Planet's top picks, Anh Binh, and it looked nice.
 
 But our table had ants on it, and when we moved they came with us. It seems every evening meal in Hue would be thwarted by ants of some kind or another. We persevered, our springs rolls were of the average out-of-a-packet variety and came with a peculiar snowman carving. The mains were average too, Sam described her beef dish as “normal”, my eel dish was tasty, but all too boney. The Lonely Planet description wasn't fitting at all. The demeanour of the waiters was interesting too, any orders were shouted, one at a time, to the next person, one by one until it reached the kitchen. The furniture was nice though.
 
-{% figure hue-351.jpg landscape %}A peculiar snowman{% endfigure %}
+{% figure hue-351.jpg landscape %}
+A peculiar snowman
+{% endfigure %}

--- a/source/_posts/hue-vietnam/4.md
+++ b/source/_posts/hue-vietnam/4.md
@@ -13,17 +13,23 @@ We returned to the imperial enclosure and the Royal Theatre for the dancing we h
 
 The performance was by the Theatre of Hue and Traditional Arts, and many of the dances originated here as part of the imperial court. The theatre itself had row after row of red and golden chairs leading to an ornate stage with a throne at the centre. Dragons swirl about the edges, and upstairs a balcony surrounded the room. It had all been rebuilt on former foundations, and had originally started in 1826.
 
-{% figure hue-352.jpg landscape %}Samantha, waiting for the show to begin{% endfigure %}
+{% figure hue-352.jpg landscape %}
+Samantha, waiting for the show to begin
+{% endfigure %}
 
 The opening act saw four men, dressed in red and gold robes, playing traditional instruments. A simple introduction that made way to a dragon dance. Two large dragons, one yellow, one green, each moved by two dancing people, swayed and pranced about the stage, behaving as if they were real, a convincing illusion. Their giant heads swayed to the beat of a carnal drum, and they ceremoniously mated to magically produce a baby dragon. It was all very impressive.
 
-{% figure hue-353.jpg landscape %}Dragon and baby{% endfigure %}
+{% figure hue-353.jpg landscape %}
+Dragon and baby
+{% endfigure %}
 
 The second dance was a fan dance (vũ phiến), and eight ladies in pink, with yellow fans in each hand and blue headdresses swirled and moved to create undulating repeating patterns. They'd line up and create cascading fan effects, rippling down the line in a manner that felt natural and harmonious, as if one.
 
 A nine piece instrumental act followed, with even more weird and wonderful instruments I'd never seen or heard before. And then to the finale, a sixteen person lantern dance (lục cúng hoa đăng), all the lights dimmed, and in each hand they held a candle. Moving in the dark, the flames floated, creating magical shapes; the dancers lifted each other up, higher and higher, making ever more strange and interesting compositions of light, all to traditional live music.
 
-{% figure hue-354.jpg landscape %}A spectacular lantern dance{% endfigure %}
+{% figure hue-354.jpg landscape %}
+A spectacular lantern dance
+{% endfigure %}
 
 ## Imperial enclosure
 
@@ -33,9 +39,13 @@ Only half an hour long, it was very good, and worth the early morning and 70,000
 
 We followed the road around the edge of the enclosure, past the University of Arts and to the West corner, and the restored Truong San residence. Although the buildings were beautiful, they were themselves empty, dark and echoey inside. Still water surrounded them, like a moat, and filled with purple flowers. A young girl and her mum played amongst the yellow walled, red doored buildings of the house, flowers in their hair, sitting on the steps and being cute for the camera. The walls were rich with colour, blue shapes marked into yellow walls, sculptures standing tall on ornate gateways. On the rooftops, gaudi-esque dragons clamber from the corners, and blue marbled sculptures are embedded in the walls. The old, original imperial city must have been very special.
 
-{% figure hue-355.jpg landscape %}Tree roots on a wall{% endfigure %}
+{% figure hue-355.jpg landscape %}
+Tree roots on a wall
+{% endfigure %}
 
-{% figure hue-360.jpg landscape %}Pose for the camera{% endfigure %}
+{% figure hue-360.jpg landscape %}
+Pose for the camera
+{% endfigure %}
 
 ### Dien Tho residence
 
@@ -47,15 +57,21 @@ And from here we found ourselves where we left off on Thursday, the To Mieu Temp
 
 We had to take our shoes off before entering the temple which houses shrines and dedications to each of the former emperors. Each shrine is placed in a line, with a portrait on top. The ceilings and columns are a deep red, with golden engravings and ribbons. Red and gold everywhere.
 
-{% figure hue-366.jpg portrait %}Inside the To Mieu Temple{% endfigure %}
+{% figure hue-366.jpg portrait %}
+Inside the To Mieu Temple
+{% endfigure %}
 
 Outside the pavilion a local art class were sketching their own interpretations of dragons, bronze urns and the buildings. Younger children sat on the dragon balustrades, pretending to ride them. Of course Sam had to have a go too.
 
-{% figure hue-363.jpg landscape %}Children playing on the stone dragons{% endfigure %}
+{% figure hue-363.jpg landscape %}
+Children playing on the stone dragons
+{% endfigure %}
 
 And now we had seen all four corners of the enormous imperial city. We left via the central temple, then out through the north exit and a little cafe on the north most wall where we had Vietnamese coffee. Outside it started to rain.
 
-{% figure hue-370.jpg landscape %}A water lily outside the cafe{% endfigure %}
+{% figure hue-370.jpg landscape %}
+A water lily outside the cafe
+{% endfigure %}
 
 ## Exploring the citadel
 

--- a/source/_posts/hue-vietnam/5.md
+++ b/source/_posts/hue-vietnam/5.md
@@ -9,12 +9,18 @@ page: 5
 
 Most of the morning in Hue was spent packing. Sam ran about taking photos of the hotel too, and all the emperor's portraits scattered about the place. We had one last breakfast at La Residence, the kind Irish chef made Sam a couple of pancakes and a dippy runny egg. Enough to keep her going all day. As usual I couldn't eat much, it being travel day and breakfast time.
 
-{% figure hue-372.jpg landscape %}Breakfast at La Residence{% endfigure %}
+{% figure hue-372.jpg landscape %}
+Breakfast at La Residence
+{% endfigure %}
 
-{% figure hue-377.jpg landscape %}Our bulging bags, packed and ready to go{% endfigure %}
+{% figure hue-377.jpg landscape %}
+Our bulging bags, packed and ready to go
+{% endfigure %}
 
 It was time to go and our bags were bulging, bursting at the seams and, of course, heavy. We still had two weeks to go! From the hotel we took a taxi to the station, what would have been a five minute walk, but we'd tried that before. This train was on time, and we clambered on board. Two seats were dedicated to our bags, good job the train wasn't busy. Little did we know today was Vietnam's celebration of independence and Ho Chi Minh's birthday.
 
 It was a four hour trip. And we were on our way to [Phong Nha, via Dong Hoi](/2012/12/phong-nha-vietnam/).
 
-{% figure hue-376.jpg landscape %}Goodbye Hue{% endfigure %}
+{% figure hue-376.jpg landscape %}
+Goodbye Hue
+{% endfigure %}

--- a/source/_posts/iguacu-falls-brazil.md
+++ b/source/_posts/iguacu-falls-brazil.md
@@ -19,11 +19,15 @@ page: 1
 
 ## Rio to Iguaçu
 
-{% figure brazil-176.jpg landscape %}Iguazu Falls{% endfigure %}
+{% figure brazil-176.jpg landscape %}
+Iguazu Falls
+{% endfigure %}
 
 We flew Gol airlines to Foz do Iguacu, and with our Lonely Planet guide we knew to sit on the left side of the plane for the best view of the falls. It only took an hour or so to get there, and when we landed at 3pm it felt like a different country; clear skies, 30C and a hot wind.
 
-{% figure brazil-083.jpg landscape %}Iguazu falls from the flight into Foz do Iguaçu{% endfigure %}
+{% figure brazil-083.jpg landscape %}
+Iguazu falls from the flight into Foz do Iguaçu
+{% endfigure %}
 
 Outside the airport we befriended a Canadian couple going to the same place as us, and we waited half an hour for the green bus that runs every 20 mins. Eventually it arrived and we paid the R$3 bus fare to Parque Nacional do Iguaçu before struggling to lift our heavy backpacks over the in-bus turnstile whilst the vehicle zoomed around a corner, flinging us left and right. Turnstiles are a trait common to all brazilian buses. At the park we paid the R$40 entrance fee and caught an in-park bus towards the waterfalls.
 
@@ -31,7 +35,9 @@ Outside the airport we befriended a Canadian couple going to the same place as u
 
 We were staying at Hotel Cataratas, a five star orient express hotel. This was our splurge, a small slice of decadence and a chance to indulge in a little grandeur and opulence. After all, we’d had a friendly cheque from the HMRC, so why not treat ourselves?
 
-{% figure brazil-110.jpg portrait %}Our room in Hotel Cataratas{% endfigure %}
+{% figure brazil-110.jpg portrait %}
+Our room in Hotel Cataratas
+{% endfigure %}
 
 Despite a spa, pool, gourmet food and utter luxury, the main advantage of this hotel, and the reason we stayed here, is its location. It’s the only hotel inside the national park and gives all guests unrestricted access to the park whilst it is closed to the public. So, at sunset, or even sunrise, you can have the place to yourself, without teems of tourists. The hotel entrance is a mere minute walk from your first spectacular view of the waterfalls, but set back enough so as not to distract from the scenery. It’s the hotel all visitors wish they were staying at.
 
@@ -39,49 +45,75 @@ We’d booked a pricey two nights, and arrived at 5pm, just as the park was clos
 
 The sounds of nature enriched the place, birds nested above the restaurant and huge lizards scuttled about, as if on a day trip from the forest. Swallows flitted down and drank from the pool. By the pool we covered ourselves in bug repellant and sun lotion and tried a vanilla ice cream and coke cocktail.
 
-{% figure brazil-085.jpg landscape %}Sam by the hotel pool{% endfigure %}
+{% figure brazil-085.jpg landscape %}
+Sam by the hotel pool
+{% endfigure %}
 
 ## Exploring the falls at dusk
 
 Time to explore the ‘cataratas’ (falls) for the first time. Starting at the viewpoint closest to the hotel we took the 1.2km trilha das cataratas that follows the river shore. The first view shows a phenomenal crescent of two tiered waterfalls out across the other side of the river (on the Argentinian side).
 
-{% figure brazil-092.jpg landscape %}Exploring the falls at dusk{% endfigure %}
+{% figure brazil-092.jpg landscape %}
+Exploring the falls at dusk
+{% endfigure %}
 
-{% figure brazil-093.jpg landscape %}Crashing waves, just a small part of the falls{% endfigure %}
+{% figure brazil-093.jpg landscape %}
+Crashing waves, just a small part of the falls
+{% endfigure %}
 
 It was dusk, and wildlife was coming out for the evening. Butterflies were everywhere, and they weren’t shy landing on you. From the 88 butterfly ([diaethria anna](http://en.wikipedia.org/wiki/Diaethria_anna)) to large spiders weaving their webs and millipedes walking out in front of you, the bugs and insects were abundant and you needed to be careful where you put your hands. Giant black and white tegu lizards scared us as they ran out in front of us, across the trail. Some reached up to four foot in length.
 
-{% figure brazil-090.jpg landscape %}Little [Callicore](http://en.wikipedia.org/wiki/Callicore) butterfly{% endfigure %}
+{% figure brazil-090.jpg landscape %}
+Little [Callicore](http://en.wikipedia.org/wiki/Callicore) butterfly
+{% endfigure %}
 
-{% figure brazil-091.jpg landscape %}88 butterfly ([diaethria anna](http://en.wikipedia.org/wiki/Diaethria_anna)){% endfigure %}
+{% figure brazil-091.jpg landscape %}
+88 butterfly ([diaethria anna](http://en.wikipedia.org/wiki/Diaethria_anna))
+{% endfigure %}
 
-{% figure brazil-087.jpg landscape %}[Richard’s Blue Morpho](http://en.wikipedia.org/wiki/Morpho_richardius) butterfly{% endfigure %}
+{% figure brazil-087.jpg landscape %}
+[Richard’s Blue Morpho](http://en.wikipedia.org/wiki/Morpho_richardius) butterfly
+{% endfigure %}
 
-{% figure brazil-088.jpg portrait original %}Monitor lizard{% endfigure %}
+{% figure brazil-088.jpg portrait original %}
+Monitor lizard
+{% endfigure %}
 
-{% figure brazil-089.jpg landscape %}Orb weaving spider{% endfigure %}
+{% figure brazil-089.jpg landscape %}
+Orb weaving spider
+{% endfigure %}
 
 As I was knelt down taking a photo of a spider, a four foot coatis clambered down beside us, sniffing around for food, “Paul, turn around, turn around now”, Sam whispered. A coatis is a sort of racoon and is common to northern Argentina. He clearly didn’t care what we were up to and was happy for us to snap some photos.
 
-{% figure brazil-120.jpg landscape %}Coatis on the path down to the falls{% endfigure %}
+{% figure brazil-120.jpg landscape %}
+Coatis on the path down to the falls
+{% endfigure %}
 
 The paved route had a green wooden barrier, and headed down towards the waterfall climax, Garganta do Diablo, with the occasional look out point. Every view along the trail was awesome, using the true meaning of the word; we couldn’t believe the power and beauty of the place as the constant sound of crashing water surrounded us, amidst blue orange skies, the odd fluffy white cloud, the fascinating wildlife and luscious forest.
 
-{% figure brazil-095.jpg portrait %}View of Garganta do Diablo from the trail{% endfigure %}
+{% figure brazil-095.jpg portrait %}
+View of Garganta do Diablo from the trail
+{% endfigure %}
 
 ### Garganta do diablo
 
 Then we reached Garganta do Diablo, where there is a walkway right out into the middle of the thundering waterfalls. The spray from the falls is like heavy rainfall, and walking out you are going to get soaked. We braved it with our bags and Sam donned a poncho for the occasion, I risked the camera too in it’s waterproof bag. Out into the falls we eked, the cold refreshing water driving into our faces, water drops trickling down our cheeks, soaking and delighting us. From the edge of the final platform you can look right down into the abyss, where the river plunges deeper into the darkness, so far and so deep all you can see is the rebounding spray and the occasional crazy swallow flying into the waterfall.
 
-{% figure brazil-097.jpg landscape %}Sam and Paul drenched under the falls{% endfigure %}
+{% figure brazil-097.jpg landscape %}
+Sam and Paul drenched under the falls
+{% endfigure %}
 
-{% figure brazil-099.jpg landscape %}Iguazu falls in black and white{% endfigure %}
+{% figure brazil-099.jpg landscape %}
+Iguazu falls in black and white
+{% endfigure %}
 
 ### Personal paradise
 
 This must be one of the most beautiful places on the planet and we had it all to ourselves at sunset. We took a moment to appreciate the glory of nature as the sun disappeared on the Argentinian side of the park and as flocks of swallows flew high above us. We slowly meandered back to our hotel, a little sopping, in awe of what we’d just experienced.
 
-{% figure brazil-106.jpg landscape %}Paul watching the waterfall as the sun sets{% endfigure %}
+{% figure brazil-106.jpg landscape %}
+Paul watching the waterfall as the sun sets
+{% endfigure %}
 
 That night we tried the hotels buffet. Sat outside by the pool we made our wine selection (or beer, I had Skol) as the nighttime frogs serenaded us and the neon blue fireflies painted the forest with light.
 

--- a/source/_posts/iguacu-falls-brazil/2.md
+++ b/source/_posts/iguacu-falls-brazil/2.md
@@ -15,7 +15,9 @@ You can get a jeep or cycle the 9km trail, but we decided to walk it, with the h
 
 We trekked along a dirt path. Certain plants were tagged with ribbons, marked for scientific use, and our guide excellently explained the flora and fauna we came across. From the beetle that saws through branches, to assorted berries on route - sniffing and squeezing to help identify them. He pointed out animal trails through the trees and identified the bird calls we could hear. The thick throaty call of a Toucan excited us, but we couldn’t spot him in the trees.
 
-{% figure brazil-112.jpg landscape %}Trying to spot a Toucan on the trail{% endfigure %}
+{% figure brazil-112.jpg landscape %}
+Trying to spot a Toucan on the trail
+{% endfigure %}
 
 The butterflies here were bigger and more beautiful than ever, and there were hundreds of them, including the huge owl butterfly with it’s bright blue inside wing. Great ants wandered around beneath our feet, and large spiders lay in wait for their prey.
 
@@ -31,13 +33,19 @@ We pressed onwards, and about half way along our guide heard the sounds of monke
 
 <iframe width="580" height="325" src="http://www.youtube.com/embed/Bbbwl2Se8bI?rel=0" frameborder="0" allowfullscreen></iframe>
 
-{% figure brazil-115.jpg landscape original %}Capuchin monkey near Iguazu falls{% endfigure %}
+{% figure brazil-115.jpg landscape original %}
+Capuchin monkey near Iguazu falls
+{% endfigure %}
 
 Onwards we trekked, 5km, then 7km, then 8km, and picking up the pace to get to the boat. Our guide always happy to answer our questions or point out interesting things, from the great dangling roots of trees, to strangling vines, to protected palms, palmito, burrows in the ground made by birds (and the dirt on nearby branches), the non-native orange tree and efforts to protect the forest and the wild papaya.
 
-{% figure brazil-113.jpg landscape %}Pausing to listen for wildlife{% endfigure %}
+{% figure brazil-113.jpg landscape %}
+Pausing to listen for wildlife
+{% endfigure %}
 
-{% figure brazil-114.jpg portrait %}Tree with great dangling vines{% endfigure %}
+{% figure brazil-114.jpg portrait %}
+Tree with great dangling vines
+{% endfigure %}
 
 In between nature we talked about life in Chicago versus England or Brazil, the oddities of language, the history of the park and other travels. All the while on the lookout for something new and exciting in the trees.
 
@@ -47,7 +55,9 @@ After three hours we reached the boat and probably the scariest loo I’ve ever 
 
 There was some commotion at the front of the boat and we all clambered to see what was going on. On the riverbank a six foot alligator was perched, covered in butterflies. We moved the boat for a closer look, and he slithered back into the river and away.
 
-{% figure brazil-117.jpg landscape original %}Alligator near Iguazu river{% endfigure %}
+{% figure brazil-117.jpg landscape original %}
+Alligator near Iguazu river
+{% endfigure %}
 
 Next up, tandem kayaking, in the same river as the alligator. As a man that can’t really swim I’ve never canoed or kayaked before, so this proved interesting. Leg over the boat, and shuffle down into the yellow kayak, frightening all the scary looking spiders in there. Push off, and we’re away, heading downstream. Now what?
 
@@ -57,27 +67,43 @@ Rather than walking the 3km back, arms and legs now thoroughly exhausted, we jee
 
 Back at the hotel we spent the rest of the afternoon by the pool, with a coconut cocktail and mango juice, and some burgers for dinner (avoiding the pricier dinner menus by getting the poolside food).
 
-{% figure brazil-119.jpg landscape %}Pink corridors of Hotel Cataratas{% endfigure %}
+{% figure brazil-119.jpg landscape %}
+Pink corridors of Hotel Cataratas
+{% endfigure %}
 
-{% figure brasil-048.jpg portrait %}Cocktail in a coconut{% endfigure %}
+{% figure brasil-048.jpg portrait %}
+Cocktail in a coconut
+{% endfigure %}
 
 ## Waterfalls at dusk (again)
 
 Not wanting to break tradition, and to make the most of the surroundings, we went back down to see the waterfalls that evening, for a second perfect sunset. This time we took the tripod and tried capturing some long exposure shots.
 
-{% figure brazil-122.jpg landscape %}Heading back to the waterfalls{% endfigure %}
+{% figure brazil-122.jpg landscape %}
+Heading back to the waterfalls
+{% endfigure %}
 
-{% figure IMG_4059.JPG landscape %}Coatis hanging out of a dustbin{% endfigure %}
+{% figure IMG_4059.JPG landscape %}
+Coatis hanging out of a dustbin
+{% endfigure %}
 
-{% figure brazil-121.jpg landscape %}Butterfly and the falls, at sunset{% endfigure %}
+{% figure brazil-121.jpg landscape %}
+Butterfly and the falls, at sunset
+{% endfigure %}
 
 The grounds were setting up for the “X-games” the next day, so on the way down we took pictures of Coatis with a group of famous skateboarders. To add to our wildlife list we saw two Agouti rodents (like giant rats but without tails) scavenging for food. Despite the skateboarders on their way back up the trail was quiet, and down by Garganta do Diablo we had the incredible falls to ourselves again. This time we came in swimwear and fully embraced the water. Despite doing it for the second time, it was as amazing as ever, and we stayed until darkness capturing photos and drying off in the warm evening.
 
-{% figure brazil-130.jpg landscape %}Paul by himself at the centre of Garganta do diablo{% endfigure %}
+{% figure brazil-130.jpg landscape %}
+Paul by himself at the centre of Garganta do diablo
+{% endfigure %}
 
-{% figure brasil-061.jpg landscape %}Long exposure of Igauzu falls{% endfigure %}
+{% figure brasil-061.jpg landscape %}
+Long exposure of Igauzu falls
+{% endfigure %}
 
-{% figure brasil-063.jpg landscape %}Black and white long exposure{% endfigure %}
+{% figure brasil-063.jpg landscape %}
+Black and white long exposure
+{% endfigure %}
 
 ### Luminescent flying beetles
 

--- a/source/_posts/iguacu-falls-brazil/3.md
+++ b/source/_posts/iguacu-falls-brazil/3.md
@@ -23,9 +23,13 @@ Starting at 11am we took a guided jeep tour through the forest to the boat. It w
 
 At the boat we were given waterproof sacks for our bags and big orange lifejackets for the trip. We sat at the front, on sizzling hot plastic chairs that’d been left in the sun too long. The boat departed and we sped upstream, through some rapids towards the falls.
 
-{% figure brazil-139.jpg landscape %}Sam and Paul on a boat, heading out to the waterfalls{% endfigure %}
+{% figure brazil-139.jpg landscape %}
+Sam and Paul on a boat, heading out to the waterfalls
+{% endfigure %}
 
-{% figure brazil-150.jpg landscape %}A boat about to pass under one of the falls{% endfigure %}
+{% figure brazil-150.jpg landscape %}
+A boat about to pass under one of the falls
+{% endfigure %}
 
 At the falls we did one pass so we could take photos and video, taking a look at the righthand crescent of falls and then at the left most ones. Next we put everything away for the crucial second part.
 
@@ -33,19 +37,29 @@ The boat slowly crept towards the waterfalls, a light mist, then a rain shower, 
 
 Back on land we dripped until small puddles formed around our feet, large orange butterflies flew down to drink from them, and we lay on the rocks, drying off in the hot sun.
 
-{% figure brazil-146.jpg portrait %}Paul with butterflies{% endfigure %}
+{% figure brazil-146.jpg portrait %}
+Paul with butterflies
+{% endfigure %}
 
-{% figure brazil-149.jpg portrait %}Refreshing by the falls{% endfigure %}
+{% figure brazil-149.jpg portrait %}
+Refreshing by the falls
+{% endfigure %}
 
 ### Waterfall crescent
 
 From here we did the upper circuit walk, ‘Circuito Superior’. Along the top of the ‘waterfall crescent’, as I call it, there is a constructed walkway which we followed. In flip flops, I looked over the edge and watched the peaceful water turn into a raging torrent. We vied for space and the occasional good view and photo position with groups of kids and elderly coach tours. The people came in waves, and we need only wait a short while for everything to quiet down; it seems most people on this side get a guided tour of the park, which is entirely unnecessary.
 
-{% figure brazil-153.jpg landscape %}Sam watching waterfall crescent{% endfigure %}
+{% figure brazil-153.jpg landscape %}
+Sam watching waterfall crescent
+{% endfigure %}
 
-{% figure brazil-156.jpg landscape %}Waterfall crescent from circuito superior{% endfigure %}
+{% figure brazil-156.jpg landscape %}
+Waterfall crescent from circuito superior
+{% endfigure %}
 
-{% figure brazil-158.jpg landscape %}Samantha, waterfalls, a rainbow, fluffy clouds. Butterfly just out of shot.{% endfigure %}
+{% figure brazil-158.jpg landscape %}
+Samantha, waterfalls, a rainbow, fluffy clouds. Butterfly just out of shot.
+{% endfigure %}
 
 The fantastic birds were ever present, including peregrine falcons, plush crested jays that escaped my camera lens, great egret, black vulture, southern lapwing, cattle tyrant (or bandana bird as we called him) and three striped flycatchers.
 
@@ -53,7 +67,9 @@ The fantastic birds were ever present, including peregrine falcons, plush creste
 
 We stopped for some snacks and a coffee before catching the mini green train up to Garganta do Diablo. Up here is a long walkway across the wide shallow river and there’s not much to see until you’re right out into the so-called devil’s throat, where the plunge is the deepest and the air thick with rebounding mist. Again, you get soaked here too, even though you’re above everything this time. Between the crowds and water splashes we took our pictures quickly. We posed, and smiled and let the water cool us and then it was home time, ushered by staff back to the train because it was 6pm and the park was closing.
 
-{% figure brazil-165.jpg portrait %}Iguazu falls, from Argentina{% endfigure %}
+{% figure brazil-165.jpg portrait %}
+Iguazu falls, from Argentina
+{% endfigure %}
 
 <iframe width="580" height="325" src="http://www.youtube.com/embed/3LTLkLci9l0?rel=0" frameborder="0" allowfullscreen></iframe>
 
@@ -63,7 +79,9 @@ At the exit we bought some trinkets and met our driver for the return leg, back 
 
 We ate in the piano bar again and returned to our plush hotel room.
 
-{% figure brazil-171.jpg landscape %}Goodbye Igauzu{% endfigure %}
+{% figure brazil-171.jpg landscape %}
+Goodbye Igauzu
+{% endfigure %}
 
 ## Goodbye with a champagne breakfast
 

--- a/source/_posts/jiuzhaigou-huanglong-china.md
+++ b/source/_posts/jiuzhaigou-huanglong-china.md
@@ -19,7 +19,9 @@ After our traditional Tibetan breakfast ([butter tea](http://en.wikipedia.org/wi
 
 Songpan is already at an altitude of 3000m, but the route kept climbing higher and higher. Our driver stopped and offered us something on the way — all in Chinese we couldn't fathom what it was, we turned him down but later realised it was probably something for altitude sickness. We felt a little light headed, and I noticed a quickened heart rate, but otherwise we were fine, except perhaps for Sam's panicking that we wouldn't be. She stopped worrying when the beautiful sight of mountaintops shrouded in mist appeared, and in the bitterly cold wind we stopped to get some photos.
 
-{% figure china-huanglong-001.jpg landscape %}Route X120 through Min mountains to Huanglong{% endfigure %}
+{% figure china-huanglong-001.jpg landscape %}
+Route X120 through Min mountains to Huanglong
+{% endfigure %}
 
 ## Huanglong national park
 
@@ -27,25 +29,37 @@ The drive was only about an hour and soon we'd arrived at [Huanglong](http://en.
 
 From the cable car station there's a magnificent vista of the Min mountain range. It looks out on Route X120 which we'd meandered down to reach the park. The range itself sits on the edge of the Tibetan plateau. Chinese tourists jostle on the wooden platform to get the best spot for selfies and pictures taken with an iPad. Nearby there's the first of many oxygen bars for those suffering with altitude sickness, and of course there was a shop selling panda merchandise, as is custom all over Sichuan province.
 
-{% figure china-huanglong-002.jpg landscape %}Route to the clouds — view from the cable car station of the road we drove down to reach the park.{% endfigure %}
+{% figure china-huanglong-002.jpg landscape %}
+Route to the clouds — view from the cable car station of the road we drove down to reach the park.
+{% endfigure %}
 
 The paved trail lead us downwards into the national park with fabulous forest views and an occasional fleeting glimpse of the pools below. The sun hadn't broken through the clouds yet and the mountaintop plants were still glistening with dew drops.
 
 Not fully gauging how big the whole of Huanglong park is (there were no maps), we took this trail very slowly. We stopped often to photograph or watch songbirds that danced about the trees, collecting autumn berries. Six or so Chinese grouse were spotted rummaging about the undergrowth too. Above us the clouds kept the mountaintops covered.
 
-{% figure china-huanglong-003.jpg landscape %}Chinese grouse{% endfigure %}
+{% figure china-huanglong-003.jpg landscape %}
+Chinese grouse
+{% endfigure %}
 
-{% figure china-huanglong-004.jpg landscape %}Songbird in the treetops{% endfigure %}
+{% figure china-huanglong-004.jpg landscape %}
+Songbird in the treetops
+{% endfigure %}
 
-{% figure china-huanglong-005.jpg landscape %}Autumnal colours in Huanglong{% endfigure %}
+{% figure china-huanglong-005.jpg landscape %}
+Autumnal colours in Huanglong
+{% endfigure %}
 
 After an hour or so we reached the top of the park where a circular boardwalk takes you around the ‘multi-coloured pond’. Climbing the steps to reach the top of this was hard work. A lot like the Songpan hike yesterday, the altitude meant our hearts were racing, and we could feel our pulse, we felt out of breath. This part of the park is at 3500m and has over 600 tiny pools. Eventually we made it to the pond, which sits above the valley alongside an old temple. A bit unexpectedly we were joined by hundreds of other tourists.
 
 The pools were a gorgeous blue, but to begin with, from the crowded boardwalk viewpoints it was hard to capture in a photo; the overcast sky bleached the water. It wasn't until we'd walked further around to a higher vantage point that the colours really dazzled us. The light blue tones covered the calcium pools — each filled to the brim with water. The pools are divided by mesmerising wavy borders, built from calcium over thousands of years.
 
-{% figure china-huanglong-013.jpg landscape %}The stunning [turquoise pools of Huanglong](https://500px.com/photo/87465515/pools-of-huanglong-by-paul-hayes){% endfigure %}
+{% figure china-huanglong-013.jpg landscape %}
+The stunning [turquoise pools of Huanglong](https://500px.com/photo/87465515/pools-of-huanglong-by-paul-hayes)
+{% endfigure %}
 
-{% figure china-huanglong-014.jpg landscape %}Samantha and the multi-coloured pond at the top of Huanglong park{% endfigure %}
+{% figure china-huanglong-014.jpg landscape %}
+Samantha and the multi-coloured pond at the top of Huanglong park
+{% endfigure %}
 
 Continuing down the mountain we passed the ‘flamboyant pond’ and ‘azalea pond’. We didn't have a map and we had no idea how big the park was. Further down, past the bonsai pond and the mirror pond, past waterfalls, alongside hordes of Chinese tourists (not another English speaker in the park). We had 5 hours in total, but 3 hours in and we'd not seen half of it.
 
@@ -53,15 +67,21 @@ The last part of the park, or the start if you do it all up hill from the main e
 
 We occasionally took a pause from the sights to photograph the songbirds, which were often close to the paths and noisily chirping.
 
-{% figure china-huanglong-007.jpg landscape %}Samantha and Paul in Huanglong national park{% endfigure %}
+{% figure china-huanglong-007.jpg landscape %}
+Samantha and Paul in Huanglong national park
+{% endfigure %}
 
-{% figure china-huanglong-008.jpg landscape %}Songbird on the edge of a calcite pool{% endfigure %}
+{% figure china-huanglong-008.jpg landscape %}
+Songbird on the edge of a calcite pool
+{% endfigure %}
 
 Even hiking down hill we were exhausted, and the hill seemed never-ending. Past us walked Tibetan locals carrying supplies; hoisted on their backs were great sacks of rice and other essentials.
 
 At the end, our feet aching from rushing downhill, we grabbed a doughnut and a pizza before we left. And that was a lucky thing too.
 
-{% figure china-huanglong-009.jpg landscape %}Turquoise pools in Huanglong park{% endfigure %}
+{% figure china-huanglong-009.jpg landscape %}
+Turquoise pools in Huanglong park
+{% endfigure %}
 
 ## The Traffic Jam
 
@@ -75,7 +95,9 @@ Our driver couldn't speak English, and we had to guess what was going on. Everyo
 
 From hereon we moved at a snails pace or not at all. The sun set and the dark closed in. We edged north, towards Jiu dao, and the hours begun to fall away. First one hour, then two, then four. Chinese drivers are impatient, and once one driver uses the oncoming traffic lane to jump the queue everyone was doing it.
 
-{% figure china-huanglong-012.jpg landscape %}Stuck in a taxi, on a remote mountain road, in a traffic jam{% endfigure %}
+{% figure china-huanglong-012.jpg landscape %}
+Stuck in a taxi, on a remote mountain road, in a traffic jam
+{% endfigure %}
 
 On a hairpin corner we were in a deadlock, traffic going one-way was spread out in four channels, packed across both lanes — one of which should be clear. Buses, minivans, taxis. People got out of their cars and began cooking dinner on the roadside, or brewing tea, or going for a stroll; we were 5 hours in now. We begun to wonder whether we'd make it to the hotel tonight, if at all.
 
@@ -83,7 +105,9 @@ Another hour passed, engines switched off, lights off, people bedding down and t
 
 We thought that was it, traffic begun moving freely again, for a few kilometres, until, with dread, we stopped again, on the first turn of Jiudaoguai. We groaned as drivers begun to block the lanes again, and for three more hours we crawled along the 9 hairpin turns of Jiudaoguai. Those few kilometres took another 4 hours, and by now it was way past midnight and every minute in the car was a minute of lost sleep.
 
-{% figure china-huanglong-011.jpg landscape %}The seventh turn of Jiudaoguai{% endfigure %}
+{% figure china-huanglong-011.jpg landscape %}
+The seventh turn of Jiudaoguai
+{% endfigure %}
 
 We tried to sleep, curled up one way, then another, but a backseat isn't big enough for two sleepers. We contemplated using the boot too, but that wouldn't work either. I gave up and put on some music, and begun texting people in hope of finding out what was going on.
 

--- a/source/_posts/jiuzhaigou-huanglong-china/2.md
+++ b/source/_posts/jiuzhaigou-huanglong-china/2.md
@@ -13,7 +13,9 @@ pages: 3
 page: 2
 ---
 
-{% figure china-jiuzhaigou-020.jpg landscape %}Long Lake at Jiuzhaigou{% endfigure %}
+{% figure china-jiuzhaigou-020.jpg landscape %}
+Long Lake at Jiuzhaigou
+{% endfigure %}
 
 ## Jiuzhaigou
 
@@ -27,15 +29,21 @@ The park trails total over 98km, spread over three valleys, much of it can be hi
 
 On one of the panda-endorsed green buses we weaved along the winding roads up into the mountains. From the entrance we passed the stunning Dragons lake, Shuzheng lakes, Tiger lake and Rhinocerous lake; a video on the bus described the features as we passed. It is all stunning, and we were so relieved to have made it here. We continued past Nuorilang junction, the intersection of three valleys, and continued to the top of Zechawa valley (则查洼沟, Zécháwā Gōu), and we hopped off the bus at Long Lake (长海, Cháng Hǎi).
 
-{% figure china-jiuzhaigou-001.jpg landscape %}Long Lake at the top of Zechawa valley{% endfigure %}
+{% figure china-jiuzhaigou-001.jpg landscape %}
+Long Lake at the top of Zechawa valley
+{% endfigure %}
 
 Long lake is the largest and deepest of all the Jiuzhaigou lakes and stretches out over 7km. From the bus stop the shimmering turquoise lake disappears into the distance, guarded by magnificent mountain peaks on either side. It is jaw dropping, and despite the crowds (which arrive in waves) there was enough ambiance and stillness to properly take in our surroundings.
 
 From Long Lake we followed the hoards along the boardwalks, down to five-colour lake, or colourful pond (五彩池, Wǔcǎi Chí). It seems to have many translations. It's one of the smallest and shallowest lakes, but it is the most radiant, with otherworldly blues and greens. With a landscape so gorgeous it's hard to take a bad picture, photogenic even with overcast skies. The lake is so bright and colourful the images all look fake. The water was still and the mountains and conifers reflected in the surface. Magical.
 
-{% figure china-jiuzhaigou-018.jpg landscape %}Five-colour pond{% endfigure %}
+{% figure china-jiuzhaigou-018.jpg landscape %}
+Five-colour pond
+{% endfigure %}
 
-{% figure china-jiuzhaigou-019.jpg landscape %}Turquoise and crystal clear Five-colour pond{% endfigure %}
+{% figure china-jiuzhaigou-019.jpg landscape %}
+Turquoise and crystal clear Five-colour pond
+{% endfigure %}
 
 At this time of year The Seasonal lakes (季节海, Jìjié Hǎi); three lakes in this valley (lower, middle and upper), are almost empty so we gave them a miss.
 
@@ -45,7 +53,9 @@ Back on the bus, squeezed between the armpits of Chinese tourists, we returned t
 
 We tried capturing some long exposures of the falls, but the paths are boardwalks and our tripod bounced with each passerby. The spray soaked the lens too, and we were content just to watch and listen after that.
 
-{% figure china-jiuzhaigou-003.jpg landscape %}Nuorilang falls{% endfigure %}
+{% figure china-jiuzhaigou-003.jpg landscape %}
+Nuorilang falls
+{% endfigure %}
 
 ### Rize valley
 
@@ -53,9 +63,13 @@ Many of the trails in the park are on the lake side away from the road, and we f
 
 Beneath the calm surface fallen trees spread out in a curious underwater landscape, the water is so clear and blue you can see deep into the lake with the right light. From these trees new plants have grown, poking out from the surface to create fantastic reflections. The yellowing autumnal colours across the lake also created a sublime image.
 
-{% figure china-jiuzhaigou-004.jpg landscape %}Mirror lake at Jiuzhaigou{% endfigure %}
+{% figure china-jiuzhaigou-004.jpg landscape %}
+Mirror lake at Jiuzhaigou
+{% endfigure %}
 
-{% figure china-jiuzhaigou-017.jpg landscape %}A duck on Mirror Lake{% endfigure %}
+{% figure china-jiuzhaigou-017.jpg landscape %}
+A duck on Mirror Lake
+{% endfigure %}
 
 After a cake-heavy picnic, cake smuggled out of breakfast in a plastic bag, we left Mirror lake and continued north to Pearl waterfall. Radically different to Nuorilang, here a thin layer of water falls over an enormous stretch of rock that heads down the valley.
 
@@ -67,12 +81,16 @@ Over the afternoon the clouds split up into fluffy white clusters, revealing blu
 
 At the waters edge three brides were seemingly having their wedding photos taken, though as they left without grooms or family it seems most likely to have been a fashion shoot.
 
-{% figure china-jiuzhaigou-015.jpg landscape %}Paul at Five Flower Lake{% endfigure %}
+{% figure china-jiuzhaigou-015.jpg landscape %}
+Paul at Five Flower Lake
+{% endfigure %}
 
 ### Shuzheng valley
 
 It was 5pm now, and the park closes at 6. We took the bus down towards the exit, but got off to look at the lakes we'd first seen when we arrived. From the large Rhino lake we walked to Tiger lake and then on to the Shuzheng falls and lakes. We thought about walking to the exit, but once again we misjudged the scale of the park. Once on the bus it took another 15mins to get there. This place is enormous, and it's fabulous that it's all protected as a national park.
 
-{% figure china-jiuzhaigou-016.jpg landscape %}Samantha next to Rhino lake{% endfigure %}
+{% figure china-jiuzhaigou-016.jpg landscape %}
+Samantha next to Rhino lake
+{% endfigure %}
 
 Our driver picked us up and we returned to New Jiuzhai hotel. The road out of town was still bad, for our midday flight we were to leave at 5am. We had a quick evening dinner in the lovely hotel restaurant; Tibetan duck, beef noodles, vegetable noodles and Vietnamese-esque pork spring rolls. We packed and were asleep by 9pm. What a fabulous day.

--- a/source/_posts/jiuzhaigou-huanglong-china/3.md
+++ b/source/_posts/jiuzhaigou-huanglong-china/3.md
@@ -27,8 +27,14 @@ Beyond that there was no traffic and through the winding mountain roads we raced
 
 Our extraordinary Songpan, Huanglong and Jiuzhaigou adventure was over, time to fly to [Chengdu](/2014/09/chengdu-china/).
 
-{% figure china-jiuzhaigou-day-2-001.jpg landscape %}Mountains near [Jiuzhai Huanglong airport](http://en.wikipedia.org/wiki/Jiuzhai_Huanglong_Airport) as the sun comes up{% endfigure %}
+{% figure china-jiuzhaigou-day-2-001.jpg landscape %}
+Mountains near [Jiuzhai Huanglong airport](http://en.wikipedia.org/wiki/Jiuzhai_Huanglong_Airport) as the sun comes up
+{% endfigure %}
 
-{% figure china-jiuzhaigou-day-2-003.jpg landscape %}Speeding towards the airport as the day begins{% endfigure %}
+{% figure china-jiuzhaigou-day-2-003.jpg landscape %}
+Speeding towards the airport as the day begins
+{% endfigure %}
 
-{% figure china-jiuzhaigou-day-2-002.jpg landscape %}Our intrepid and awesome driver, courteous and patient throughout{% endfigure %}
+{% figure china-jiuzhaigou-day-2-002.jpg landscape %}
+Our intrepid and awesome driver, courteous and patient throughout
+{% endfigure %}

--- a/source/_posts/kuala-lumpur-malaysia.md
+++ b/source/_posts/kuala-lumpur-malaysia.md
@@ -16,9 +16,13 @@ page: 1
 
 The first leg of our Malaysia and Borneo tour began in Kuala Lumpur (KL), at the upmarket Traders hotel. It’s in the centre of town, 40 minutes from the airport, and with probably the best views of the Petronas Towers. Buildings in KL go straight up; condominiums, skyscrapers, office blocks, most buildings must be over 20 floors. Our hotel was no exception, and our room was on the 29th floor.
 
-{% figure kuala-lumpur-034.jpg portrait %}View of the Petronas Towers from Traders hotel{% endfigure %}
+{% figure kuala-lumpur-034.jpg portrait %}
+View of the Petronas Towers from Traders hotel
+{% endfigure %}
 
-{% figure kuala-lumpur-002.jpg landscape %}Our room with a view{% endfigure %}
+{% figure kuala-lumpur-002.jpg landscape %}
+Our room with a view
+{% endfigure %}
 
 Jet-lagged and exhausted we’d checked in late the night before, just awake enough to be astonished by our [perfect nighttime cityscape](http://instagram.com/p/lkbDlXNFC8/ "Instagram"). When we opened the curtains the next morning [we could barely see them](http://host.trivialbeing.org/up/kuala-lumpur-003.jpg "Foggy towers"), thick fog and rain made a day of slumber our best choice. We were however up in time for breakfast at 10:30am, the buffet was large but expensive, and with so many options in town we only had breakfast here once. My highlight was a Chinese noodle soup in a rich chicken broth, but there was sushi and fried rice, fresh fruit and pastries too.
 
@@ -32,13 +36,17 @@ Our relaxation was interrupted by mild camera panic, some photos were showing vi
 
 Being in Malaysia one week after the MH370 plane disappearance was profound. Everywhere people were glued to TVs and radios, waiting for the next announcement from the prime minister. Taxi drivers had little TVs, and big screens blasted out the news. Where was it? What had happened to the plane? Everyone in Malaysia was keen to find out. Radio DJs read out “Pray for MH370” messages, and outside malls were large prayer walls, with heartfelt letters and prayers of safe return. Purple ribbons symbolised the disaster, and the news events remained with us throughout our holiday.
 
-{% figure borneo-iphone-002.jpg landscape %}Prayers for MH370{% endfigure %}
+{% figure borneo-iphone-002.jpg landscape %}
+Prayers for MH370
+{% endfigure %}
 
 ## Petronas towers
 
 The weather brightened a bit by the afternoon, and we walked back to Traders via the Petronas towers and another mall. It turned out that perhaps today wasn’t the best day to relax and do nothing, as our only other day, a Monday, everything would be closed. Nevermind, it’s a kind of forceful relaxation. KL is much the concrete jungle, its recent development, widespread construction and faceless modernness suck out whatever character it might have had. It’s probably a great place to live, or do business, but as a holiday destination it’s best as a short stop over. That suited us just fine.
 
-{% figure kuala-lumpur-005.jpg landscape %}Beneath the Petronas Towers{% endfigure %}
+{% figure kuala-lumpur-005.jpg landscape %}
+Beneath the Petronas Towers
+{% endfigure %}
 
 ## Atmosphere 360
 
@@ -46,9 +54,13 @@ That night, based on reviews and the Lonely Planet, we took a taxi to the observ
 
 I was in a foul mood most of the night and didn’t think the food was worth the price. Samantha made the most of her buffet (and my awful company), and enjoyed the seafood, stews, rice and so on. Perhaps it was the jet lag and lack of sleep getting to me? Yeah, I’ll go with that, definitely.
 
-{% figure kuala-lumpur-012.jpg landscape %}Twilight view of Kuala Lumpur from Atmosphere{% endfigure %}
+{% figure kuala-lumpur-012.jpg landscape %}
+Twilight view of Kuala Lumpur from Atmosphere
+{% endfigure %}
 
-{% figure borneo-iphone-003.jpg portrait %}Observation tower and Atmosphere 360{% endfigure %}
+{% figure borneo-iphone-003.jpg portrait %}
+Observation tower and Atmosphere 360
+{% endfigure %}
 
 My mood lightened as soon as we left the ‘revolvaurant’, and the slow walk back via the towers and park was more romantic. The mall was still open, and despite it being 10pm, the park was alive with people. By the lake we saw a long-tailed mammal scarper up a tree, it looked a bit like an otter or a marten, but my online searches haven’t revealed what’s usually seen in the park, or what city wildlife lives in KL.
 

--- a/source/_posts/kuala-lumpur-malaysia/2.md
+++ b/source/_posts/kuala-lumpur-malaysia/2.md
@@ -13,29 +13,43 @@ Inside small egrets (some red), storks, crowned-pigeons, parrots and peacocks fl
 
 Using auto-focus on the F4 zoom lens meant the eyes of the birds were often out of focus, and switching to manual was fiddly, but gave significantly better results, provided the bird hung around long enough. The practice was welcome, the 200mm lens was still new to us both.
 
-{% figure kuala-lumpur-017.jpg landscape %}Egret at KL Bird Park{% endfigure %}
+{% figure kuala-lumpur-017.jpg landscape %}
+Egret at KL Bird Park
+{% endfigure %}
 
-{% figure kuala-lumpur-018.jpg landscape %}Western and Victorian Crowned Pigeon at KL Bird Park{% endfigure %}
+{% figure kuala-lumpur-018.jpg landscape %}
+Western and Victorian Crowned Pigeon at KL Bird Park
+{% endfigure %}
 
-{% figure kuala-lumpur-028.jpg landscape %}Hornbill eating berries at KL Bird Park{% endfigure %}
+{% figure kuala-lumpur-028.jpg landscape %}
+Hornbill eating berries at KL Bird Park
+{% endfigure %}
 
 ### Hornbill Cafe
 
 After a few hours with the birds we stopped for lunch at the Hornbill Cafe, an impressive little place with really good food. This was our first opportunity to have Nasi Lemak and Nasi Goreng, and the fried chicken Samantha ate here was the best she had in all of Malaysia. We’d advise against sitting outside though, as you finish your meal the egrets with their pointy beaks know you’re nearly done and begin to encroach. If you walk away before your plates are taken there’ll be an unsightly bird melee, chicken bones and rice will be flung over the terrace. We definitely didn’t do that, and we didn’t run away either.
 
-{% figure borneo-iphone-004.jpg landscape %}Egret wants my lunch{% endfigure %}
+{% figure borneo-iphone-004.jpg landscape %}
+Egret wants my lunch
+{% endfigure %}
 
 Just as we boarded the rundown taxi (it was a poor old green thing, lovingly kept together with sticky tape) it began raining. Not too bothered about doing much, or seeing much (very unlike us), we spent the rest of our afternoon in the hotel’s Skybar on floor 33. That meant a lot of swimming and lounging about with fabulous views. With everything else being shut, or wet, the comfy red sofas and cocktails kept us entertained until dinner.
 
-{% figure kuala-lumpur-032.jpg landscape %}Relaxing by the rooftop pool{% endfigure %}
+{% figure kuala-lumpur-032.jpg landscape %}
+Relaxing by the rooftop pool
+{% endfigure %}
 
-{% figure kuala-lumpur-033.jpg portrait %}Cocktails by the towers{% endfigure %}
+{% figure kuala-lumpur-033.jpg portrait %}
+Cocktails by the towers
+{% endfigure %}
 
 ## Skybar and Gobo
 
 At dusk I tried putting up a tripod to capture the Petronas towers – just as the sun sets and the lights come on (“magic time”). Apparently that’s not allowed, something about licensing a waiter said, probably just a pool-bar ambience thing. I settled with resting it sideways on a well positioned ash-tray, balanced on a window ledge, that did the job. We thought about venturing out for dinner, but the reviews for “Upstairs at Gobo”, part of Traders, were all positive, we took the easy option and stayed in. Our booking was quite late, 9pm, so we hung about the Skybar a little longer, where they make a very good caipirinha (once you’ve convinced the waiter, and your wife, that you did see it on the menu, and it is available).
 
-{% figure kuala-lumpur-001.jpg portrait %}Samantha at the Skybar{% endfigure %}
+{% figure kuala-lumpur-001.jpg portrait %}
+Samantha at the Skybar
+{% endfigure %}
 
 Smart casual, business savvy Gobo Upstairs was quiet when we arrived, but for a long table of conference delegates; something about international obesity. Through the glass ceiling and the large windows the twinkles of Kuala Lumpur’s towering lights shone in, giving the restaurant a prestigious ambiance. The bread basket included freshly made charcoal bread, something we hadn’t ever seen before, but given how much we saw it again it must be popular in Malaysia — it’s not burnt, and it tasted just like any other bread, but it’s black through. The menu was split into land and sea dishes, we had one from each. It was the fine dining experience we were looking for, everything was cooked exquisitely.
 
@@ -47,6 +61,8 @@ Smart casual, business savvy Gobo Upstairs was quiet when we arrived, but for a 
 
 Our last night in KL before [flying south to Kuching](/2014/05/kuching-borneo/ "Kuching, Borneo") (Borneo) and the LimeTree hotel, we packed our bags and took a few last photos of the towers. Our flight was early, and our taxi was leaving at 7am.
 
-{% figure borneo-iphone-005.jpg portrait %}Samantha at Gobo{% endfigure %}
+{% figure borneo-iphone-005.jpg portrait %}
+Samantha at Gobo
+{% endfigure %}
 
 Next morning, when we left, the moon was still out. Through KL’s morning rush hour, along the freeway, back past the condominiums, endless high rises and Asian suburbia, we drove through the eerie mist and palm plantations to the airport. At the LCC terminal, with a cheap Starbucks breakfast, [we boarded the AirAsia flight to Sarawak](/2014/05/kuching-borneo/ "Kuching, Borneo"). Goodbye KL, we’ll see you again in a couple of weeks.

--- a/source/_posts/kuching-borneo.md
+++ b/source/_posts/kuching-borneo.md
@@ -19,7 +19,9 @@ page: 1
 
 Kuching was the first of three stops in Borneo, a “sophisticated and chic city” surrounded with luscious natural parks, all within easy day-visit reach. We’d be in Kuching for four days, staying at the LimeTree hotel, highest rated on Trip Advisor. A white minibus picked us up from the airport, “Just two?” our driver asked. On the surface, and compared to Kuala Lumpur, the city is small, and beyond the golden crowned Sarawak State Assembly and pointed library, it looked like there wasn’t much to do. Equally, switching from five star business luxury to a modest but quirky and characterful hotel was a shock to the system. Nonetheless, we loved everything about this city and this hotel, and we could have stayed twice as long — there’s so many places to see and places to eat. It exudes a relaxed charm, not unlike [Hoi An in Vietnam](/2012/12/hoi-an-vietnam/), or even [Paraty in Brazil](/2011/12/paraty-brazil/).
 
-{% figure kuching-109.jpg landscape %}Kuching at night{% endfigure %}
+{% figure kuching-109.jpg landscape %}
+Kuching at night
+{% endfigure %}
 
 ## The LimeTree hotel
 
@@ -33,7 +35,9 @@ Settled, unpacked, and over the newly found [crack on the camera’s screen](htt
 
 From the waterfront promenade we found new chinatown and the main bazaar. T-shirts bore the Sarawak emblem of a hornbill bird, wrapped in a green Starbucks-esque circle. Shops overflow onto the paths, and there are many cultural craft shops and galleries, some with classic or antique carvings that are both mysterious and frightening. Little stalls on the roadside sell Kek Lapis, tasty layer cakes of all flavours, from chocolate to bright green pandan leaves — tastings are free and we must have bought at least four of these lovely treats. Though the canned “winter melon” and “green tea jasmine” soft drinks were so weird we only took two sips, then bought ice cream and more drinks to washout the flavour.
 
-{% figure borneo-iphone-006.jpg square %}Yucky winter watermelon and green tea drinks{% endfigure %}
+{% figure borneo-iphone-006.jpg square %}
+Yucky winter watermelon and green tea drinks
+{% endfigure %}
 
 ## Traditional Dayak cuisine
 
@@ -47,4 +51,6 @@ For dinner we felt adventurous, looking for some authentic and radical local cui
 
 The curly jungle ferns tasted odd, both fresh and pithy. Wild ginger flower is quite delicious.
 
-{% figure borneo-iphone-008.jpg square %}A tower of Dayak cuisine, Ulam raja{% endfigure %}
+{% figure borneo-iphone-008.jpg square %}
+A tower of Dayak cuisine, Ulam raja
+{% endfigure %}

--- a/source/_posts/kuching-borneo/2.md
+++ b/source/_posts/kuching-borneo/2.md
@@ -17,25 +17,35 @@ A friendly park-ranger (seemingly more knowledgable and helpful than the guides 
 
 Wild Bornean bearded pigs meander about park HQ — before leaving we’d past three; mud cakes the thick hairs on their back, and flies cling on as they trot about. Around their nose long wispy hair dangles down, a thick bikers beard. They sniff and snort at the grass, and approached us before walking away disinterested.
 
-{% figure kuching-041.jpg landscape %}Wild bearded pigs at Bako park HQ{% endfigure %}
+{% figure kuching-041.jpg landscape %}
+Wild bearded pigs at Bako park HQ
+{% endfigure %}
 
 From HQ the trail took us out beyond the smart looking lodges, boat jetty and boardwalk. Beneath the boardwalk, on the sand below, were funky big-armed fiddler crabs, large-shelled hermit crabs and mudskipper fish.
 
-{% figure kuching-045.jpg landscape %}Large hermit crab crawling along the beach{% endfigure %}
+{% figure kuching-045.jpg landscape %}
+Large hermit crab crawling along the beach
+{% endfigure %}
 
 When walking in the rainforest be watchful of where you tread and where you put your hands. Along the hand rails ants and termites run up and down, ferrying whatever it is they ferry; tree trunks you might lean on, or slip and grab, come with four inch spikes that could impale you; and curly, dangling wooden vines might, if you’re especially unlucky, be a snake waiting for dinner.
 
 The trail was hard on the ankles, gnarly slippery tree roots are everywhere, puddles hide the depth of holes, and there’s a little bit of climbing too. As recommended we wore proper boots, long-sleeved shirts and light trousers, but by mid-morning we were dripping with sweat, sleeves and trousers rolled up and red-faced. At trails end, by the beach, we welcomed the cooling sea breeze.
 
-{% figure kuching-049.jpg portrait %}Be careful where you put your hands in the jungle{% endfigure %}
+{% figure kuching-049.jpg portrait %}
+Be careful where you put your hands in the jungle
+{% endfigure %}
 
-{% figure kuching-050.jpg portrait %}Gnarly trail with slippery tree roots{% endfigure %}
+{% figure kuching-050.jpg portrait %}
+Gnarly trail with slippery tree roots
+{% endfigure %}
 
 ### Proboscis monkeys
 
 We didn’t see any monkeys, and on the way back we passed many who told us, “they’re all hanging out at park HQ”. We hurried back, we were headed there anyway for lunch. By the education centre I caught sight of someone staring into a tree, “just a bunch of proboscis” she explained. Two female proboscis were in the tree, they had a golden orange face and back which turned grey along their limbs. A sharp pointed nose markedly sticks out. From the treetops they crashed down with a racket onto the corrugated roof and swung away into the foliage. Wow.
 
-{% figure kuching-052.jpg landscape %}Female Proboscis monkeys at Bako national park{% endfigure %}
+{% figure kuching-052.jpg landscape %}
+Female Proboscis monkeys at Bako national park
+{% endfigure %}
 
 ### Lintrang trail (5.6km)
 
@@ -51,9 +61,13 @@ Back down by park HQ, back with plenty of time to reach the boat, we stumbled on
 
 After watching these monkeys for too long, though not long enough for our liking, we really did have to rush. Leaving the proboscis on the beach, we rejoined our Canadian friends for the boat trip back, a little sad not to be staying the night — though we had many more nature treks planned. At the port our driver was waiting, and soon enough we were being whisked back to our hotel by minibus.
 
-{% figure kuching-063.jpg portrait %}Female proboscis monkey in a tree{% endfigure %}
+{% figure kuching-063.jpg portrait %}
+Female proboscis monkey in a tree
+{% endfigure %}
 
-{% figure kuching-065.jpg portrait %}Alpha male proboscis monkey on the beach near park HQ{% endfigure %}
+{% figure kuching-065.jpg portrait %}
+Alpha male proboscis monkey on the beach near park HQ
+{% endfigure %}
 
 ## John Brookes Bistro
 
@@ -66,6 +80,8 @@ Now aching, our legs unwilling to take us very far, we ate dinner at the waterfr
 * Banana fritters
 {% endmenu %}
 
-{% figure kuching-111.jpg landscape %}Laksa from John Brooke's Bistro{% endfigure %}
+{% figure kuching-111.jpg landscape %}
+Laksa from John Brooke's Bistro
+{% endfigure %}
 
 Back at the hotel’s rooftop bar we had lime caipiroska cocktails, and called it a night

--- a/source/_posts/kuching-borneo/3.md
+++ b/source/_posts/kuching-borneo/3.md
@@ -21,27 +21,41 @@ With the chicken marinading we all clambered into a comfortable people-carrier a
 
 Our chef (I can call him that) explained all the weird and wonderful fresh things, whilst picking out the items we needed for our course, putting them in our cute wicker bags. There were long beans, snake beans, orange egg plants, pea sized egg plants, curry leaf, green peppercorns and fiddle head jungle ferns (in three stages of freshness — from good to slimy). Yams and tapioca, wild ginger flower and stems, sour prunes (or snakeskin prunes — so acidic it can cook fish), baby corn (still with its greenery) and sago flour. There was red wild star fruit, which has a thin flesh and edible seeds but is very sour. We needed ripe pineapple for our dish — you can tell ripeness by the green/yellow, we picked up some that were about half yellow half green. There were sour custard apples, which looked like deflated pineapples. In Sam’s bag was a bunch of pandan leaves — like a quiver with arrows, she swung about with them and narrowly avoided (or sometimes not) tickling passers by with the tips of the leaves.
 
-{% figure kuching-033c.jpg portrait 620 %}Samantha with her quiver basket and pandan arrows{% endfigure %}
+{% figure kuching-033c.jpg portrait 620 %}
+Samantha with her quiver basket and pandan arrows
+{% endfigure %}
 
-{% figure kuching-067.jpg portrait %}It may not look like it, but this is an egg plant{% endfigure %}
+{% figure kuching-067.jpg portrait %}
+It may not look like it, but this is an egg plant
+{% endfigure %}
 
-{% figure kuching-035.jpg landscape %}Wild ginger flower{% endfigure %}
+{% figure kuching-035.jpg landscape %}
+Wild ginger flower
+{% endfigure %}
 
-{% figure kuching-036.jpg landscape %}Red star fruit{% endfigure %}
+{% figure kuching-036.jpg landscape %}
+Red star fruit
+{% endfigure %}
 
-{% figure kuching-034.jpg landscape %}Wild fiddle head jungle fern (midin){% endfigure %}
+{% figure kuching-034.jpg landscape %}
+Wild fiddle head jungle fern (midin)
+{% endfigure %}
 
 From the fruit and veg aisles we moved to the meat and fish. A fishmonger posed with two enormous fresh water shrimp, and a man squeezed past us carrying a hundred chicken eggs. Piles and piles of crispy anchovies were on every table; the more expensive they are, the more crispy, “don’t scrimp on the anchovies”. Chef had already bought our chicken, “always buy meat first thing”.
 
 The market was notably devoid of durian, and that rancid smell. Apparently they aren’t yet in season. Chef gave us a good tip too, if you smell of durian (should you have eaten it, you mad person!), you can wash your hands with water soaked in durian skin, which extracts the smell.
 
-{% figure kuching-072.jpg landscape %}Enormous fresh water shrimp{% endfigure %}
+{% figure kuching-072.jpg landscape %}
+Enormous fresh water shrimp
+{% endfigure %}
 
 ### Pandan boxes
 
 With ingredients ready, we drove back to the school to continue cooking. First up we made sweet tako boxes for our dessert. Using the pandan leaves we carefully folded and cut as instructed, creating 20 or so leafy boxes held together with a cocktail stick. Inside them we hid some sweetcorn (“a surprise”). Next we prepared coconut water by squeezing fresh coconut in a bowl of water, this formed part of a sugar and flour mixture which we stirred on a low heat until it bubbled. That became the dessert, we poured it over the sweetcorn and filled the boxes, and put in the fridge for later. Very simple and incredibly tasty. Best eaten fresh!
 
-{% figure kuching-030.jpg landscape %}Constructing tako boxes from pandan leaves{% endfigure %}
+{% figure kuching-030.jpg landscape %}
+Constructing tako boxes from pandan leaves
+{% endfigure %}
 
 ### Sambal midin
 
@@ -51,9 +65,13 @@ As a side to the chicken curry we prepared Sambal midin, midin being fresh jungl
 
 To the main course, we fried our chicken with red chilli paste, white candle nut paste, brown cumin paste, turmeric paste and some dark brown bumbu paste, then onion, star anise and a pounded mix of lemongrass, ginger, galangal, garlic and shallots. We added water slowly and waited until the bone changed colour and the meat was cooked inside. We added lots more water, some fried potatoes and left for 20 minutes.
 
-{% figure kuching-031.jpg landscape %}Prepping the jungle ferns{% endfigure %}
+{% figure kuching-031.jpg landscape %}
+Prepping the jungle ferns
+{% endfigure %}
 
-{% figure kuching-032.jpg landscape %}Cooking our chicken curry{% endfigure %}
+{% figure kuching-032.jpg landscape %}
+Cooking our chicken curry
+{% endfigure %}
 
 ### How to prepare pineapple
 
@@ -61,7 +79,9 @@ In the meantime we prepped some fresh pineapple. We’d always just cut off the 
 
 Around a table we devoured our feast; sarawak chicken curry, sambal midin, rice, coconut tako boxes, and fresh pineapple. Yummy! We were finished by 3pm, and of course, like all previous cooking courses, we bought a new apron before leaving.
 
-{% figure kuching-077.jpg landscape %}Our cooked and ready to eat sambal midin and chicken curry{% endfigure %}
+{% figure kuching-077.jpg landscape %}
+Our cooked and ready to eat sambal midin and chicken curry
+{% endfigure %}
 
 Outside it was searing hot. Rather than traipse about in the heat we made our plans and reservations for tomorrow (a morning drive to Semeneggoh orangutan reserve, and an afternoon hike in Kubah national park). We didn’t do much after that, I relaxed in the hotel while Sam hunted down a good-looking wooden hornbill statue (it broke on the return flight, but nothing a bit of super glue couldn’t fix).
 

--- a/source/_posts/kuching-borneo/4.md
+++ b/source/_posts/kuching-borneo/4.md
@@ -13,9 +13,13 @@ It didn’t start well though, at 8:20 there was still no sign of our pickup. Th
 
 When we wandered down the road to the reserve entrance we found the park ranger finishing up his spiel to a group of 50 or so others. We’d heard from a couple in our hotel that the orangutans weren’t playing ball, and hadn’t come out for feeding for a few days. (To be honest, that’s a good thing, it’s better that they don’t need to rely on food handouts — they are after all returning to their wild instincts). We all gathered by the feeding platform and waited, … and waited. For an hour the group was silent, patient, hopeful. But the ranger told us the apes were still several kilometres away, they weren’t hungry, and we wouldn’t see any furry orange monkeys today.
 
-{% figure kuching-078.jpg landscape %}Waiting for orang-utan{% endfigure %}
+{% figure kuching-078.jpg landscape %}
+Waiting for orang-utan
+{% endfigure %}
 
-{% figure kuching-081.jpg landscape %}A beastly ant at Semenggoh{% endfigure %}
+{% figure kuching-081.jpg landscape %}
+A beastly ant at Semenggoh
+{% endfigure %}
 
 There used to be walking trails through the park, in the past you could have spent a day here, wandering the forests, looking for orangutans yourself. But there were ape attacks and the paths are now closed, seemingly for good. So after the feeding you’ve got to go. We could have come back for the afternoon feeding for free, but we had other plans. (We expected to see orangutans in Kota Kinabalu, and hoped to see some in Danum Valley).
 
@@ -27,7 +31,9 @@ The journey back was to the tune of 90s mix radio, Alanis Morisette played us ou
 
 Kubah national park is famous for its variety of frog and palm species (though the frogs are nocturnal and you need to stop the night if you want to see them). The park ranger was the most charismatic and friendly man we met in all of Malaysia. “The trails are easy, you won’t need a guide”, we’d already chosen the Waterfall trail; a 3km one-way trek from park HQ with a luscious swim-in-able pool and waterfall at the end of it. About 3 hours in total.
 
-{% figure kuching-083.jpg landscape %}A [rufous piculet](http://www.projectnoah.org/spottings/242276082 "Project Noah") in Kubah national park{% endfigure %}
+{% figure kuching-083.jpg landscape %}
+A [rufous piculet](http://www.projectnoah.org/spottings/242276082 "Project Noah") in Kubah national park
+{% endfigure %}
 
 ### Waterfall trail
 
@@ -35,25 +41,39 @@ The trail begins with an arduous walk up a steep paved road without any shade. I
 
 The forest felt noticeably more alive and dense than at Bako, more insects, more chirping and whistling, more Cicadas, and more wildlife we couldn’t see. The frog pond is man-made, but forms a breeding pool for many species of amphibian. While Sam cooled down I explored quietly. I didn’t get far before a barely visible web blocked my route. And I came face to face with the black spider that made it; it had an intriguing green striped abdomen. I saw three species of frog too, but I wouldn’t know how to identify them. I also knew that where there’s frogs there’s likely to be predators, such as snakes. I looked very carefully, I didn’t find one, but in a rotting tree trunk I found a recently-shed snake skin, about four foot long. It had red dots along one edge, possibly from a paradise tree snake.
 
-{% figure kuching-084.jpg landscape 620 %}Unidentified green-bellied spider{% endfigure %}
+{% figure kuching-084.jpg landscape 620 %}
+Unidentified green-bellied spider
+{% endfigure %}
 
-{% figure kuching-086.jpg landscape %}Discarded snake skin{% endfigure %}
+{% figure kuching-086.jpg landscape %}
+Discarded snake skin
+{% endfigure %}
 
 When Sam had recovered we pressed on, eventually reaching the turn that took us into the depths of the rainforest. The trail begins with a sharp decline, made easier with concrete slab steps. As it levels out the path alters between old rotten wood and a dirt track, easier on the ankles than the root-laden Bako trail. Spindly spiders and ants rushed about the forest floor, and a sign warned us of dangerous bees (as well as stingless ones). Occasionally a giant bug would stop us in our tracks; a blue shielded centipede, then a mysterious giant millipede, over a foot long — it was in a rush somewhere and wouldn’t slow down for photos. Enormous strangling fig trees and endangered ironwood trees climb into the canopy above. Falling trees are common, and many had crashed to the forest floor, sometimes the trail was blocked and we had to go around. One had smashed through a low bridge we needed to cross; the trunk made a good substitute; another has taken down half a flight of steep wooden steps — again, we scrambled over the decaying trunk to get to the other side.
 
-{% figure kuching-099.jpg landscape %}Giant centipede in Kubah national park{% endfigure %}
+{% figure kuching-099.jpg landscape %}
+Giant centipede in Kubah national park
+{% endfigure %}
 
-{% figure kuching-101.jpg landscape %}A giant millipede in a rush{% endfigure %}
+{% figure kuching-101.jpg landscape %}
+A giant millipede in a rush
+{% endfigure %}
 
-{% figure kuching-091.jpg landscape %}Kubah national park waterfall trail{% endfigure %}
+{% figure kuching-091.jpg landscape %}
+Kubah national park waterfall trail
+{% endfigure %}
 
 A slight rustling noise on a slope high above us made us look, and we watched as a small tree frog leaped down the hill toward us, its jumps were huge — covering metres at a time. It landed in front of us, briefly steadied itself, then continued, barreling itself down the hill; beware of unstoppable hopping amphibians travelling at speed.
 
 It hadn’t rained yet today, which made the humidity just about bearable. And the cool flowing river, waterfall and pool at the end of the trail (or the midpoint), was gorgeously refreshing. The river flows over three rocky plateaus, the steepest forming a magnificent waterfall which can be reached by carefully creeping along the slippery wet rock.
 
-{% figure borneo-iphone-016.jpg landscape %}Arriving at the waterfall{% endfigure %}
+{% figure borneo-iphone-016.jpg landscape %}
+Arriving at the waterfall
+{% endfigure %}
 
-{% figure kuching-102.jpg landscape %}Waterfall long exposure{% endfigure %}
+{% figure kuching-102.jpg landscape %}
+Waterfall long exposure
+{% endfigure %}
 
 The walk back, as per usual, was faster, and the steep paved road was both downhill and cooler. Back at park HQ a school was prepping for an overnight stay, noisy kids were running about and a mountain of bags was blocking a road. Our intrepid minibus driver was there to pick us up again, and before we’d had time to recover we were being whisked back to the hotel once again.
 
@@ -69,4 +89,6 @@ I wanted some traditional Sarawak style Laksa before [flying north to Kota Kinab
 
 Kuching is a charming, wonderful place we would happily come back to. There’s so much to see and do, the people are lovely, the city is quiet, the food is delicious. A real Bornean delicacy.
 
-{% figure kuching-108.jpg portrait %}Bronze cats outside John Brookes{% endfigure %}
+{% figure kuching-108.jpg portrait %}
+Bronze cats outside John Brookes
+{% endfigure %}

--- a/source/_posts/lancing-forests-and-whisky.md
+++ b/source/_posts/lancing-forests-and-whisky.md
@@ -22,15 +22,23 @@ From the A27 we spotted a large cathedral on the south downs. Trying to reach it
 
 Back down the hill, through the narrow one way lanes, back in a circle. Take two. We turned left instead of straight on and found ourselves at Lancing College with its towering chapel and ornate school buildings. The chapel was open to the public, and by ourselves, we toured the crypt, pulpit et al. Some gloves sat on the back of a chair.
 
-{% figure IMG_7894.JPG landscape %}Lancing College{% endfigure %}
+{% figure IMG_7894.JPG landscape %}
+Lancing College
+{% endfigure %}
 
-{% figure IMG_7849.JPG landscape %}Interior of Lancing College{% endfigure %}
+{% figure IMG_7849.JPG landscape %}
+Interior of Lancing College
+{% endfigure %}
 
 Post-photography and tuna mayo sandwiches, we drove West, along the coast, into the sun and towards Worthing, passing the pier and stopping by the sea.
 
-{% figure IMG_7930.JPG landscape %}Worthing beach{% endfigure %}
+{% figure IMG_7930.JPG landscape %}
+Worthing beach
+{% endfigure %}
 
-{% figure IMG_7956.JPG landscape %}Old man Paul by the sea{% endfigure %}
+{% figure IMG_7956.JPG landscape %}
+Old man Paul by the sea
+{% endfigure %}
 
 The tide was out and where the pebbles stopped we found sand! Sand! Who’d have thought there’d be sand here! Birds nibbled at sea creatures as the sun began to dip. We bought a fresh flat fish from the fisherman and, back at home in Brighton, made homemade fish and chips as the sun, a glowing ball of red, dipped behind Worthing in the distance.
 
@@ -40,9 +48,13 @@ A long time ago, when Sam had a little more free time, she signed up to numerous
 
 We’d seen Fat Pig a short while back, and knew we enjoyed LaBute’s work, and “In a forest” did not disappoint. Whilst not wanting to spoil anything, it had Metallica, a lot of swearing, audience alienation (in a good way), and a lot of fighting. Both Sam and I highly recommend it, its run ends in June.
 
-{% figure in-a-forest-dark-and-deep-1.jpg landscape original %}Matthew Fox and Olivia Williams in, “In a forest dark and deep”{% endfigure %}
+{% figure in-a-forest-dark-and-deep-1.jpg landscape original %}
+Matthew Fox and Olivia Williams in, “In a forest dark and deep”
+{% endfigure %}
 
-{% figure in-a-forest-dark-and-deep-2.jpg landscape original %}Matthew Fox and Olivia Williams in, “In a forest dark and deep”{% endfigure %}
+{% figure in-a-forest-dark-and-deep-2.jpg landscape original %}
+Matthew Fox and Olivia Williams in, “In a forest dark and deep”
+{% endfigure %}
 
 The Q & A gave us a fascinating insight into the ongoing work at the early stages of a new production, chopping bits out, making other parts flow better, responding to audience reaction, getting the script “locked down” and preparing for press night.
 
@@ -54,7 +66,9 @@ I’ve never been into Whisky, probably because I’m young and just hadn’t gi
 
 Five of us ordered the Whisky Tour, five 250ml samples covering the lowlands, highlands, Speyside, Campbeltown and Orkney. I preferred the darker, smoother Whiskies, the 12yr Old Pulteney was a common favourite, as was the Mortlach 16yr. Until now I couldn’t distinguish one Whisky from another, but having five samples to compare helped me pick out the subtle (and not so subtle) differences; spiciness, lightness, smoothness, loch-ness (Scottish pun, my bad).
 
-{% figure albannach.jpg square original %}Whiskies at the Albannach{% endfigure %}
+{% figure albannach.jpg square original %}
+Whiskies at the Albannach
+{% endfigure %}
 
 Obviously with this much Whisky we needed some food, the braised rabbit leg was very tasty, as was the Cullen Skink (smoked haddock and potato soup) starter.
 

--- a/source/_posts/landscape-photography-scottish-highlands.md
+++ b/source/_posts/landscape-photography-scottish-highlands.md
@@ -17,7 +17,9 @@ page: 1
 
 ## A 30th birthday surprise
 
-{% figure scotland-001-loch-assynt.jpg landscape %}Calda House on Loch Assynt, at sunrise.<br />On [day two](/2015/01/landscape-photography-scottish-highlands/3/) of our tutorial with Ian Cameron.{% endfigure %}
+{% figure scotland-001-loch-assynt.jpg landscape %}
+Calda House on Loch Assynt, at sunrise.<br />On [day two](/2015/01/landscape-photography-scottish-highlands/3/) of our tutorial with Ian Cameron.
+{% endfigure %}
 
 On a Friday night, the weekend before my 30th birthday, Samantha sat down with me after work and told me that we’d be going away this coming weekend. She was treating me to a long weekend away in the snowy and picturesque Scottish highlands, where we’d spend our time amidst mountains and lochs learning landscape photography, and a spend a little time tasting extravagant food too. She’d already informed people at work that I’d be away (and that they should try to avoid arranging meetings with me on Monday and Tuesday). Her card read:
 
@@ -54,7 +56,9 @@ Samantha
 
 We took a midday EasyJet flight from Gatwick Airport to Inverness. While we waited for the flight, which was a little delayed (and we were nervous it’d be cancelled because of snow – there’d been travel problems all week in Scotland because of snow drifts), we enjoyed a cooked breakfast at the airport’s Comptoir Libanais restaurant; [just as we had done for my birthday when in London, 2013](/2013/02/birthday-surprise/2/). Soon we were in the air and flying North, over England’s clear skies, into Scotland, over the Cairngorms where the mountaintops looked beautiful after a fresh covering of snow, and down into Inverness, on the North coast, where I happened to see a pod of whales beneath the water. As flights go, that was good one. At the airport we hopped on the half-hour bus to Inverness town centre. It was colder, but not too cold. That didn’t stop us from dropping into a camping shop on route to our hotel to pick up a couple of warm things.
 
-{% figure scotland-002-cairngorms.jpg landscape %}Cairngorms under snow{% endfigure %}
+{% figure scotland-002-cairngorms.jpg landscape %}
+Cairngorms under snow
+{% endfigure %}
 
 ## The Glenmoriston Town House
 
@@ -62,9 +66,13 @@ Our hotel was nestled alongside the River Ness; you might guess what loch feeds 
 
 With a bit of time to spare (before the early sunset) we explored a little of Inverness town centre; walking along the river, then up to [Inverness Castle](http://en.wikipedia.org/wiki/Inverness_Castle) (now a court room) – only the castle grounds are open to the public. From the castle you can see right the way West, towards the mountains, where the sun was casting a reddish light. We continued along the river a bit further, then double backed to the hotel for a hot chocolate and a rest before dinner.
 
-{% figure scotland-004-glenmoriston-town-house.jpg landscape %}Our room at The Glenmoriston Town House{% endfigure %}
+{% figure scotland-004-glenmoriston-town-house.jpg landscape %}
+Our room at The Glenmoriston Town House
+{% endfigure %}
 
-{% figure scotland-007-inverness-castle.jpg landscape %}Inverness Castle{% endfigure %}
+{% figure scotland-007-inverness-castle.jpg landscape %}
+Inverness Castle
+{% endfigure %}
 
 ## Abstract
 
@@ -83,8 +91,12 @@ One of Sam’s main reasons for picking this hotel was its incredible food. Its 
 
 I chose the venison, and Sam had the crab, but otherwise our meals were identical. The venison was my highlight – the strong meat flavour combined excellently with sweetened walnuts, cabbage and beetroot; I savoured every bite. The simple cured salmon with a touch of whisky and ginger was also divine.
 
-{% figure scotland-005-salmon.jpg landscape %}Cured wild salmon{% endfigure %}
+{% figure scotland-005-salmon.jpg landscape %}
+Cured wild salmon
+{% endfigure %}
 
-{% figure scotland-006-venison.jpg portrait %}Roast saddle of Venison{% endfigure %}
+{% figure scotland-006-venison.jpg portrait %}
+Roast saddle of Venison
+{% endfigure %}
 
 Feeling loved, and full up on all that food (plus some lovely bread which they kept bringing), it was time to sleep; tomorrow [our two day photography adventure would begin](/2015/01/landscape-photography-scottish-highlands/2/).

--- a/source/_posts/landscape-photography-scottish-highlands/2.md
+++ b/source/_posts/landscape-photography-scottish-highlands/2.md
@@ -17,9 +17,13 @@ We’d brought a lot of camera gear with us. Sam had simply said: “we need all
 
 Ian began with the basics, teaching us the different ways of photographing a waterfall and using that as a means of us learning how to balance shutter speed, ISO and aperture. Moving water can be captured in three distinct ways; staccato – where the water droplets form short lengths usually at a shutter speed of 0.3s or faster; stringy – where the lengths grow longer and form a continuous line from one point of interest to another at shutter speeds of 0.5s to 0.6s; and misty or foggy – where all motion is obscured and the water becomes a blur with light and dark patches. Stringy is often the most desired outcome, as it smoothes out the rough edges while persisting a sense of motion.
 
-{% figure scotland-003-waterfalls.jpg landscape %}A waterfall taken at different shutter speeds<br/>__Left__: misty, __middle__: stringy, __right__: staccato{% endfigure %}
+{% figure scotland-003-waterfalls.jpg landscape %}
+A waterfall taken at different shutter speeds<br/>__Left__: misty, __middle__: stringy, __right__: staccato
+{% endfigure %}
 
-{% figure scotland-008-stream.jpg portrait %}A stream, using a shutter speed that captures the stringy effect{% endfigure %}
+{% figure scotland-008-stream.jpg portrait %}
+A stream, using a shutter speed that captures the stringy effect
+{% endfigure %}
 
 Here there were also many “macro landscapes” as Ian referred to them. Endless textures, repeating patterns and compositions amongst the slippery rocks and undergrowth. But a mildly heavy snow drift pushed us back to the car, and we continued on to Ullapool to grab some lunch from Tesco. The afternoon saw us go North from Ullapool, along the A835 again, up to Loch Lurgainn and [Stac Pollaidh mountain](http://en.wikipedia.org/wiki/Stac_Pollaidh), for our first “big landscape” tutorial.
 
@@ -35,17 +39,27 @@ The weather was changeable, and the clouds moved swiftly. The light dazzled us i
 
 ### Examples of different lighting
 
-{% figure scotland-011-stac-pollaidh.jpg landscape %}Stac Pollaidh with direct light on the mountain but the water looking dead{% endfigure %}
+{% figure scotland-011-stac-pollaidh.jpg landscape %}
+Stac Pollaidh with direct light on the mountain but the water looking dead
+{% endfigure %}
 
-{% figure scotland-009-stac-pollaidh.jpg landscape %}Stac Pollaidh with luminous light and no direct light{% endfigure %}
+{% figure scotland-009-stac-pollaidh.jpg landscape %}
+Stac Pollaidh with luminous light and no direct light
+{% endfigure %}
 
-{% figure scotland-012-stac-pollaidh.jpg landscape %}Stac Pollaidh with direct light on the mountain and reeds (longer exposure){% endfigure %}
+{% figure scotland-012-stac-pollaidh.jpg landscape %}
+Stac Pollaidh with direct light on the mountain and reeds (longer exposure)
+{% endfigure %}
 
 A gap in the clouds lit up the snowy peak in a dazzling yellow, some clouds created a shadowy middle, and then the reeds lit up too, and that’s what we’d been waiting for. And then as quickly as it had appeared it was gone again, and now the sun was too low behind the mountains for it to re-emerge. We settled for that and returned to the car to warm up with a lovely cup of tea.
 
-{% figure scotland-013-stac-pollaidh.jpg landscape %}Stac Pollaidh amidst a snow flurry{% endfigure %}
+{% figure scotland-013-stac-pollaidh.jpg landscape %}
+Stac Pollaidh amidst a snow flurry
+{% endfigure %}
 
-{% figure scotland-014-stac-pollaidh.jpg landscape %}Stac Pollaidh looking cold and blue in luminous light{% endfigure %}
+{% figure scotland-014-stac-pollaidh.jpg landscape %}
+Stac Pollaidh looking cold and blue in luminous light
+{% endfigure %}
 
 ## Sunset and snow over Altandhu
 
@@ -53,7 +67,9 @@ From Stac Pollaidh Ian drove us towards the coast, along roads with suicidal she
 
 We stopped near a mound that offered a view over a collection of small islands looking West. If we were lucky the sun might peek through and we’d have something a little bit special. Up on the mound the wind was blowing a gale, and we sheltered behind a stone placard while we waited. For a brief moment red beams of light materialised, before a mini blizzard swept us up and all visibility disappeared. And that was that.
 
-{% figure scotland-015-blizzard-althandu.jpg landscape %}Mini blizzard looking down at Altandhu{% endfigure %}
+{% figure scotland-015-blizzard-althandu.jpg landscape %}
+Mini blizzard looking down at Altandhu
+{% endfigure %}
 
 ## The Royal Hotel Ullapool
 
@@ -61,4 +77,6 @@ It took a couple of hours to get back to Ullapool, where we checked in to [The R
 
 Over dinner, Ian, Samantha and I shared talk of sports, life and photography before settling in for the night. Tomorrow was an early start, and the forecast said it’d be much colder. Good job The Royal were packing us a bacon buttie breakfast!
 
-{% figure scotland-015-royal-hotel.jpg landscape %}Four poster bed at The Royal Hotel{% endfigure %}
+{% figure scotland-015-royal-hotel.jpg landscape %}
+Four poster bed at The Royal Hotel
+{% endfigure %}

--- a/source/_posts/landscape-photography-scottish-highlands/3.md
+++ b/source/_posts/landscape-photography-scottish-highlands/3.md
@@ -15,31 +15,47 @@ Although not _extreme_, it was colder than anything we were used to and we’d b
 
 With the sky so clear it might not be so good for sunrise, there’d be nothing for the early light to catch, other than the peaks of the mountains. The original plan was to head to [Ardvreck Castle](http://en.wikipedia.org/wiki/Ardvreck_Castle), the 16th century ruins of which overlook Loch Assynt in Sutherland. We set off in that direction, but prepared to change our plans – perhaps to carry on towards the beach, but we were lucky; in the East the sky was clear for the sun to shine through, but importantly, in the West a bank of thick cloud lay still – just beyond the mountains and positioned for the morning light to strike it with all its wondrous pink and purple hues. “This could be spectacular, you might be very lucky”, Ian said. Rather than head behind the castle and shoot a silhouette, we stopped in front of it, near the ruins of the double gabled Calda House.
 
-{% figure scotland-015-calda-house-cold.jpg landscape %}Calda House looking cold and remote before dawn{% endfigure %}
+{% figure scotland-015-calda-house-cold.jpg landscape %}
+Calda House looking cold and remote before dawn
+{% endfigure %}
 
 We parked the car, and the three of us headed down towards the beach edge of Loch Assynt. Approaching the scene from behind was doubly important this time, not only would we create footprints in the sand, but we’d disturb the delicate snow that still rested on each and every pebble. Out across the water sat the picturesque ruins of Ardvreck Castle in front of [Quinag mountain](http://en.wikipedia.org/wiki/Quinag). Using the gitzo tripods we were borrowing, we searched for a composition; I tried something looking North towards Calda House using the curve of the beach while Sam setup looking across the water with some lovely rocks in the foreground.  We were using hard edged filters again, and we paid careful attention to line up the edge with a line in the composition. And then we waited for the earth to spin.
 
-{% figure scotland-027-setup.jpg landscape %}Samantha setting up{% endfigure %}
+{% figure scotland-027-setup.jpg landscape %}
+Samantha setting up
+{% endfigure %}
 
 Soon the light began to change, the edges of the clouds started to catch the earliest light and turn a subtle pink. This only grew stronger, and pinker; quickly the cloud edges were a radiant pink, while the undersides turned a deep purple. The loch in front caught the luminous light beautifully, turning a mystical cyan–magenta colour. The most miraculous composition was across the water, and at the last minute I changed view to capture it, just as the pink light caught the white mountaintop. “This is the best I’ve seen this”, Ian said with unbridled excitement, and he was snapping through rolls of fuji film at a time. I returned to my original composition, to capture the double gabled house against the luminous pink landscape, using a 4-stop filter to slow down the shutter speed and smooth out the ripples in the water.  And then that light was gone, the pink turned to yellow and the scene totally changed. Yet it remained fascinating, at different times different scenes lit up, sometimes the mountain was in shadow while the castle was bathed in yellow light, or visa versa, at others the castle looked orange, and sometimes it was lost altogether as the same light covered both it and the mountain. It was cold, but it was dry (we couldn’t see our breath) and there was no wind; standing there, watching the light unfold was comfortable, peaceful and beautiful. Where we’d put our bags and lens caps down small ice crystals had formed, and the grasses were weighted down with a layer of frost.
 
-{% figure scotland-001-loch-assynt.jpg landscape %}Calda House at sunrise{% endfigure %}
+{% figure scotland-001-loch-assynt.jpg landscape %}
+Calda House at sunrise
+{% endfigure %}
 
-{% figure scotland-017-loch-assynt.jpg landscape %}Loch Assynt and Ardvreck Castle at sunrise{% endfigure %}
+{% figure scotland-017-loch-assynt.jpg landscape %}
+Loch Assynt and Ardvreck Castle at sunrise
+{% endfigure %}
 
-{% figure scotland-018-loch-assynt.jpg landscape %}Looking out across the luminous Loch Assynt, by Samantha{% endfigure %}
+{% figure scotland-018-loch-assynt.jpg landscape %}
+Looking out across the luminous Loch Assynt, by Samantha
+{% endfigure %}
 
 We took lots of pictures. First across the water, then of the house, then more of the castle and some longer exposures with the rocks, then again of the house as the sun came up over the hill – this was a particularly fun one to watch, as the sun cast a gorgeous shadow against the ruins which moved across the front of the building, while also lighting up the grass and a stray branch sticking out into the water. The time slowly crept by without us noticing. Soon enough it was 11:30am, three hours had passed and it was time to drink coffee, eat our packed bacon sandwiches and warm up in the car.
 
-{% figure scotland-016-calda-house.jpg landscape %}Calda House as the sun hit the East wall{% endfigure %}
+{% figure scotland-016-calda-house.jpg landscape %}
+Calda House as the sun hit the East wall
+{% endfigure %}
 
-{% figure scotland-026-loch-assynt.jpg landscape %}Ardvreck castle separated by light from Quinag mountain, by Samantha{% endfigure %}
+{% figure scotland-026-loch-assynt.jpg landscape %}
+Ardvreck castle separated by light from Quinag mountain, by Samantha
+{% endfigure %}
 
 ## Scots pine and miniature frozen trees
 
 A little further around Loch Assynt we stopped again to photograph some large Scots pine trees that live on a small island, although our focus quickly turned to the frozen water’s edge in front of us where many shrubs had broken through the ice and looked like miniature frozen trees. Even though it was midday, this deep into Winter the light is “productive” all day. From the car we trudged through the snow, being careful not to slip into a hidden stream or the masked edge of the loch; the snow disguised all the traps. Then we had the slight issue of trying to find solid ground for the tripods. We must’ve spent about an hour here, and the golden yellow light didn’t change much in that time. I used a zoom lens with a wide aperture to soften reeds in the foreground and try and pick out the little trees.
 
-{% figure scotland-022-miniature-tree.jpg landscape %}Miniature frozen tree{% endfigure %}
+{% figure scotland-022-miniature-tree.jpg landscape %}
+Miniature frozen tree
+{% endfigure %}
 
 In the cold the one battery we had (the spare had died a few months back) for the old Canon 500D quickly gave up. Ian lent Samantha his Fuji X-T1 mirrorless camera with an 18-55mm lens as an alternative. Sam loved this camera, as each setting seemed to have its own dial and could be instantly set and tweaked, unlike the Canon one which in comparison was a quagmire of menus.
 
@@ -51,13 +67,21 @@ From this viewpoint we were high above [Cam Loch](http://en.wikipedia.org/wiki/C
 
 As we drove past the loch it looked still and was casting a nice reflection, Samantha set off in that direction to photograph it, while Ian and I continued up the road to capture a snowy hut in the late afternoon sun. It sat amidst wintery grasses and a backdrop of snow-peaked mountains. When we arrived everything looked just right; the snow pristine but shallow enough to have texture, the light dazzling, the sky interesting, and this quirky old building made for an interesting foreground. The composition made itself, and both Ian and I setup something similar. When Sam returned she put her tripod further up the hill in a different place altogether and captured her own unique but stunning composition that included both Cul Mor and Suilven peaks.
 
-{% figure scotland-019-elphin.jpg landscape %}House and Cul Mor, by Paul{% endfigure %}
+{% figure scotland-019-elphin.jpg landscape %}
+House and Cul Mor, by Paul
+{% endfigure %}
 
-{% figure scotland-021-elphin.jpg landscape %}House, Cul Mor and Suilven, by Samantha{% endfigure %}
+{% figure scotland-021-elphin.jpg landscape %}
+House, Cul Mor and Suilven, by Samantha
+{% endfigure %}
 
-{% figure scotland-020-loch.jpg landscape %}Cam Loch, by Samantha{% endfigure %}
+{% figure scotland-020-loch.jpg landscape %}
+Cam Loch, by Samantha
+{% endfigure %}
 
-{% figure scotland-028-samantha.jpg landscape %}Samantha taking her pictures{% endfigure %}
+{% figure scotland-028-samantha.jpg landscape %}
+Samantha taking her pictures
+{% endfigure %}
 
 ## Brae of Achnahaird
 
@@ -65,13 +89,19 @@ Our spot for sunset would be near to yesterday’s, back towards Ullapool then W
 
 The intention was to capture the reflection of these mountains in the pools of water around the sand dunes, against the lovely evening light. As we approached the dunes we found that the pools were frozen solid (despite being on sand), and that some clouds in the West were blocking out the sun’s light. We needed to improvise. We quickly abandoned any attempt at photographing a reflection and first turned to the sand dunes themselves, the bristly grass sticks out from the top like bushy eyebrows and replaced the pools as an interesting foreground.
 
-{% figure scotland-023-brae-of-achnahaird.jpg landscape %}Brae of Achnahaird{% endfigure %}
+{% figure scotland-023-brae-of-achnahaird.jpg landscape %}
+Brae of Achnahaird
+{% endfigure %}
 
 Ice on a beach is a peculiar and rare thing and where the water was shallowest the ice had left interesting mottled patterns and textures in the sand. This became our final subject, and as the night closed in and the temperatures dropped we begun to feel the cold. We noticed that the ice patches had visibly grown whilst we’d been there. Setting the heavy tripods up on the ice was a hoot, with legs sprawled, we could slide the pod about the icy surface and quickly find the composition we wanted; photography on ice.
 
-{% figure scotland-024-beach-ice.jpg portrait %}Frozen beach{% endfigure %}
+{% figure scotland-024-beach-ice.jpg portrait %}
+Frozen beach
+{% endfigure %}
 
-{% figure scotland-025-beach-ice.jpg portrait %}Mottled ice patches on the beach{% endfigure %}
+{% figure scotland-025-beach-ice.jpg portrait %}
+Mottled ice patches on the beach
+{% endfigure %}
 
 ## Drive home
 

--- a/source/_posts/london-2012.md
+++ b/source/_posts/london-2012.md
@@ -23,7 +23,9 @@ page: 1
 
 In 2011 Samantha and I ran the Olympic games ticketing website gauntlet, and in the public ballot we came away with tickets for two Olympic events; hockey and table tennis. Then in the second round, getting up at 6am, Sam nabbed basketball, canoe sprint and volleyball. A good haul.
 
-{% figure olympics-003.jpg landscape %}Our London 2012 olympic tickets{% endfigure %}
+{% figure olympics-003.jpg landscape %}
+Our London 2012 olympic tickets
+{% endfigure %}
 
 One year later and it was time for the games to begin. Day one of the London 2012 Olympics. After seven years of planning, preparations, new hotels, new venues, an excellent and fun 'get ahead of the games' campaign, the ticket buying fiasco, the hoo-ha over the logo and goodness knows what else, the time had come.
 

--- a/source/_posts/london-2012/2.md
+++ b/source/_posts/london-2012/2.md
@@ -17,34 +17,56 @@ It was more of the same at Stuart’s (Sam’s dad), after lunch we watched the 
 
 My first event was men’s hockey, on the first Wednesday of the games. I went with Marek from Last.fm and after work we took the javelin train from King’s Cross to Stratford, smooth, effortless travel to the Olympic Park. Through Westfield shopping centre and then security with their airport scanners and ticket inspectors, all very friendly and jovial, we entered the park.
 
-{% figure olympics-002.jpg landscape %}The Olympic park and stadium{% endfigure %}
+{% figure olympics-002.jpg landscape %}
+The Olympic park and stadium
+{% endfigure %}
 
 With an ear-to-ear grin I walked through the brand new park, firstly past the swooping aquatic centre and beneath the huge welcome signs, then past the beautiful stadium, the odd twisted orbit sculpture, the TV studios, the London 2012 megastore, the handball arena, the Coke beat-box, and the park live big screen, to the back, to the blue and pink hockey stadium, the Riverbank Arena.
 
-{% figure olympics-004.jpg portrait %}‘How far to your venue?’, pink branding that worked{% endfigure %}
+{% figure olympics-004.jpg portrait %}
+‘How far to your venue?’, pink branding that worked
+{% endfigure %}
 
-{% figure olympics-005.jpg landscape %}Olympic stadium{% endfigure %}
+{% figure olympics-005.jpg landscape %}
+Olympic stadium
+{% endfigure %}
 
-{% figure olympics-006.jpg landscape %}Marek in the olympic park{% endfigure %}
+{% figure olympics-006.jpg landscape %}
+Marek in the olympic park
+{% endfigure %}
 
 We climbed to our seats and settled down for the first of two games. Our view looked out across the park and London’s skyline. Canary wharf, the stadium, the orbit, the cable cars, the dome. A fabulous backdrop for this sporting event.
 
-{% figure olympics-007.jpg landscape %}Olympic hockey stadium{% endfigure %}
+{% figure olympics-007.jpg landscape %}
+Olympic hockey stadium
+{% endfigure %}
 
 Argentina vs Pakistan was the first match, with [Pakistan beating Argentina 2-0](http://london2012.bbc.co.uk/hockey/event/men/match=hom400a06/index.html), in a sloppy opening game. Second up came Germany vs South Korea. We watched with Heineken and Pain au chocolat in hand, and at first cheered the Germans, Marek is after all German. But soon they were 1-0 up, and the Koreans were playing impressively. Breaking forward with excellent passing and individual skill. The arena roared, “KO-RE-A, KO-RE-A”, and they kept pushing. A penalty corner, but no conversion, a deflection, but no goal. 10-9-8, the seconds counted down, it was over, and [Germany had won 1-0](http://london2012.bbc.co.uk/hockey/event/men/match=hom400b06/index.html). Fabulous excitement.
 
-{% figure olympics-008.jpg landscape %}Argentina vs Pakistan{% endfigure %}
+{% figure olympics-008.jpg landscape %}
+Argentina vs Pakistan
+{% endfigure %}
 
-{% figure olympics-010.jpg landscape %}Germany vs South Korea{% endfigure %}
+{% figure olympics-010.jpg landscape %}
+Germany vs South Korea
+{% endfigure %}
 
 On our exit, famous folk bid us farewell from large screens. Simon Pegg warned us to mind the gap, Charlize Theron waved goodbye. The smiling, enthusiastic volunteers waved us goodbye, and politely, kindly, ushered us all to the exit.
 
-{% figure olympics-011.jpg landscape %}Hockey stadium at night{% endfigure %}
+{% figure olympics-011.jpg landscape %}
+Hockey stadium at night
+{% endfigure %}
 
-{% figure olympics-013.jpg landscape %}Olympic stadium at night{% endfigure %}
+{% figure olympics-013.jpg landscape %}
+Olympic stadium at night
+{% endfigure %}
 
-{% figure olympics-014.jpg portrait %}Orbit sculpture{% endfigure %}
+{% figure olympics-014.jpg portrait %}
+Orbit sculpture
+{% endfigure %}
 
-{% figure olympics-015.jpg landscape %}Marek and his phone{% endfigure %}
+{% figure olympics-015.jpg landscape %}
+Marek and his phone
+{% endfigure %}
 
 Back out through Westfield, where volunteers pressed music to their megaphones and spontaneously danced, down to the underground, where another volunteer urged us to the end of the platform with promises of cake and a VIP party. These volunteers were incredible, so friendly, so helpful, and what an atmosphere they cultivated. Where there would be queues, congestion and frustration there was movement, laughter and joy. Fantastic.

--- a/source/_posts/london-2012/3.md
+++ b/source/_posts/london-2012/3.md
@@ -11,38 +11,60 @@ That night I stayed over in London, and, after work again, I met Sam at Earl’s
 
 Before it all started we gathered around a TV screen inside the venue to watch Chris Hoy take gold in the velodrome, making good on Pendleton’s previous disqualification in the women’s team sprint. With the win, there were roars of support, and the sitting supporters waved their union jack flags emphatically.
 
-{% figure olympics-016.jpg portrait %}Volleyball heroes statue{% endfigure %}
+{% figure olympics-016.jpg portrait %}
+Volleyball heroes statue
+{% endfigure %}
 
 ### USA vs Brazil
 
 To our seats, high up in the rafters, the cheapest £20 tickets, but still with a good view. The opening match would be a classic, monsters in the volleyball world, [USA vs. Brazil](http://www.bbc.co.uk/sport/olympics/2012/live-video/p00w2zz7). As we know, Brazilians know how to celebrate and cheer, and there was a raucous atmosphere as the game got underway.
 
-{% figure olympics-022.jpg portrait original %}Go Brasil!{% endfigure %}
+{% figure olympics-022.jpg portrait original %}
+Go Brasil!
+{% endfigure %}
 
 Brazil narrowly took the first set 25-23, but lost out by a similar margin in the very tight second set, 27-25, despite having set point. We learnt about the stop-start sport as it progressed; the timeouts, the maximum number of touches, the dig and then the spike and the tactics. We strained to see when a point went one way or another, the subtle deflection or net touch hard to pick up without a TV and viewing from the stands. And in the breaks we watched the big screen bongo-cam, where the crowd pretended to play said instrument. It was loud, and every point was celebrated with a ten second snippet of “Got the power!”, or some other adrenaline pumping chorus.
 
-{% figure olympics-017.jpg landscape %}Men’s olympic volleyball{% endfigure %}
+{% figure olympics-017.jpg landscape %}
+Men’s olympic volleyball
+{% endfigure %}
 
-{% figure olympics-018.jpg landscape %}Another volleyball action shot{% endfigure %}
+{% figure olympics-018.jpg landscape %}
+Another volleyball action shot
+{% endfigure %}
 
 After the second set the US took control, winning the next two sets in a row, 25-19, 25-17, to [win the match 3-1](http://london2012.bbc.co.uk/volleyball/event/men/match=vom400b09/index.html). But the game itself was mammoth, going on a good 40 minutes longer than scheduled. The GBR (go team GB!) vs. ITA game was delayed starting, but soon got underway.
 
-{% figure olympics-019.jpg landscape %}Sam at her first olympic event{% endfigure %}
+{% figure olympics-019.jpg landscape %}
+Sam at her first olympic event
+{% endfigure %}
 
-{% figure olympics-020.jpg portrait %}Paul at Earl’s Court{% endfigure %}
+{% figure olympics-020.jpg portrait %}
+Paul at Earl’s Court
+{% endfigure %}
 
-{% figure olympics-021.jpg landscape %}Go Team GB{% endfigure %}
+{% figure olympics-021.jpg landscape %}
+Go Team GB
+{% endfigure %}
 
 ### Team GB vs Italy
 
 This was our only Team GB match, and as the 93rd seed versus the third best team in the world, we expected to lose. Still, we waved our flags, shouted and cheered for every single point. Half way through the first set we were holding our own, the red shirted guys combatting whatever the Italians threw at them, well, not throwing, that would be a foul. (See, we read the rules from Sam’s handy print-out). But [Italy ended the victors](http://london2012.bbc.co.uk/volleyball/event/men/match=vom400a09/index.html), with a comprehensive 3-0 victory, 25-19, 25-16, 25-20.
 
-{% figure olympics-024.jpg landscape %}Samantha supporting Team GB{% endfigure %}
+{% figure olympics-024.jpg landscape %}
+Samantha supporting Team GB
+{% endfigure %}
 
-{% figure olympics-025.jpg landscape %}Paul supporting Team GB{% endfigure %}
+{% figure olympics-025.jpg landscape %}
+Paul supporting Team GB
+{% endfigure %}
 
-{% figure olympics-023.jpg landscape %}2 – 2, all to play for{% endfigure %}
+{% figure olympics-023.jpg landscape %}
+2 – 2, all to play for
+{% endfigure %}
 
 Ashamedly we snuck out before the last point, avoiding the crowds and grabbing one of the last underground tubes to Turnpike Lane, where a friend put us up for the night. Two consecutive best-of-five-set volleyball matches is hard work, and we were shattered.
 
-{% figure olympics-026.jpg landscape %}Outside Earl’s Court{% endfigure %}
+{% figure olympics-026.jpg landscape %}
+Outside Earl’s Court
+{% endfigure %}

--- a/source/_posts/london-2012/4.md
+++ b/source/_posts/london-2012/4.md
@@ -13,84 +13,138 @@ From underground, to Kings Cross, the snake like queue and the well organised ja
 
 We were heading to see Women’s basketball at the Basketball Arena. A large but temporary building, a tight white skin covered a protruding metal texture to create an almost organic look.
 
-{% figure olympics-027.jpg portrait %}Sam in the olympic park{% endfigure %}
+{% figure olympics-027.jpg portrait %}
+Sam in the olympic park
+{% endfigure %}
 
-{% figure olympics-029.jpg landscape %}Women’s basketball tickets{% endfigure %}
+{% figure olympics-029.jpg landscape %}
+Women’s basketball tickets
+{% endfigure %}
 
 ### Women’s basketball
 
 Rubbing the sleep out of our eyes, we focused on the court below, as the first match was about to begin. [Croatia vs. Angola](http://www.bbc.co.uk/sport/olympics/2012/live-video/p00w300q), two struggling teams at the foot of their group. Not the tightest of matches, both in score and skill, it felt like a warm up game. But the crowd emphatically [cheered Croatia to victory 75-56](http://london2012.bbc.co.uk/basketball/event/women/match=bkw400a10/index.html), although we’d rooted for Angola.
 
-{% figure olympics-030.jpg landscape %}Basketball arena{% endfigure %}
+{% figure olympics-030.jpg landscape %}
+Basketball arena
+{% endfigure %}
 
-{% figure olympics-031.jpg portrait %}Paul in front of the basketball court{% endfigure %}
+{% figure olympics-031.jpg portrait %}
+Paul in front of the basketball court
+{% endfigure %}
 
 The half time entertainment was a display of gymnastics and basketball prowess, as players jumped from trampolines, somersaulting, passing the ball and scoring impressive baskets by all manner of means.
 
-{% figure olympics-032.jpg landscape %}Australia warming up{% endfigure %}
+{% figure olympics-032.jpg landscape %}
+Australia warming up
+{% endfigure %}
 
 AUS vs RUS was up next. We’d seen Australia batter Team GB on the TV, and were happy to recognise the players again, notably the tall bulky captain, Laura Jackson. After the first quarter Australia were up 21-15, despite not making any of their three point attempts. This proved costly and by half time Russia had brought it back to 32-30.
 
-{% figure olympics-034.jpg landscape original %}Australia vs Russia{% endfigure %}
+{% figure olympics-034.jpg landscape original %}
+Australia vs Russia
+{% endfigure %}
 
 The second half time show showcased the talents of the local cheerleading squad, and we watched, bathed in pink light, as they tossed each other into the air. A momentary interlude, we switched our attention to my phone, where I streamed the rowing from the BBC olympics app, to see the women’s double sculls final and Team GB storm to victory.
 
-{% figure olympics-035.jpg landscape %}Half-time acrobatics{% endfigure %}
+{% figure olympics-035.jpg landscape %}
+Half-time acrobatics
+{% endfigure %}
 
-{% figure olympics-036.jpg landscape %}Streaming the boat race{% endfigure %}
+{% figure olympics-036.jpg landscape %}
+Streaming the boat race
+{% endfigure %}
 
 Back to the match, and at the end of the third quarter it was 54-48 to AUS. To the final quarter, and Russia opened strongly, storming forward and scoring a rally of three pointers. With fifty seconds to go it was 68-66 to AUS, and Russia were giving it their all, coming forward once again, but missing that vital basket. Australia countered, and the stadium erupted with cheers as they made the two-point basket for a four-point advantage. And that’s how it ended, [70-66 to Australia](http://london2012.bbc.co.uk/basketball/event/women/match=bkw400b10/index.html), a thrilling match to watch, right to the end.
 
-{% figure olympics-037.jpg landscape %}Scoreboard{% endfigure %}
+{% figure olympics-037.jpg landscape %}
+Scoreboard
+{% endfigure %}
 
-{% figure olympics-038.jpg landscape %}Samantha and a kangaroo{% endfigure %}
+{% figure olympics-038.jpg landscape %}
+Samantha and a kangaroo
+{% endfigure %}
 
-{% figure olympics-040.jpg landscape %}Aussie olympic support{% endfigure %}
+{% figure olympics-040.jpg landscape %}
+Aussie olympic support
+{% endfigure %}
 
 ### Exploring the park
 
 Despite going to just one event in the park, we wanted to hang around for the rest of the day. The forecast had said rain, but it never came, instead there were blue skies, fluffy white clouds and hot sunshine. Outside the arena we watched as giant basketball players signed autographs.
 
-{% figure olympics-043.jpg landscape %}Samantha examining the map{% endfigure %}
+{% figure olympics-043.jpg landscape %}
+Samantha examining the map
+{% endfigure %}
 
-{% figure olympics-044.jpg landscape %}Olympic flags outside the basketball arena{% endfigure %}
+{% figure olympics-044.jpg landscape %}
+Olympic flags outside the basketball arena
+{% endfigure %}
 
 We explored the swooping wooden velodrome, a beautiful permanent structure. And stood on tiptoes to try and see the BMX park. Atop a small grassy hill stood the Olympic rings in all their glory, with a queue to have a photo taken beneath them. Of course we queued, and befriended those ahead and behind us. Eventually it was our turn, and we jumped and  whooped, waving the union jack beneath the five rings. Snap, snap, snap.
 
-{% figure olympics-046.jpg landscape %}Paul and Sam beneath the olympic rings{% endfigure %}
+{% figure olympics-046.jpg landscape %}
+Paul and Sam beneath the olympic rings
+{% endfigure %}
 
-{% figure olympics-047.jpg landscape %}Samantha, olympic rings and union jack{% endfigure %}
+{% figure olympics-047.jpg landscape %}
+Samantha, olympic rings and union jack
+{% endfigure %}
 
-{% figure olympics-049.jpg landscape %}Paul doing a jump{% endfigure %}
+{% figure olympics-049.jpg landscape %}
+Paul doing a jump
+{% endfigure %}
 
-{% figure olympics-042.jpg landscape %}The Velodrome{% endfigure %}
+{% figure olympics-042.jpg landscape %}
+The Velodrome
+{% endfigure %}
 
 We picnicked and slept on the grass of park live, watching [Jessica Ennis begin her heptathlon](http://www.bbc.co.uk/sport/olympics/2012/schedule-results/athletics/20120803#start-time-1000) campaign on the big screen, watching [Ben Ainslie push The Great Dane in the sailing](http://london2012.bbc.co.uk/sailing/event/finn-men/phase=sam002910/index.html) -- [slowing down and giving him dirty air](http://www.bbc.co.uk/sport/olympics/2012/live-video/p00w305z), and Roger Federer struggling but eventually winning in the [tennis semi final](http://london2012.bbc.co.uk/tennis/event/men-singles/match=tem001201/index.html).
 
-{% figure olympics-045.jpg landscape %}Picnic in park live{% endfigure %}
+{% figure olympics-045.jpg landscape %}
+Picnic in park live
+{% endfigure %}
 
-{% figure olympics-051.jpg landscape %}View of olympic park{% endfigure %}
+{% figure olympics-051.jpg landscape %}
+View of olympic park
+{% endfigure %}
 
 The day passed by, slowly and quietly, all rather lovely. In the evening we explored further, following the riverside walk, alongside the beautiful British flowers and Gloriana boat, as used to bring the torch to the stadium and to lead the jubilee flotilla. Then around the outside of the stadium (but not inside), sad to think, at the time, that we wouldn’t make it inside.
 
-{% figure olympics-052.jpg portrait %}No climbing{% endfigure %}
+{% figure olympics-052.jpg portrait %}
+No climbing
+{% endfigure %}
 
-{% figure olympics-053.jpg portrait %}Orbit sculpture and flowers{% endfigure %}
+{% figure olympics-053.jpg portrait %}
+Orbit sculpture and flowers
+{% endfigure %}
 
-{% figure olympics-054.jpg landscape %}Everyone is someone’s favourite{% endfigure %}
+{% figure olympics-054.jpg landscape %}
+Everyone is someone’s favourite
+{% endfigure %}
 
-{% figure olympics-055.jpg portrait %}Paul and the orbit{% endfigure %}
+{% figure olympics-055.jpg portrait %}
+Paul and the orbit
+{% endfigure %}
 
-{% figure olympics-060.jpg landscape %}Aquatics centre{% endfigure %}
+{% figure olympics-060.jpg landscape %}
+Aquatics centre
+{% endfigure %}
 
 Penultimate stop, the London 2012 megastore, for some official olympic venue t-shirts and other paraphernalia we seemed happy to purchase. A key ring, a mug, and so on.
 
-{% figure olympics-057.jpg portrait %}Olympic obelisk{% endfigure %}
+{% figure olympics-057.jpg portrait %}
+Olympic obelisk
+{% endfigure %}
 
-{% figure olympics-058.jpg landscape %}Samantha in the olympic park{% endfigure %}
+{% figure olympics-058.jpg landscape %}
+Samantha in the olympic park
+{% endfigure %}
 
 Before leaving we settled down with a large curry to share and watched Rebecca Addlington attempt to defend her Olympic 800m gold, streaming it again on my phone. Sat just metres away from the actual event, we cheered her on, and she [won an excellent Bronze medal](http://www.bbc.co.uk/sport/olympics/2012/sports/swimming/events/womens-800m-freestyle).
 
 We bought a bottle of wine and relaxed on the train home from St Pancras. A fantastic day.
 
-{% figure olympics-063.jpg landscape %}Time to go home{% endfigure %}
+{% figure olympics-063.jpg landscape %}
+Time to go home
+{% endfigure %}

--- a/source/_posts/london-2012/6.md
+++ b/source/_posts/london-2012/6.md
@@ -13,9 +13,13 @@ A new week, another Olympic event. But first some excitement. All week I’d bee
 
 Back to today’s event though. And that evening I met my mum in London and travelled to the Excel Arena for some men’s table tennis action, specifically the team semi-final. A sport I was desperate to see in the original ballot, I’d purchased the more expensive seats, we couldn’t have been much closer to the table.
 
-{% figure olympics-064.jpg landscape %}Excel Arena{% endfigure %}
+{% figure olympics-064.jpg landscape %}
+Excel Arena
+{% endfigure %}
 
-{% figure olympics-065.jpg portrait %}Mum at the olympics, ready to see some table tennis{% endfigure %}
+{% figure olympics-065.jpg portrait %}
+Mum at the olympics, ready to see some table tennis
+{% endfigure %}
 
 Outside the arena an exhibition showcased the history of Table Tennis, a glass enclosure held paddles from an early Olympic games, and on large boards the sport was explained. A big screen showed highlights of the earlier semi final.
 
@@ -23,22 +27,32 @@ Outside the arena an exhibition showcased the history of Table Tennis, a glass e
 
 Inside we found our seats, next to the friends and family area, beneath the media folk. Today’s match, South Korea vs. Hong Kong China. Korea were the favourites, inevitably the majority were rooting for Hong Kong China. Table Tennis team is best of five matches, with a team of three. Two singles matches, a doubles match and then another two singles. Each match is the best of five games, first to eleven.
 
-{% figure olympics-067.jpg landscape %}Ping Pong table{% endfigure %}
+{% figure olympics-067.jpg landscape %}
+Ping Pong table
+{% endfigure %}
 
 The first match, Peng Tang (HKG) vs. Seungmin Ryu (KOR), was incredibly close. Serve, ping, pong, top spin smash, smashed return, point won. Every now and then the rally grew insane, both players edging away from the table, getting further and further back, smashing the small plastic white ball at each other, with incredible skill and accuracy. “Oooh”, “aaah”, the crowd gasped, as each player would do something extraordinary to return.
 
-{% figure olympics-068.jpg landscape %}Hong Kong vs Korea{% endfigure %}
+{% figure olympics-068.jpg landscape %}
+Hong Kong vs Korea
+{% endfigure %}
 
 This match went to five games, 11-7, 4-11, 6-11, 11-8. The final game stood poised at 9-9, the two best players poised to take their team 1-0 up. Serve, smash, and Korea were 10-9 up. Then a long rally, bam, saved, bam, saved, smash, return, then a delicate return shot from Korea, which just clips the net and drops the right side, match won, and Seungmin Ryu roars in celebration.
 
 A short break, a warm up and on to the second match. Tianyi Jiang (HKG) vs Saehyuk Joo (KOR). This now became about one man, Saehyuk Joo, no matter how hard Jiang tried, Joo combatted perfectly. This player was clearly on another level, an enthralling defensive style. His tactic was simply to return every shot with unimaginable back spin and accuracy, taking the power from the ball. Jiang tried harder and harder to win points, smash following smash, but calm and collected, Joo stooped low to return a deft, perfectly poised shot, floating the ball back, until, inevitably Jiang made a mistake. Korea took this match easily, 11-3, 11-6, 11-8.
 
-{% figure olympics-069.jpg landscape %}Table tennis action shot{% endfigure %}
+{% figure olympics-069.jpg landscape %}
+Table tennis action shot
+{% endfigure %}
 
 And to the doubles. With Korea 2-0 up the support for Hong Kong China grew, and huge roars for “HONG KONG” ran out amongst the crowd. Every point won was met with loud cheers. The doubles match was frenetic, players alternating shots, serving cross-table, once more with incredible rallies. Hong Kong took the first match, 11-5, but lost the following two, 6-11, 2-11. In the fourth, Hong Kong pulled it back with a nervy edgy 13-11 victory. But it wasn’t enough, and Korea closed out the match 11-9, [winning the bout 3-0 overall](http://london2012.bbc.co.uk/table-tennis/event/men-team/match=ttm400202/index.html).
 
-{% figure olympics-070.jpg landscape %}Table tennis doubles{% endfigure %}
+{% figure olympics-070.jpg landscape %}
+Table tennis doubles
+{% endfigure %}
 
 Mum and I made the journey home, taking the DLR back to Bank, with a genuinely funny driver and receptive carriage of cheering international sports fans. At one point the train stopped, and the lights went out. “Wasn’t me”, the driver announced. Then the subdued crappy train back to Brighton, another late night.
 
-{% figure olympics-071.jpg portrait %}Olympic banners at the Excel Arena{% endfigure %}
+{% figure olympics-071.jpg portrait %}
+Olympic banners at the Excel Arena
+{% endfigure %}

--- a/source/_posts/london-2012/7.md
+++ b/source/_posts/london-2012/7.md
@@ -7,15 +7,21 @@ page: 7
 
 ## Eton Dorney
 
-{% figure olympics-074.jpg landscape %}Eton Dorney and tickets{% endfigure %}
+{% figure olympics-074.jpg landscape %}
+Eton Dorney and tickets
+{% endfigure %}
 
 And after that late night, Sam pulled me up at 5am(!) to get into a car and be driven to Eton Dorney, via a Windsor park and ride, for some early morning [Canoe Sprint action](http://www.bbc.co.uk/sport/olympics/2012/schedule-results/canoe-sprint/20120807#start-time-0930). I brought a pillow and slept most of the journey, and Sam had the excellent forethought to provide fresh croissants and coffee from a thermos.
 
 Running on sugar and caffeine, we meandered the walkways to the Eton Dorney ticket booths, not without their own pink monoliths and Wenlock statues. Orange and purple uniformed volunteers welcomed us, “Good morning”, they smiled, and, as usual, we passed through the security gates into the park.
 
-{% figure olympics-072.jpg portrait %}Sam is excited!{% endfigure %}
+{% figure olympics-072.jpg portrait %}
+Sam is excited!
+{% endfigure %}
 
-{% figure olympics-073.jpg landscape %}Samantha, London 2012{% endfigure %}
+{% figure olympics-073.jpg landscape %}
+Samantha, London 2012
+{% endfigure %}
 
 A few breakfast places and shops, a try it yourself rowing room, and one huge stand lining the manmade lake made up Eton Dorney. An hour or so early, we meandered, eating our breakfast, wrapping up warm. It was a particularly blustery day, that threatened to shower, a day for which we’d be sitting outside.
 
@@ -27,30 +33,44 @@ At 9:46am the Men’s C2 1000m (C = Canoe) heats. Much slower this time, as expe
 
 At 10:07am, hurtling through these races now, the Women’s K1 500m heats. This set of races bothered us. In each race, bar the first, all six competitors would go through to the semi final, their positions in the heat deciding their lanes. This made the races a little lacklustre, except perhaps for the Iranian, the one racer out of 26 to be eliminated at this stage. Still, in heat four we cheered on our British hopeful Rebecca Cawthorn. Frantically waving our union jacks, and shouting “GO ON! GO ON!”, she won her heat to much applause.
 
-{% figure olympics-078.jpg landscape %}Packed seats{% endfigure %}
+{% figure olympics-078.jpg landscape %}
+Packed seats
+{% endfigure %}
 
-{% figure olympics-075.jpg landscape %}K1 500m crossing the finish line{% endfigure %}
+{% figure olympics-075.jpg landscape %}
+K1 500m crossing the finish line
+{% endfigure %}
 
 Between races the compere kept us entertained, with the usual bongo cam, mexican wave rehearsals and variants and so on. Although the mexican wave doesn’t work so well when it just goes along in a straight line. You can’t see it approaching.
 
 At 10:35am, the Women’s K2 500m. In this event Team GB were a last minute entry. We raced in the first heat. Again, we stood up, waved our flags, cheered and shouted, although this time to not so much avail, finishing fifth, but still qualifying for the semis.
 
-{% figure olympics-077.jpg landscape %}K2 500m finish line{% endfigure %}
+{% figure olympics-077.jpg landscape %}
+K2 500m finish line
+{% endfigure %}
 
 With the heats out of the way we were on to the semis. First up, as before, at 11:01am, the Men’s K4 1000m semi. Australia won with a very fast 2:52.505 time. They went on to win the competition (we didn’t see that), but in the final actually went slower than this.
 
 At 11:09am, the Men’s C2 1000m semi final. As usual, we arbitrarily picked our team to support, no team GB in any of the men’s races. Russia and China won these respectively. And the two runners up in each also went through to the final, Belarus, Romania, Czech Republic and Cuba. In the final, which we didn’t see, Germany went on to take gold.
 
-{% figure olympics-076.jpg landscape %}Men’s C2 1000m{% endfigure %}
+{% figure olympics-076.jpg landscape %}
+Men’s C2 1000m
+{% endfigure %}
 
 Come 11:30am and we’re onto the Women’s K1 500m semis. 24 boats racing again, this time in the lanes they’d fought for, in three semi finals. In the third race we cheered on Rebecca Cawthorn again. A sea of red, blue and white appeared in the stands, and cheers followed Rebecca as she sped down the lake in her matching union jack styled kayak. She was narrowly second, by three tenths of a second, 1:52.542, but still comfortably qualifying for the final. Sadly in the final she didn’t medal, fighting it out with the Italian again, but only for 5th and 6th place.
 
-{% figure olympics-079.jpg landscape %}Go Team GB!{% endfigure %}
+{% figure olympics-079.jpg landscape %}
+Go Team GB!
+{% endfigure %}
 
-{% figure olympics-080.jpg landscape %}Paul supporting Team GB, in his waterproofs{% endfigure %}
+{% figure olympics-080.jpg landscape %}
+Paul supporting Team GB, in his waterproofs
+{% endfigure %}
 
 And to the last races of the day, Women’s K2 500m. As expected, Team GB didn’t make it through the semis, finishing up seventh and long way back in the race. Still, it didn’t dampen our spirits and we cheered them on to the very end. Germany, China and Sweden won these semis,  with Germany eventually taking gold in the final.
 
 And to the end of our Canoe Sprint experience, just in time for some lunch. Knackered, we slowly walked back to the park and ride, rode the leather seated First bus back to the car, and drove home again. We kept 5live on, and listened to the Brownlee brothers take gold and Bronze in the triathlon. Too tired to stop and visit Windsor castle, and at home too tired to do much other than sleep. We slept, for most of the day.
 
-{% figure olympics-082.jpg portrait %}Goodbye Eton Dorney{% endfigure %}
+{% figure olympics-082.jpg portrait %}
+Goodbye Eton Dorney
+{% endfigure %}

--- a/source/_posts/london-2012/8.md
+++ b/source/_posts/london-2012/8.md
@@ -15,25 +15,39 @@ We took a half day holiday, and headed over, via the javelin train, for one fina
 
 On to the next queue, standing in the beautiful sunshine, waiting to enter a giant beat-box. Red, and white, with pads and panels, as you walked around you could touch the pads to create noises, samples from different sports combined to form a beat, of sorts. As you climbed the song grew, layered. It wasn’t too exciting, and I was rushing, eager to get out and over to the stadium.
 
-{% figure olympics-083.jpg landscape %}Cola beat-box{% endfigure %}
+{% figure olympics-083.jpg landscape %}
+Cola beat-box
+{% endfigure %}
 
-{% figure olympics-084.jpg portrait %}Paul beating the beat-box{% endfigure %}
+{% figure olympics-084.jpg portrait %}
+Paul beating the beat-box
+{% endfigure %}
 
 But at the top there’s a lovely view and a chance to hold the Olympic torch, we obliged. Holding the golden torch, it was lighter than expected, and the emblasoned London 2012 logo looked great. We stood on the plinth, held the torch and had our photos snapped. At the bottom there was free Coke, and a cult-like sugar rush party. But alas, we had to run.
 
-{% figure olympics-086.jpg landscape %}Samantha and the olympic torch{% endfigure %}
+{% figure olympics-086.jpg landscape %}
+Samantha and the olympic torch
+{% endfigure %}
 
-{% figure olympics-087.jpg portrait %}Paul holding the olympic torch{% endfigure %}
+{% figure olympics-087.jpg portrait %}
+Paul holding the olympic torch
+{% endfigure %}
 
-{% figure olympics-089.jpg landscape %}London 2012 olympic torch{% endfigure %}
+{% figure olympics-089.jpg landscape %}
+London 2012 olympic torch
+{% endfigure %}
 
 ### Olympic stadium
 
 Skipping across the park, past the BBC TV studio, to the Stadium, in through entrance B and over the moat. We’re in the stadium! We smiled, this was so exciting, this felt like the Olympics more than anything else, and we were here, soaking it up, beneath the clear blue skies and gorgeous summer evening. And our seats were fantastic, just above the 200m start line, long jump to our left, high jump to our right and javelin diagonally across. We could see everything, and the crown like spikes of the stadium surrounded us.
 
-{% figure olympics-090.jpg landscape %}Inside the olympic stadium{% endfigure %}
+{% figure olympics-090.jpg landscape %}
+Inside the olympic stadium
+{% endfigure %}
 
-{% figure olympics-092.jpg landscape %}Good seats{% endfigure %}
+{% figure olympics-092.jpg landscape %}
+Good seats
+{% endfigure %}
 
 ### Men’s decathlon
 
@@ -43,7 +57,9 @@ With a tasty curry and some beer, we settled down for the sporting action. The M
 
 Come 19:15 it’s the turn of the Men’s 110m hurdles semi finals. Three semi-finals, we cheered on Team GB’s Clarke in the first and Turner in the second. Watching the hurdles, live, side-on is incredible. The speed with which they cover 110m, and the fluency of each jump. Very exciting.
 
-{% figure olympics-091.jpg landscape %}Start of Men’s 110m hurdles semi final{% endfigure %}
+{% figure olympics-091.jpg landscape %}
+Start of Men’s 110m hurdles semi final
+{% endfigure %}
 
 Marks. Set. FIRE! And the stadium erupts, cheering, louder and louder for Clarke. 13.31 seconds, a personal best. Third in his race, just missing out on the automatic qualification. We anxiously watched the next two races, hoping that 13.31 would be fast enough to qualify for the final. Semi final 2, Xie of China gets 13.34, but Turner of GB misses out with 13.42. Still in with a chance. Semi final 3, Fourie in third gets 13.28, but fourth place 13.35! Clarke makes it into the final, by the skin of his teeth. The stadium is buzzing.
 
@@ -59,39 +75,63 @@ At 20:10, the big event we’d all been waiting for. The 200m semi final, a race
 
 Yohan Blake was in the first semi. He warmed up beneath us, and wandered along the track waving to the crowds. Jamaican flags waved frantically. The cameras and announcer introduced each of the athletes, with Blake doing his “beast” routine to the screens.
 
-{% figure olympics-093.jpg portrait original %}Yohan Blake{% endfigure %}
+{% figure olympics-093.jpg portrait original %}
+Yohan Blake
+{% endfigure %}
 
-{% figure olympics-096.jpg portrait original %}Yohan Blake preparing for 200m semi final{% endfigure %}
+{% figure olympics-096.jpg portrait original %}
+Yohan Blake preparing for 200m semi final
+{% endfigure %}
 
 They settled down and took their marks, the stadium hushed, silence, you could hear a pin drop. Set. FIRE! Blink and you’ll miss it, they leap from the starting blocks, and storm around the corner to our right. And now they were in the distance, crossing the finish line, 20.01s, Blake wins — just, 20.02, 20.03 second and third. [A very fast, very close semi](http://london2012.bbc.co.uk/athletics/event/men-200m/phase=atm002200/index.html). And the speed of these guys, seeing it in the flesh, incredible.
 
-{% figure olympics-097.jpg landscape %}Running{% endfigure %}
+{% figure olympics-097.jpg landscape %}
+Running
+{% endfigure %}
 
 Usain Bolt was in the second semi. Suddenly the stadium was glimmering, flashes flickering everywhere, everyone taking a picture, “I was there, I saw this man run”, us included. Bolt raised his arm in acknowledgement, and there were cheers. He casually prepared, not phased in any sense, high fiving the lucky volunteer behind him. When the announcer introduced him, the stadium went a little crazy.
 
-{% figure olympics-094.jpg landscape %}Usain Bolt{% endfigure %}
+{% figure olympics-094.jpg landscape %}
+Usain Bolt
+{% endfigure %}
 
-{% figure olympics-098.jpg landscape original %}Usain Bolt being friendly with the volunteers{% endfigure %}
+{% figure olympics-098.jpg landscape original %}
+Usain Bolt being friendly with the volunteers
+{% endfigure %}
 
-{% figure olympics-095.jpg landscape %}Bolt{% endfigure %}
+{% figure olympics-095.jpg landscape %}
+Bolt
+{% endfigure %}
 
-{% figure olympics-100.jpg landscape original %}Bolt being introduced to the stadium{% endfigure %}
+{% figure olympics-100.jpg landscape original %}
+Bolt being introduced to the stadium
+{% endfigure %}
 
-{% figure olympics-101.jpg landscape %}On your marks{% endfigure %}
+{% figure olympics-101.jpg landscape %}
+On your marks
+{% endfigure %}
 
 Once more they settled down in their lanes. Checked their feet against the starting blocks, measured their fingers against the white lines and prepared to race, Bolt doing his usual hail Mary. Silence again, 80,000 people hushed, waiting. Marks. Set — body raised up. FIRE! And Bolt storms ahead, taking the corner, gaining momentum and creating a widening gap. Half way round he knows he’s winning, and winning by some distance, he slows down, [and almost seems to jog the last 100m](http://www.bbc.co.uk/sport/0/olympics/18907716). He wins, 20.18s.
 
-{% figure olympics-102.jpg landscape %}Usain Bolt disappears into the distance{% endfigure %}
+{% figure olympics-102.jpg landscape %}
+Usain Bolt disappears into the distance
+{% endfigure %}
 
 In the third and final semi, Christian Malcolm of Team GB took the stage, racing alongside another fast Jamaican, Warren Weir. And this race was not without its share of the drama. In lane two Mathieu from the Bahamas false-started, quite significantly. His race was over, disqualified. He stood beneath us, dressed in blue, looking dejected, not quite sure what he’d done, or why he’d set off so early. The race re-started, and Malcolm came third, 20.51, behind Weir at 20.28. Sadly not fast enough to qualify for the final.
 
 Bolt went on to take the [200m gold medal](http://www.bbc.co.uk/sport/0/olympics/18914449), in 19.32s, his season’s best and completing his double-double, the first man ever to retain both the 100m and the 200m. Blake and Weir came in second and third to take a Jamaican clean sweep. Total domination.
 
-{% figure olympics-103.jpg landscape %}Olympic stadium at twilight{% endfigure %}
+{% figure olympics-103.jpg landscape %}
+Olympic stadium at twilight
+{% endfigure %}
 
-{% figure olympics-104.jpg landscape %}Samantha in the stadium{% endfigure %}
+{% figure olympics-104.jpg landscape %}
+Samantha in the stadium
+{% endfigure %}
 
-{% figure olympics-105.jpg landscape original %}Remote control minis for transporting javelins{% endfigure %}
+{% figure olympics-105.jpg landscape original %}
+Remote control minis for transporting javelins
+{% endfigure %}
 
 ### Women’s 400m hurdles final
 
@@ -105,9 +145,13 @@ Next, another 200m race, this time the [Women’s 200m final](http://www.bbc.co.
 
 The [Women’s long jump](http://www.bbc.co.uk/sport/0/olympics/19189351) was drawing to a close, British hopeful Proctor not happy with her jump, she went out in the early stages. Reese from the US went on to win, with a jump of 7.12m. From our angle, with the women jumping towards us, it was hard to see the length of the jumps. But we had a good idea whether a jump was a foul or not.
 
-{% figure olympics-106.jpg portrait %}Women’s long jump{% endfigure %}
+{% figure olympics-106.jpg portrait %}
+Women’s long jump
+{% endfigure %}
 
-{% figure olympics-107.jpg landscape %}Olympic stadium{% endfigure %}
+{% figure olympics-107.jpg landscape %}
+Olympic stadium
+{% endfigure %}
 
 ### Men’s 110m hurdles final
 
@@ -115,14 +159,22 @@ The last big event of the night was the [Men’s 110m hurdles final](http://www.
 
 The crowds started to disperse, but we hung around a little longer, watching the Men’s decathlon 400m and the Women’s 100m hurdles victory ceremony. We soaked up the last of the Olympic atmosphere, our live sporting events had come to a close. It’d been phenomenal. Such a perfect, warm summer’s evening to enjoy these athletics.
 
-{% figure olympics-109.jpg landscape %}Sam and Paul in the olympic stadium{% endfigure %}
+{% figure olympics-109.jpg landscape %}
+Sam and Paul in the olympic stadium
+{% endfigure %}
 
-{% figure olympics-110.jpg landscape %}Paul after the olympic events have ended{% endfigure %}
+{% figure olympics-110.jpg landscape %}
+Paul after the olympic events have ended
+{% endfigure %}
 
-{% figure olympics-111.jpg landscape %}Soaking up the last bits of atmosphere{% endfigure %}
+{% figure olympics-111.jpg landscape %}
+Soaking up the last bits of atmosphere
+{% endfigure %}
 
 In the crowds, queueing for Stratford station we bumped into some friends. And then the mad dash race to Victoria, our own urban triathlon, traversing train, escalator, tube and station at high speed, to make our train to Brighton with three minutes to spare. A suitably sporty, sweaty and exhausting end to it all.
 
 After nine years, all it took was a local Olympic games to get Samantha interested in sport. From no interest at all, not even able to feign some semblance of passion for any sporting event, she became a sports fanatic, almost overnight, shouting at the TV, cheering athletes on. It was excellent and I hope she doesn’t return to her old ways after this.
 
-{% figure olympics-113.jpg landscape %}Goodbye Olympic park{% endfigure %}
+{% figure olympics-113.jpg landscape %}
+Goodbye Olympic park
+{% endfigure %}

--- a/source/_posts/longsheng-rice-terraces-china.md
+++ b/source/_posts/longsheng-rice-terraces-china.md
@@ -26,7 +26,9 @@ Beyond the park entrance for the Dragon’s backbone rice terraces there are two
 
 Luckily, hiking to your hotel is common and the villages provide a service to help. Four small ladies, none taller than 5ft, came rushing towards us, each with a wicker basket on their backs, big enough to carry our great lumping 20kg backpacks (by now they were laden with all the tourist stuff you buy when you're on holiday). For 1h30 it cost us 100 yuan per bag, about £10. The four of us, and the four bag carriers then set off up the steep hill towards the villages.
 
-{% figure china-pingan-002.jpg landscape %}Samantha and one of our bag carriers, hiking up to Ping’an{% endfigure %}
+{% figure china-pingan-002.jpg landscape %}
+Samantha and one of our bag carriers, hiking up to Ping’an
+{% endfigure %}
 
 The tarmac'd road turned to steps, to thin old stone paths and there's no way we could have got our bags there any other way. What we didn't learn until after is that there are storage areas and lockers near the ticket office — because why carry all the luggage up there? A day bag would've been fine.
 
@@ -34,9 +36,13 @@ The tarmac'd road turned to steps, to thin old stone paths and there's no way we
 
 Before travelling here we knew that the rice terraces were best in May, when the paddies are filled with water and are reflective. We expected a full green crop of rice, we didn't know that as autumn approaches the rice turns golden yellow, two weeks before it's harvested (harvesting is usually just after the Chinese golden week holiday). This yellow rice, which ripples through the terraces is spectacular, and a photographer’s dream come true (we passed at least two photography groups making the most of the timing). Our caravan of 8 hiked through these incredible scenes, onwards and upwards, until we reached Píng’ān.
 
-{% figure china-pingan-004.jpg landscape %}Golden rice terraces{% endfigure %}
+{% figure china-pingan-004.jpg landscape %}
+Golden rice terraces
+{% endfigure %}
 
-{% figure china-pingan-005.jpg landscape %}Longsheng rice terraces in autumn{% endfigure %}
+{% figure china-pingan-005.jpg landscape %}
+Longsheng rice terraces in autumn
+{% endfigure %}
 
 ## Ping’an and Liqing hotel
 
@@ -44,14 +50,20 @@ Píng’ān is the largest of the villages with many guesthouses, each with its 
 
 I expected our room to be quite basic, like in Songpan, but it exceeded expectations; a large bed, a balcony, a big enough bathroom. Just enough and nothing more. The food was alright too, and when we arrived, sweating and aching, we devoured their fried rice, fried noodles and spring rolls, washed down with a litre of cold lager.
 
-{% figure china-pingan-003.jpg landscape %}Our room at Liqing hotel{% endfigure %}
+{% figure china-pingan-003.jpg landscape %}
+Our room at Liqing hotel
+{% endfigure %}
 
 ## Evening in Ping’an
 
-{% figure china-pingan-007.jpg landscape %}Crescent rice terraces in the late evening{% endfigure %}
+{% figure china-pingan-007.jpg landscape %}
+Crescent rice terraces in the late evening
+{% endfigure %}
 
 After a nap we still had time enough that evening to explore and take photos. We doubled back along the route we'd walked in on to find the perfect spot to picture the crescent yellow terraces. The light faded faster than expected, owing mostly to the sun going behind a mountain long before sunset and the sudden onset of rain, a dark cloud materialising from nowhere. Hiking back into town we found Victor, a businessman from Shanghai, photographing the scenery with his expensive camera; he was on a photography trip with a large group — we passed him a few more times while there and he always said hello.
 
 We'd eaten recently and didn't need a massive dinner, so we stopped at the Píng’ān guesthouse, which was busy, with a friendly atmosphere, and ordered the local sticky rice in bamboo alongside a chicken curry — albeit a tasty curry quite different to any we've had before. Sam also enjoyed the local Osmanthus wine which tasted a little like madeira. Our ears were filled with the tales of an ex-trucker Australian recanting her travels around Asia, to her table and everyone else's.
 
-{% figure china-pingan-006.jpg landscape %}Dinner at Ping’an guesthouse{% endfigure %}
+{% figure china-pingan-006.jpg landscape %}
+Dinner at Ping’an guesthouse
+{% endfigure %}

--- a/source/_posts/longsheng-rice-terraces-china/2.md
+++ b/source/_posts/longsheng-rice-terraces-china/2.md
@@ -18,11 +18,15 @@ page: 2
 
 Like in Yangshuo we got up early to take pictures of sunrise, the timing and the scenery were too fabulous to miss this opportunity. However, once again, as in Yangshuo, the weather let us down and the early morning sun couldn’t pierce through the mountain fog. We waited at the top of a crescent terrace for the sunrise at 6:15am, and then for the sun to rise over the edge of the mountain at gone 7am; with the tripod setup we observed the farmers start their day. Either in boots or barefoot, they took their sharp knives and hacked away at the grass that grew between the lines of rice, stopping occasionally for a smoke. They collected the grass in bales, which would presumably feed their livestock.
 
-{% figure china-pingan-day-2-001.jpg landscape %}Grasshopper{% endfigure %}
+{% figure china-pingan-day-2-001.jpg landscape %}
+Grasshopper
+{% endfigure %}
 
 When the sun did eventually appear the light was best from the top of the valley, we climbed back up towards Ping’an and copied some other early risers by going into a rice terrace which was now a burning bright yellow. Of course rice paddies are drenched in water and the plants sit in a good foot of wet mud, that’s ok as long as you stick to the slippery path besides them. Well, as I said, that path is very slippery and Sam’s sandals have almost no grip, so as we squidged around the bend her foot gave way and half of her leg slid deep into the mud, splashing her and me in a delightful coating of mud. We traipsed back through the hotel, muddy, just as the cleaner had finished mopping up the reception floor.
 
-{% figure china-pingan-day-2-002.jpg landscape %}The morning sun catching the rice terraces{% endfigure %}
+{% figure china-pingan-day-2-002.jpg landscape %}
+The morning sun catching the rice terraces
+{% endfigure %}
 
 ## Guided tour of the rice terraces
 
@@ -32,7 +36,9 @@ After breakfast (toast, yoghurt, pancake), the four of us (Sam and I, Mieke and 
 
 From our hotel we trekked up the west side of Ping’an to see the “Seven stars around the moon”, a set of rice terraces that culminate in small dots at the top of a hill (the stars), with one of these peaks being much larger and stony than the others (the moon). There are two viewpoints, one halfway up and one from the top, and between them entrepreneurs sell their fresh passion fruits and postcards, or an opportunity to dress up and have your photo taken. At 9am the light was unexpectedly perfect, lighting the yellow rice beautifully and casting shadows into the valley. As Yúnli explained the stages of growing rice to the others I snapped as many photos of the terraces as I could. By the second viewpoint the light had changed.
 
-{% figure china-pingan-day-2-000.jpg landscape %}[Golden longsheng rice terraces](https://500px.com/photo/87435759/golden-rice-terraces-by-paul-hayes) at "Seven stars around the moon"{% endfigure %}
+{% figure china-pingan-day-2-000.jpg landscape %}
+[Golden longsheng rice terraces](https://500px.com/photo/87435759/golden-rice-terraces-by-paul-hayes) at "Seven stars around the moon"
+{% endfigure %}
 
 Our progress was slow as at every twist and turn we stopped to take more pictures of the astonishing landscape, or we stumbled on interesting wildlife, such as a luminescent green scarab. We met local Zhuang women on route, they cut their hair only twice in their lifetime and wear it differently based on their social status (married, single, with child) — they also sell bangles and postcards.
 
@@ -40,33 +46,51 @@ Our progress was slow as at every twist and turn we stopped to take more picture
 
 From the stars and moon we hiked around to another terrace, named “Nine dragons and five tigers”, where there are nine ridges that look like dragons, alongside five mounds that supposedly look like tigers. Whatever you call it, the rice terraces were once again a brilliant yellow and an incredible site to behold. From our viewpoint we were also dazzled by hundreds of large butterflies and dragonflies.
 
-{% figure china-pingan-day-2-013.jpg landscape %}Panorama of the “Nine dragons and five tigers” rice terrace{% endfigure %}
+{% figure china-pingan-day-2-013.jpg landscape %}
+Panorama of the “Nine dragons and five tigers” rice terrace
+{% endfigure %}
 
-{% figure china-pingan-day-2-003.jpg landscape %}Nine dragons and five tigers rice terrace{% endfigure %}
+{% figure china-pingan-day-2-003.jpg landscape %}
+Nine dragons and five tigers rice terrace
+{% endfigure %}
 
 ### Hike to Zhuang village
 
 Our hike would then take us to the remotest village, Zhuang, where there are no restaurants or guesthouses, only villagers and their homes. The trail from the rice terrace to here is different, passing through a valley and up and over the hills, its a narrow stone path that is at times arduous and without shade and takes about 2 hours oneway. We passed by a reservoir and its squabbling black duck residents, along an unfinished road two years in the making, through an ancient cemetery with ornate tombstones, and through small fields where the grass whipped at our bare legs. There were more butterflies and dragonflies, and we tried (often in vain) to photograph them, I caught sight of a hummingbird hawk-moth, and we all stopped to watch a golden yellow caterpillar with a hipster-like black mohican (except our guide, she has a fear of caterpillars). Sam marvelled at strawberry-like fruit that grows alongside the path, and we stopped to try some on the way back.
 
-{% figure china-pingan-day-2-004.jpg landscape %}"[Striped blue crow](http://www.projectnoah.org/spottings/876806003)" butterfly{% endfigure %}
+{% figure china-pingan-day-2-004.jpg landscape %}
+“[Striped blue crow](http://www.projectnoah.org/spottings/876806003)” butterfly
+{% endfigure %}
 
-{% figure china-pingan-day-2-005.jpg landscape %}Unidentified butterfly{% endfigure %}
+{% figure china-pingan-day-2-005.jpg landscape %}
+Unidentified butterfly
+{% endfigure %}
 
-{% figure china-pingan-day-2-006.jpg landscape %}[Unidentified hipster caterpillar](http://www.projectnoah.org/spottings/883136003){% endfigure %}
+{% figure china-pingan-day-2-006.jpg landscape %}
+[Unidentified hipster caterpillar](http://www.projectnoah.org/spottings/883136003)
+{% endfigure %}
 
 The path itself was surprisingly busy (not uncomfortably), Yúnli hadn’t ever seen it this busy, “Usually only foreigners walk along here, the Chinese don’t like to walk”. And at the entrance of Zhong Liu we queued to climb the steep pebbled path up to the village where we’d rest and eat lunch. At a small farmers house we sat outside on the tiniest of chairs, as if taken from a primary school, and enjoyed a fabulous lunch cooked by our intrepid guide. Fried potatoes and garlic, freshly picked pumpkin boiled with salt and sugar, greens, smoked dried pork, tomatoes and egg, and of course a couple of beers. All the ingredients were grown here, anything brought in costs a premium. The house doubles as a local convenience store and sells to the villagers mosquito repellants, tea, and tobacco.
 
-{% figure china-pingan-day-2-007.jpg landscape %}Approaching Zhuang village{% endfigure %}
+{% figure china-pingan-day-2-007.jpg landscape %}
+Approaching Zhuang village
+{% endfigure %}
 
-{% figure china-pingan-day-2-010.jpg landscape %}Roger and Mieke hiking back towards Ping’an{% endfigure %}
+{% figure china-pingan-day-2-010.jpg landscape %}
+Roger and Mieke hiking back towards Ping’an
+{% endfigure %}
 
 ### And back again
 
 We returned by the same route, quieter and cooler this time, and were followed half the way by a stray but friendly dog. Once again there were butterflies and caterpillars to gawk at, and Sam found a peculiar leaf-like insect we later learned was a water scorpion. A man strolled past us, 10ft long bamboo trunks hoisted over his shoulder. Nearly back we forked left and took a lower path around the terraces and into town. Corn was tied up and hung out to dry from wooden rafters, fed to the pigs — villagers don’t eat the corn; concrete slabs were bright red with thousands of red chillies spread out to dry in the sun. We were back by 5pm, my pedometer reading 27,000 steps.
 
-{% figure china-pingan-day-2-008.jpg landscape %}Roger, Mieke, Samantha and me{% endfigure %}
+{% figure china-pingan-day-2-008.jpg landscape %}
+Roger, Mieke, Samantha and me
+{% endfigure %}
 
-{% figure china-pingan-day-2-009.jpg portrait %}Our guide, Yúnli{% endfigure %}
+{% figure china-pingan-day-2-009.jpg portrait %}
+Our guide, Yúnli
+{% endfigure %}
 
 ## One more night in Ping’an
 
@@ -76,8 +100,12 @@ Our last evening in Ping’an, we explored the parts we hadn’t seen, finding v
 
 The hike into town was arduous and long, uphill and sweaty. We’d expected something similar on our return, and a similar price to pay to get our bags out. But on Friday morning the landslide was finally cleared and we could return via a shorter route, which was also cheaper. We had more time in the hotel than expected, and we watched as the sun came up on a beautiful new morning; the lighting would be perfect just as we’d board the minibus. After breakfast our four bag carriers hoisted up the luggage and we set off down the mountain, a mere 15 minutes later we were at the car park. This time we were prepared for a long hike, and I’d hoped for some spectacular views as we exited, but this route was mostly town and small shops, the rice terraces high above us and out of sight.
 
-{% figure china-pingan-day-2-012.jpg landscape %}A spider on the route out of town{% endfigure %}
+{% figure china-pingan-day-2-012.jpg landscape %}
+A spider on the route out of town
+{% endfigure %}
 
 It was the same crazy driver we had before who took us down the mountain. At the site of the landslide we gasped at its enormity, the temporary road just a slither through huge mounds of red dirt. The minibus slalom’d around slower traffic and we passed a naked man walking on the road side; it took about two hours to reach Guilin airport, where we’d continue to Guangzhou and then [Hong Kong](/2014/09/hong-kong-china/).
 
-{% figure china-pingan-day-2-011.jpg landscape %}Goodbye Ping’an{% endfigure %}
+{% figure china-pingan-day-2-011.jpg landscape %}
+Goodbye Ping’an
+{% endfigure %}

--- a/source/_posts/not-quite-the-life-of-riley.md
+++ b/source/_posts/not-quite-the-life-of-riley.md
@@ -16,11 +16,15 @@ This week Samantha also had her finals, the last exams of her masters; cocooning
 
 On Friday we had tickets for “Life of Riley”, a new Ayckbourn play, at Brighton Theatre. On a friday night the place was two thirds empty and the audience an average thirty years older than us. Local theatre really is no comparison to the West End. The production had its moments, and you could see the old flares of genius, but all in all it was tired, average and poor. And as the lights and music were fading out at the end of the play, the Pink Floyd track abruptly cut out and the lights flickered on and off. Our programme is lost somewhere in the stalls.
 
-{% figure life-of-riley.jpg landscape original %}A scene from Ayckbourn’s Life of Riley{% endfigure %}
+{% figure life-of-riley.jpg landscape original %}
+A scene from Ayckbourn’s Life of Riley
+{% endfigure %}
 
 Saturday took us into London, for a friend’s 30th birthday, the first 30th we’ve been to, and I’m sure the first of many. We made a day of it, and wandered around Southbank, the London Eye, Houses of Parliament and St. James’ park, in the glorious sunshine, it felt like summer had come early. We played with the settings on the DSLR camera, and watched the pelicans at St. James’ being fed whole fish, into their chop-stick like beaks. We lunched at Hummus Bros., did a spot of last minute shopping and had a long rest in comfy leather chairs in a Nero coffee shop.
 
-{% figure IMG_8032.JPG landscape %}London Eye{% endfigure %}
+{% figure IMG_8032.JPG landscape %}
+London Eye
+{% endfigure %}
 
 The meal was at Donzoko’s, around the back of Hamleys. We were downstairs in a cold room to ourselves, perched on stools with cheap disposable chopsticks. Between 16 of us we shared sushi, chicken and salmon teriyaki, a delightful aubergine dish and some tempura vegetables. Cold sake for everyone before a quick drink at a hawaiian bar nearby, then, as per usual, a dash to Victoria station to make sure we caught the last train at 00:05 am.
 

--- a/source/_posts/out-and-about-in-london-norman-conquests-and-sleeping-beauty.md
+++ b/source/_posts/out-and-about-in-london-norman-conquests-and-sleeping-beauty.md
@@ -18,15 +18,21 @@ A much belated part 2 of time spent in the West End and other fun places, I thin
 
 Next stop Alan Ayckbourn's trio of plays "Living Together", "Table Manners" and "Round and Round the Garden" (seen in that order) as part of "The Norman Conquests" in the round at the Old Vic - a theatre transformed for a 360 degree viewing experience. Being under 25 offers us the nice little perk of much discounted tickets, £20 for each play instead of £40-60, or thereabouts, a bargain. The six strong cast consisted of Amelia Bullmore, Jessica Hynes, Stephen Mangan, Ben Miles, Paul Ritter and Amanda Root.
 
-{% figure fofr-20090108-norman-conquests-1.jpg landscape original %}Scene from Table Manners{% endfigure %}
+{% figure fofr-20090108-norman-conquests-1.jpg landscape original %}
+Scene from Table Manners
+{% endfigure %}
 
 Going into "Living Together", Sam, Jo and I weren't sure what to expect, our seats were at the rear of the auditorium, where the stage would normally sit, but instead a circular tier of seats stood, carved into the back. We were incredibly close to the circular stage with its 'model village come wooden curtain' and light furniture set. The three plays intermingle in time, each can standalone but together they form a bigger picture, portraying different nuances and natures of the characters whilst each incredibly reveals a significant plot point subtly but realistically referenced in the other two. (Reg wandering into the front room, "Ah there it is", picks up the bin and walks out again).
 
-{% figure fofr-20090108-norman-conquests-2.jpg landscape original %}Argument scene from Table Manners{% endfigure %}
+{% figure fofr-20090108-norman-conquests-2.jpg landscape original %}
+Argument scene from Table Manners
+{% endfigure %}
 
 The stories are deeply tragic; three siblings, two unhappily married and the other single yet equally unhappy. The other three cast members make up their spouses/possible future partners whilst a sick and elderly mother and her promiscuous past resides out of sight, upstairs and bedridden. Norman is all set to run away for a romantic weekend with his wife's sister Annie, Annie's potential love interest - Tom, the dim witted Vet, believes she is going on holiday alone and that this is partly his fault; Annie's brother Reg and interfering wife Sarah arrive to look after mother for the weekend, in Annie's absence. Norman's wife Ruth remains unawares, but isn't without suspicion. Cue the start of all three plays and without wishing to reveal too much; the home made parsnip wine, Reg's cleverly devised board game he wants everyone to play, Norman's desire to make everyone happy, Tom's complete befuddlement, the rug, the silence at Breakfast, soup and salad, seating arrangements, Ruth's misinterpreted advice in the garden, the cat stuck in the tree, the tomfoolery and East Grinsted - and as the family tears itself apart you'll laugh with every turn, every revelation, every remark and your jaw will ache from the smile plastered across your face.
 
-{% figure fofr-20090108-norman-conquests-3.jpg landscape original %}Cast of Norman Conquests{% endfigure %}
+{% figure fofr-20090108-norman-conquests-3.jpg landscape original %}
+Cast of Norman Conquests
+{% endfigure %}
 
 For Table Manners and Round and Round the Garden we were seated at the top in the middle, a little further from the action but still a great view. Originally we'd decided to only go to one of the three, but on the strength of Living Together - which we now believe was the best starting place - we booked the next two. If I had to put them in order of favourites I'd put the Garden episode first, closely followed by Living Together and then Table Manners.
 
@@ -34,7 +40,9 @@ Our taste for plays, comedies, Ayckbourn and the Old Vic have been stimulated an
 
 Here's the best shot I could get of the circular stage from where we were:
 
-{% figure fofr-20090109-old-vic.JPG portrait original %}The circular stage at the Old Vic{% endfigure %}
+{% figure fofr-20090109-old-vic.JPG portrait original %}
+The circular stage at the Old Vic
+{% endfigure %}
 
 Before the shows we ate at the [Bangalore Express](http://bangaloreexpress.co.uk/) (with its double decker seating arrangement) and Yo Sushi (where we used our buy 5 plates get 5 free vouchers), both of which are in walking distance from the Old Vic.
 
@@ -42,9 +50,13 @@ Before the shows we ate at the [Bangalore Express](http://bangaloreexpress.co.uk
 
 Following the Garden, which we saw on a Saturday afternoon in December, we grabbed the tube to Hyde Park to visit the Winter Wonderland with all of its Christmastime goodies and German-like markets. Warming up with a tasty steak burger we aimlessly perused the stalls, trying out the mulled wine, the candied nuts, mini dutch pancakes in chocolate, fun hats and German sausages. Without realising it had reached 9pm we meandered towards Covent Garden before resting at "Fire and Stone", a fantastic stone-oven pizzeria where every pizza is based on a world city, I had the Marrakech, £8.95, "Cumin spiced ground lamb, mozzarella, mint yoghurt sauce, green olives, raisins & sliced red onion drizzled with chilli oil". Worth every penny.
 
-{% figure fofr-20090108-hyde-park-winter-wonderland.JPG landscape %}Hyde park winter wonderland{% endfigure %}
+{% figure fofr-20090108-hyde-park-winter-wonderland.JPG landscape %}
+Hyde park winter wonderland
+{% endfigure %}
 
-{% figure fofr-20090108-fire-and-stone.JPG landscape %}Fire and stone pizzeria{% endfigure %}
+{% figure fofr-20090108-fire-and-stone.JPG landscape %}
+Fire and stone pizzeria
+{% endfigure %}
 
 ## English National Ballet
 
@@ -52,4 +64,6 @@ The next big venture into London for Sam and I was to the Coliseum to see the En
 
 However, when the curtain lifted, the surrealism of a 3 hour show without a single spoken word, not even for the interval, slowly dawned on me, and with it I became quietly engrossed in the beautiful dance and skill before me, the miming techniques used for the plot mostly going over my head but for a few obvious examples. My slumber had me all buttered up and I left amongst the extraordinarily posh and the disproportionate number of rich attractive girls into the cold winter air, with scarf and gloves, ready for Christmas.
 
-{% figure fofr-20090108-coliseum-sleeping-beauty.JPG landscape %}Inside the Coliseum{% endfigure %}
+{% figure fofr-20090108-coliseum-sleeping-beauty.JPG landscape %}
+Inside the Coliseum
+{% endfigure %}

--- a/source/_posts/paraty-brazil.md
+++ b/source/_posts/paraty-brazil.md
@@ -13,7 +13,9 @@ pages: 6
 page: 1
 ---
 
-{% figure brazil-211.jpg landscape %}Paraty from the water{% endfigure %}
+{% figure brazil-211.jpg landscape %}
+Paraty from the water
+{% endfigure %}
 
 ## Iguaçu Falls to Paraty in 24 hours, by bus
 
@@ -37,7 +39,9 @@ We waited an hour or so for our bus, and passed the time with a bit of live foot
 
 Boarding time at last! We locked up our bags, weighed them, tagged them and threw them in the hold. We showed our passports and tickets and boarded our ‘leito’ sleeper bus. The seats were like armchairs; wide and comfortable with a handy fold-down leg rest. On an old CRT screen at the front were movies in Portuguese; ‘I am Legend’, Harry Potter and ‘Night at the Museum 2’.
 
-{% figure IMG_3828.JPG landscape %}Overnight sleeper coach{% endfigure %}
+{% figure IMG_3828.JPG landscape %}
+Overnight sleeper coach
+{% endfigure %}
 
 We set off slowly, heading out of Foz do Iguaçu onto the two lane highway and eastwards. The sun began to set and we had a roadside view of Brazil, through rolling green hills with rich red soils, through small towns and passing full to the brim churches, overflowing with people praising God. We stopped at Londrina for another pick-up and the bus filled up. The sun disappeared and the road beckoned.
 
@@ -51,7 +55,9 @@ The journey into São Paulo took an age, the huge concrete city surrounded us as
 
 90 minutes late we reached the rodoviaria. We picked up our next bus ticket and waited for the fifth and final bus in a bus station cafe, reclining on a leather sofa next to a piano and our large blue and red backpacks. Happy to be off the bus, we shared a ciabatta and freshly made fruit juice. The guy at the bar was excited to try out his English, and Sam had a conversation with him, as she loves to do.
 
-{% figure IMG_3834.JPG landscape %}São Paulo coach station{% endfigure %}
+{% figure IMG_3834.JPG landscape %}
+São Paulo coach station
+{% endfigure %}
 
 ### 6 hour coach to Paraty
 
@@ -69,11 +75,17 @@ All we wanted to do was check-in, but the welcoming French man, Yvan, complicate
 
 Inside we had a living room, a kitchen and a bedroom, all packed into a small space. The room felt dark, but then we had the shutters closed to stop the mosquitos getting in. There was a pleasant swimming pool and jacuzzi, and Heliconia plants are everywhere. By the pool is a green parrot with clipped wings, under the seats cats lie in the shade, and there’s a dalmatian puppy running around too, looking cute for all the guests. It’s a fairly small place, with only about eight rooms.
 
-{% figure brazil-206.jpg portrait %}Heliconia flower{% endfigure %}
+{% figure brazil-206.jpg portrait %}
+Heliconia flower
+{% endfigure %}
 
-{% figure brazil-207.jpg landscape %}Pet parrot at Eliconial hotel{% endfigure %}
+{% figure brazil-207.jpg landscape %}
+Pet parrot at Eliconial hotel
+{% endfigure %}
 
-{% figure IMG_4714.JPG landscape %}Our room at Eliconial{% endfigure %}
+{% figure IMG_4714.JPG landscape %}
+Our room at Eliconial
+{% endfigure %}
 
 “It’s safe here, you can go anywhere at night, even walk along the beach”, were welcomed words. Having spent so much time in Rio (and on the buses) stressing about safety and valuables this came as a great relief.
 

--- a/source/_posts/paraty-brazil/2.md
+++ b/source/_posts/paraty-brazil/2.md
@@ -13,23 +13,31 @@ But in the morning, when we opened the shutters and went out for breakfast the s
 
 Today we didn’t have much planned, but we wanted to see the old town and generally just have a look around. We headed into Paraty via a beachside wander on Praia do Jabaquara, wandering out as far as we could paddle, looking out onto the calm sea, and surrounded by rainforest covered hills. The sun was hot as we climbed the small mound between us and town, then back down, onto cobbled streets, over a small river and into Paraty.
 
-{% figure brazil-180.jpg portrait %}Sam on Praia do Jabaquara{% endfigure %}
+{% figure brazil-180.jpg portrait %}
+Sam on Praia do Jabaquara
+{% endfigure %}
 
 The old town is a criss crossing network of cobbled streets, each building painted white with brightly coloured window frames, it’s remarkably photogenic. Cars aren’t allowed in and only horse and cart navigate the uneven streets, amongst a few stray dogs.
 
-{% figure brazil-188.jpg portrait %}Resident and dog in Paraty{% endfigure %}
+{% figure brazil-188.jpg portrait %}
+Resident and dog in Paraty
+{% endfigure %}
 
 The town is hip and bohemian, and between restaurants and the odd tourist shop are fascinating art galleries and sculptures. We wandered down Rua do Comercio and tried to make a note of where interesting shops were, but it’s labyrinthine and difficult to find anything again.
 
 We stopped for a can of cooling Guaraná Antarctica, and as we recovered from the heat the clouds started to come over, and soon, before midday, the sun was gone. At the edge of town we found Paraty’s famous landmark, Igreja Santa Rita, which looked fantastic against the swirling dark clouds.
 
-{% figure brazil-183.jpg landscape %}Igreja Santa Rita beneath incoming storm{% endfigure %}
+{% figure brazil-183.jpg landscape %}
+Igreja Santa Rita beneath incoming storm
+{% endfigure %}
 
 We skirted the south of town. At the port all the tourist boats had left for the day, and the place was quiet. Further round was another church, Capela de NS das Dores. I left Sam with the camera to snap the scenery and walked ahead in search of a comfy bench.
 
 An Indian couple from California were taking pictures across the river. As with most travellers in Brazil it’s easy to strike up a conversation, and again we shared stories of our travels, waxing lyrical about Iguaçu falls, which they were heading to next. It seems popping over to the Argentinean side isn’t so easy with an Indian passport.
 
-{% figure IMG_4787.JPG landscape %}Sam and Paul by the harbour{% endfigure %}
+{% figure IMG_4787.JPG landscape %}
+Sam and Paul by the harbour
+{% endfigure %}
 
 Back into town, I tried my hand at photographing textures, which rarely come out as expected, before making our way into ‘new Paraty’, with modern roads and shops it’s very much like any other Brazilian town. We found the banks and ATMs, only one accepted European cards, 40 minutes from our hotel.
 
@@ -39,7 +47,9 @@ We stopped at a per kilo buffet restaurant for lunch and piled on the tasty barb
 
 Back in town Sam found an English speaking Cachaça expert in a room filled to the ceiling with expensive varieties. The charming assistant poured out free samples of un-aged (used in cocktails) and ten year matured (for drinking straight) Cachaça; it’s 38%—48% and made from fresh sugarcane juice that is fermented and distilled. Paraty is a renowned Cachaça producer and each year it holds a Cachaça festival. There’s a distillery and tour out of town but it was too far for us. We bought a bottle of Cachaça Coqueiro and tipsily meandered home.
 
-{% figure brazil-190.jpg portrait %}Emporio da Cachaça{% endfigure %}
+{% figure brazil-190.jpg portrait %}
+Emporio da Cachaça
+{% endfigure %}
 
 At Eliconial the jacuzzi beckoned and we relaxed amongst the warm bubbles until our hands wrinkled. We made the decision to stay here for the rest of our trip, and booked the remaining nights before heading out for dinner. An owl watched over us from the telephone lines.
 

--- a/source/_posts/paraty-brazil/3.md
+++ b/source/_posts/paraty-brazil/3.md
@@ -17,7 +17,9 @@ But we wouldn’t let this ruin our day. Out, along the beach and down into town
 
 Trindade was recommended by Rob in Rio as a quiet ‘less touristy’ place to stay. We considered finding a hostel here, but given the forecast we figured we’d want a little more than beaches and rain. But today it was gorgeous and we set about the ‘three beaches’ trek, starting off in the wrong direction and taking an unplanned hike into the hills.
 
-{% figure brazil-195.jpg portrait %}Hiking in Trindade{% endfigure %}
+{% figure brazil-195.jpg portrait %}
+Hiking in Trindade
+{% endfigure %}
 
 A narrow wooden trail climbed upwards through the rainforest. Wary of snakes hidden in the undergrowth, we clambered onwards to find waterfalls and a large fresh water pool. At the back of the pool a smooth slanted rock had a trickle of water flowing over it, forming a perfect natural water slide.
 
@@ -25,21 +27,29 @@ Sam swum across, climbed up and shuffled towards the slide. Then before she was 
 
 Further up was another pool, deeper and with a raging waterfall. Sam stood beneath it and shrieked as it crashed over her.
 
-{% figure brazil-192.jpg portrait %}Secret pools and waterfalls in Trindade{% endfigure %}
+{% figure brazil-192.jpg portrait %}
+Secret pools and waterfalls in Trindade
+{% endfigure %}
 
 Back at the beach, where large blue crabs scuttled passed us, we had lunch at a beachside hut and continued with the beach trek. Through a river we waded, and climbed up onto and over a jutting hill, the home of luminescent ladybirds. On the other side a long empty crescent beach stretched out in front of us. Huge waves crashed on the shore, and the sand was fine and soft.
 
-{% figure brazil-197.jpg landscape original %}Luminescent [tortoise beetle](http://www.projectnoah.org/spottings/10794157){% endfigure %}
+{% figure brazil-197.jpg landscape original %}
+Luminescent [tortoise beetle](http://www.projectnoah.org/spottings/10794157)
+{% endfigure %}
 
 Along the beach were a couple of secluded hostels. We stopped beneath a tree for a rest, Sam had a nap and I watched the leaf-cutter ants perform their arduous journey up and down the trunk, driving on the left. With my head down on the sand all I could hear were the sounds of the sea, the waves and the birds.
 
-{% figure brazil-198.jpg landscape %}Secluded beach near Trindade{% endfigure %}
+{% figure brazil-198.jpg landscape %}
+Secluded beach near Trindade
+{% endfigure %}
 
 An hour or so later we carried on, climbing over some rocks to find the start of the final trail. Up another dirt path we walked, around to a large natural swimming pool in the sea. Huge rocks formed a circle around a small bay, protecting it from the sea and creating somewhere awesome to swim.
 
 After a swim we headed back to Trindade to catch the 7pm bus home. Sam’s desire to see a hummingbird was growing, it seemed every time she turned away one popped up, hummed around a flower and disappeared again. She kept missing them. The first time you see one you can’t help but smile.
 
-{% figure brazil-201.jpg landscape %}Samantha hiking back{% endfigure %}
+{% figure brazil-201.jpg landscape %}
+Samantha hiking back
+{% endfigure %}
 
 Before the bus, we coo’ed at the cutest of baby chicks. Their owner came out to say hello and we had a lovely evening chat. Surprisingly, based on the experiences we’d had so far, she had good English, and when we couldn’t understand she wrote numbers or symbols in the sand. We held the chicks and she pointed out that the boy chicks have much smaller wings.
 

--- a/source/_posts/paraty-brazil/4.md
+++ b/source/_posts/paraty-brazil/4.md
@@ -9,7 +9,9 @@ page: 4
 
 Thursday was forecast to be the hottest, it was also meant to rain, but again the rain didn’t show up. We played with the marmosets at the hotel. They jumped from tree to tree and I tried to snap a midair shot. We talked work, internet, and life with the couple opposite us; the guy had lived in Brazil for a few years, but now lived in London, working with internet start-ups in Old Street, which was too much of a coincidence for my liking.
 
-{% figure brazil-202.jpg landscape %}Marmoset at Eliconial hotel{% endfigure %}
+{% figure brazil-202.jpg landscape %}
+Marmoset at Eliconial hotel
+{% endfigure %}
 
 We didn’t do much and it was lovely. We walked along the beach, swum in the sea and bathed in the sun. We had lunch at La Luna; tasty steak and fish with the usual beans, salad, rice and chip sides. The steak in Brazil is so big, tasty and cheap, but you can’t help feeling somewhat guilty that you’re supporting the deforestation. Next to us two dogs gave us starving puppy eyes.
 
@@ -23,7 +25,9 @@ In town we tried to do some shopping, but when it came to getting cash none of t
 
 And that’s how it was for the rest of the holiday, the ATM’s never worked again, we changed up the spare dollars we had and got a cash advance from the hotel to tide us over. We found others with the same problem.
 
-{% figure brazil-209.jpg landscape %}Cobbled Paraty street at night{% endfigure %}
+{% figure brazil-209.jpg landscape %}
+Cobbled Paraty street at night
+{% endfigure %}
 
 That night we ate at a posh looking black-and-white Italian restaurant, we’d been eyeing it up all week. Inside a charming but timid waiter nervously tried his English, and at the back, near an open courtyard and the cool night air we ordered. I took the opportunity to try an Acerola juice, scrumptious but hard to describe, with it I had palmito and pesto ravioli.
 

--- a/source/_posts/paraty-brazil/5.md
+++ b/source/_posts/paraty-brazil/5.md
@@ -9,15 +9,21 @@ page: 5
 
 Everyone in the hotel had been on the boat trip, and with a day to spare we did it too. In town we climbed onto the boat and waited to leave. It seemed like good value, R$25 each for most of the day. It turned out the charges were hidden; lunch, scuba rental, desserts, drinks and fruit - the prices added up to over R$100. And as boat trips go, it was lacklustre.
 
-{% figure brazil-211.jpg landscape %}Paraty from the water{% endfigure %}
+{% figure brazil-211.jpg landscape %}
+Paraty from the water
+{% endfigure %}
 
-{% figure brazil-212.jpg landscape %}Tourist boat in Paraty{% endfigure %}
+{% figure brazil-212.jpg landscape %}
+Tourist boat in Paraty
+{% endfigure %}
 
 Ten of us, on a boat that could hold 25, chugged out to an island for a spot of scuba and swim, then along to a large island with a rocky perch. Here we struggled to see monkeys and iguanas, our captain unwilling to take us closer, our eyes strained, we could make out golden brown shapes moving in the trees, but soon they were gone.
 
 While we waited for the monkeys the glorious sunshine disappeared behind grey cloud. Beach time was substituted for more swimming time. We ate a cooked dinner on the boat; fish, salad and potatoes, none too shoddy and before we knew it we were heading back to Paraty again.
 
-{% figure brazil-213.jpg landscape %}Samantha snorkelling{% endfigure %}
+{% figure brazil-213.jpg landscape %}
+Samantha snorkelling
+{% endfigure %}
 
 Despite all this we had a great time conversing with our fellow tourists, cariocas from Rio, down for the weekend, a well travelled woman from Buenos Aires, a scrawny brown woman from Miami and a small family. We spent most of the afternoon talking about cultural differences, healthcare, taxes, corruption, house prices and all that really serious stuff; “If it works in Brazil, you’ve paid for it twice”, they said, talking about privatised motorways.
 

--- a/source/_posts/paraty-brazil/6.md
+++ b/source/_posts/paraty-brazil/6.md
@@ -9,7 +9,9 @@ page: 6
 
 And so our holiday to Brazil comes to an end. We checked out the next morning, with our bags full, lifted onto our backs and ready to go. A taxi to the bus station and then a four hour Costa Verde bus into Rio, then a taxi to the airport. Wise Sam, guided by her hungry tummy, urged us to eat before going through security, and upstairs in the airport we enjoyed our final brazilian steak and chips, and I took the last chance to try a capiroska cocktail.
 
-{% figure brazil-214.jpg portrait %}Paul before leaving Paraty{% endfigure %}
+{% figure brazil-214.jpg portrait %}
+Paul before leaving Paraty
+{% endfigure %}
 
 Through the metal detectors, and out the other side, Sam was right, there would’ve been nowhere to eat here, and we passed the hour by shopping for trinkets; a flip flop keyring, unhelpfully priced in USD. The pathetic cocktail kits were laughable.
 

--- a/source/_posts/park-city-utah-with-the-family.md
+++ b/source/_posts/park-city-utah-with-the-family.md
@@ -17,37 +17,57 @@ Ah, its been a week now since I returned from the US, UTAH and the [Westgate Res
 
 Heading over appeared easier on paper, short flight to CDG, Paris then an 11 hour Air France flight to Salt Lake City (do not go to the Travelodge near Heathrow and certainly do not taste their food - if you must there is a nicer looking pub just around the corner). Looking online beforehand we noted the movies we wanted to watch, etc. Unfortunately the flight was with an Air France partner, Delta, without a sophisticated in flight entertainment system - instead giving us in the aisle airings of the awful "Little Miss Pettigrew Lives for a Day" and "Kung Fu Panda", leaving 7 hours to spare. No doubt the complimentary Kronenbourg 1664 helped the trip go a little faster. All in all it felt like a short haul flight - just really really long. Leaving the dull London 12C we were treated to a basking 88F on arrival, where we picked up our 4x4 Suzuki rental and proceeded towards Park City in the mountains.
 
-{% figure park-city-20081019-journey-up-mountain.JPG landscape %}Clouds over Salt Lake City{% endfigure %}
+{% figure park-city-20081019-journey-up-mountain.JPG landscape %}
+Clouds over Salt Lake City
+{% endfigure %}
 
 With a little time to spare before we collapsed in a heap of jet lag, we nipped to Ruby Tuesday's at the Kimball junction for our first dose of American dining alongside the odd tipping culture and the first of the auto-free refills - auto in that they always come back to fill you up. Dr Pepper, overly salted fries and a glorious Bison burger with ranch sauce nestled nicely in my tummy when I slipped into an unconscious 11 hour nap, bringing me nicely into Utah time.
 
-{% figure park-city-20081019-suzuki.JPG landscape %}Mum and our Suzuki rental{% endfigure %}
+{% figure park-city-20081019-suzuki.JPG landscape %}
+Mum and our Suzuki rental
+{% endfigure %}
 
 ## Westgate Resort
 
 Our rooms were conjoined at the wall, with handy inner door, to form a cozy, large and homely 'mega room' of duplicates. Full kitchen, half kitchen, washer dryer, one of those 'garbage disposal' grinders, balcony, three sofas, one jacuzzi, one shower with steamer and seat, one bath, four televisions each with cable, a large dining table, luxury bed robes, two safes, two king sized double beds and to wrap it all off a free newspaper in the morning (USA Today)! We were also treated to a heated half in-half out pool with two hot tubs aside it, pool tables, table tennis tables and a basketball net. Though most of my holidays are about getting out and seeing as much of the culture as possible, on the days we had nothing planned or didn't feel like going too far, these facilities made staying 'at home' a lot more enjoyable.
 
-{% figure park-city-20081019-room2.JPG landscape %}Our room at Westgate resort{% endfigure %}
+{% figure park-city-20081019-room2.JPG landscape %}
+Our room at Westgate resort
+{% endfigure %}
 
-{% figure park-city-20081019-room1.JPG landscape %}More of our room{% endfigure %}
+{% figure park-city-20081019-room1.JPG landscape %}
+More of our room
+{% endfigure %}
 
-{% figure park-city-20081019-bed.JPG landscape %}Big beds at Westgate{% endfigure %}
+{% figure park-city-20081019-bed.JPG landscape %}
+Big beds at Westgate
+{% endfigure %}
 
-{% figure park-city-20081019-jacuzzi.JPG landscape %}And a jacuzzi too{% endfigure %}
+{% figure park-city-20081019-jacuzzi.JPG landscape %}
+And a jacuzzi too
+{% endfigure %}
 
-{% figure park-city-20081019-pool.JPG landscape %}Half indoor swimming pool{% endfigure %}
+{% figure park-city-20081019-pool.JPG landscape %}
+Half indoor swimming pool
+{% endfigure %}
 
 First stop, Walmart and then Smiths for much needed groceries, bagels, drinks and Peanut Butter M&Ms! After a green chilli and cheese bagel and something I prefer to call plastic yellow rather than cheese filling, we nosed around Park City's old main street, with a little bit of shopping and a gander at some puppies in an antiques store with old native, hunting and skiing memorabilia. Eleanor cooked a very tasty roast for dinner, though she was too tired to eat most of it.
 
-{% figure park-city-20081019-main-street.JPG landscape %}Park City’s main street{% endfigure %}
+{% figure park-city-20081019-main-street.JPG landscape %}
+Park City’s main street
+{% endfigure %}
 
 ## Antelope Island
 
 Day 2 and the Indian summer continued as we drove down the valley into Salt Lake to pick up a map, visit the "[This is the place](http://en.wikipedia.org/wiki/This_Is_The_Place_Monument)" monument and carry on towards a small Mall with a terrible food court and [Antelope Island](http://en.wikipedia.org/wiki/Antelope_island). The island sits in the middle of the great lake and is home to a herd of Bison, 'wave cut platforms' and a lowly little ranch with some informational plaques. The second shot below was taking from the eating point where we enjoyed some juicy refreshments before heading home.
 
-{% figure park-city-20081019-en-route-antelope-island.JPG landscape %}Driving to Antelope Island{% endfigure %}
+{% figure park-city-20081019-en-route-antelope-island.JPG landscape %}
+Driving to Antelope Island
+{% endfigure %}
 
-{% figure park-city-20081019-view-from-eatery-antelope-isle.JPG landscape %}Antelope Island{% endfigure %}
+{% figure park-city-20081019-view-from-eatery-antelope-isle.JPG landscape %}
+Antelope Island
+{% endfigure %}
 
 ## So much shopping
 
@@ -57,37 +77,55 @@ Wednesday became an outlet store shopping trip complete with red Vans shoes, a l
 
 With morning pancakes and syrup I packed my bag for a trip up [Mount Timpanogos](http://en.wikipedia.org/wiki/Mount_Timpanogos) to view the caves. Of course, no one else in my family was up to the 1300ft hike up the paved track, so I did it alone. The thin windy road towards the entrance of the path granted stunning beautiful views of the mountains and foliage complete with autumnal colours - at the cost of nail biting corners; Eleanor was having none of it and was later glad to escape to the safe confines of another shop. Meanwhile I trekked up the mountainside for 90 minutes, past sheer drops, rattlesnake habitats, chipmunks and spray painted red areas you aren't allowed to stop in, to reach the three large cave systems at the top. Through the ragged limestone formations, out the other side and back down in half an hour and I rejoined the troupe. In the evening we met a local named Elaine and her family in Ogden where we were treated to turkey and other tasty treats. Back at home I caught the highlights of the Vice Presidential Debate, impressed by Biden.
 
-{% figure park-city-20081019-yellow.JPG landscape %}Mount Timpanogos in fall{% endfigure %}
+{% figure park-city-20081019-yellow.JPG landscape %}
+Mount Timpanogos in fall
+{% endfigure %}
 
-{% figure park-city-20081019-view.JPG landscape %}View from hike up Mount Timpanogos{% endfigure %}
+{% figure park-city-20081019-view.JPG landscape %}
+View from hike up Mount Timpanogos
+{% endfigure %}
 
-{% figure park-city-20081019-cave.JPG landscape %}One of the mountain’s cave systems{% endfigure %}
+{% figure park-city-20081019-cave.JPG landscape %}
+One of the mountain’s cave systems
+{% endfigure %}
 
 ## Heber city
 
 The weekend brought with it rain, lots and lots of rain. In it we drove around Heber city and up the monument for those in the region that have fought in wars, before going down the valley and stopping at University Mall to buy yet more things - Eleanor finding that Nordstrom had in stock some beauty products she'd been looking for.
 
-{% figure park-city-20081019-rain-monument.JPG portrait original %}Monument in Heber city{% endfigure %}
+{% figure park-city-20081019-rain-monument.JPG portrait original %}
+Monument in Heber city
+{% endfigure %}
 
 ## Salt Lake
 
 Luckily enough, the sun made its return on Monday in time for a day out with an old friend of Stuart's; from peanut butter and jelly sandwiches and views of the Wabash front we were taken down into Salt Lake to see temple square and the other latter day saints monuments and the view from the top of state street. Then a stop off at Rocky Mountain Chocolate Factory, a quick trip to the air field to see the aircraft he pilots ($25m Challenger) and back home for a fine BBQ and a game of Ticket to Ride with the family.
 
-{% figure park-city-20081019-temple.JPG landscape %}Temple square{% endfigure %}
+{% figure park-city-20081019-temple.JPG landscape %}
+Temple square
+{% endfigure %}
 
-{% figure park-city-20081019-wabash-front.JPG landscape %}View of Salt Lake City at night{% endfigure %}
+{% figure park-city-20081019-wabash-front.JPG landscape %}
+View of Salt Lake City at night
+{% endfigure %}
 
 ## Valley railway
 
 After Stuart hurt his ankle, probably playing table tennis with me, the rest of us drove down to Heber (after topping up the rear tire with a little bit of air, following the prompt on screen warning we were given) to go on the valley railway. We didn't get the steam train, instead a more forceful looking engine, and for $30 we each rode down into the valley. Having driven this route a couple of times now this wasn't the most exhilarating of trips though it did give a welcomed break to the road, and from the rear cart, which was open to the elements, you could see the snow capped mountains (they had a dusting overnight it seems) and the autumn leaves.
 
-{% figure park-city-20081019-heber.JPG landscape %}Waiting for Heber valley railway{% endfigure %}
+{% figure park-city-20081019-heber.JPG landscape %}
+Waiting for Heber valley railway
+{% endfigure %}
 
-{% figure park-city-20081019-rail.JPG landscape %}Train through the mountains{% endfigure %}
+{% figure park-city-20081019-rail.JPG landscape %}
+Train through the mountains
+{% endfigure %}
 
 That evening we tried out the [Hapa Grill](http://www.latituderg.com/HapaGrill.aspx); a sushi bar. Here I was treated to a very tasty thai beef salad; the beef and crushed peanuts really did the trick. I also took the opportunity to introduce mum and Eleanor to the wonders of sushi, starting first with the much loved California Roll (crab, cucumber and avocado) and later trying the Eel which didn't go down too well. Stuart of course stayed well away from it all; instead sticking to his faithful root beer and refills.
 
-{% figure park-city-20081019-sushi.JPG portrait %}Eleanor’s first sushi{% endfigure %}
+{% figure park-city-20081019-sushi.JPG portrait %}
+Eleanor’s first sushi
+{% endfigure %}
 
 ## Toothache
 
@@ -97,9 +135,13 @@ It was about this time that Eleanor developed a severe pain in one of her rear t
 
 That kind of put a damper on our plans for the end of the week; later that day Eleanor caught up on her sleep whilst we visited the Utah Olympic park; I conceived of many ways to beat the ball bearing slalom games at the visitor center and get the top scores before checking out the freestyle ski jumps and the bobsleigh run from a distance.
 
-{% figure park-city-20081019-ball-bearing-games.JPG landscape %}Slalom ball-bearing game at Utah Olympic Park{% endfigure %}
+{% figure park-city-20081019-ball-bearing-games.JPG landscape %}
+Slalom ball-bearing game at Utah Olympic Park
+{% endfigure %}
 
-{% figure park-city-20081019-olympic-park.JPG portrait %}View from the olympic park{% endfigure %}
+{% figure park-city-20081019-olympic-park.JPG portrait %}
+View from the olympic park
+{% endfigure %}
 
 We ate at Squatters along the way from Westgate towards PC, the Polygamy Porter ale was scrumptious but the food was distinctly lacking.
 
@@ -107,11 +149,17 @@ We ate at Squatters along the way from Westgate towards PC, the Polygamy Porter 
 
 Friday turned bitterly cold and with Saturday came snow. A couple of inches falling in just an hour. Armed with a list of targets to be met, we set off with a mission; first heading North to a "Super Target", then back down through Salt Lake, Provo and eventually Ogden, to visit a proper Steakhouse and see Elaine again; Eleanor and I opting to do some last minute shopping and picking up some fantastic bargains in Aeropostale. The succulent 9oz filet with jacket potato was delicious. Before packing we made one final stop at Walmart for treats and the Vans outlet so I could buy 3 more pairs of radiant but glorious shoes at cheap prices.
 
-{% figure park-city-20081019-canyons-snow.JPG landscape %}And then it snowed{% endfigure %}
+{% figure park-city-20081019-canyons-snow.JPG landscape %}
+And then it snowed
+{% endfigure %}
 
-{% figure park-city-20081019-snow.JPG landscape %}Swimming pool in the snow{% endfigure %}
+{% figure park-city-20081019-snow.JPG landscape %}
+Swimming pool in the snow
+{% endfigure %}
 
-{% figure park-city-20081019-sun-snow-mountains.JPG landscape %}Sun over the mountains{% endfigure %}
+{% figure park-city-20081019-sun-snow-mountains.JPG landscape %}
+Sun over the mountains
+{% endfigure %}
 
 More overnight snow led to our death defying down the mountain trek into Salt Lake to catch our 8:30am flight, where the lanes were unclear, the tracks hard to follow and the car ready to escape from beneath us, though helpfully warning of icy conditions. Through mum's excellent driving and nerve we made it to the rental drop off point, boarded our plane and we were flying away home, this time with in flight entertainment (Indy 4, Must Like Dogs and The Baker) and empty seats to lie down on - oh what a difference it makes.
 
@@ -119,8 +167,12 @@ The end.
 
 Also, Pumpkin Ale is disgusting.
 
-{% figure park-city-20081019-pumpkin-ale.JPG landscape original %}I can’t recommend pumpkin ale{% endfigure %}
+{% figure park-city-20081019-pumpkin-ale.JPG landscape original %}
+I can’t recommend pumpkin ale
+{% endfigure %}
 
 And this guy is really cool looking.
 
-{% figure park-city-20081019-awesome-cool-guy.JPG portrait %}Paul on Heber valley train{% endfigure %}
+{% figure park-city-20081019-awesome-cool-guy.JPG portrait %}
+Paul on Heber valley train
+{% endfigure %}

--- a/source/_posts/petworth-house-and-our-anniversary.md
+++ b/source/_posts/petworth-house-and-our-anniversary.md
@@ -21,21 +21,33 @@ With an Indian summer forecast, and likely the last t-shirt wearing weekend for 
 
 With the Peugeot squeezed into the only available space, we carried our picnic up to the top of the hill, and on the hidden bench, beneath falling chestnuts, we ate our roast chicken and bread rolls. Out in the misty valley, deer ran away from scary dogs and the tree leaves were already turning yellow.
 
-{% figure petworth-house-7.jpg landscape %}Petworth house and park{% endfigure %}
+{% figure petworth-house-7.jpg landscape %}
+Petworth house and park
+{% endfigure %}
 
 I packed the SLR, and with all the mist and wildlife it was a perfect opportunity for a spot of photography. Deer lay in the long grass, and as we neared they galloped away, leaving us to lament our limited zoom, incorrect camera settings and pictures of deer hind. Never mind, I still had the chance to explain aperture and shutter speeds to Sam as we knelt in the muddy grass to photograph great red mushrooms.
 
-{% figure petworth-house-6.jpg landscape original %}Stag{% endfigure %}
+{% figure petworth-house-6.jpg landscape original %}
+Stag
+{% endfigure %}
 
-{% figure petworth-house-5.jpg landscape %}Mushrooms in autumn{% endfigure %}
+{% figure petworth-house-5.jpg landscape %}
+Mushrooms in autumn
+{% endfigure %}
 
 Back at Petworth House, and after a cup of tea, a cookie and some grapes, we meandered the great hallways. Walls were lined with fantastic works of art, including many original pieces by Turner and William Blake. A view of Brighton from the sea, by Turner, sat alongside a portrait of Henry VIII in the ‘carved room’.
 
-{% figure petworth-house-3.jpg portrait %}Paul tossing grapes{% endfigure %}
+{% figure petworth-house-3.jpg portrait %}
+Paul tossing grapes
+{% endfigure %}
 
-{% figure petworth-house-2.jpg landscape %}“Carved room” in Petworth house{% endfigure %}
+{% figure petworth-house-2.jpg landscape %}
+“Carved room” in Petworth house
+{% endfigure %}
 
-{% figure petworth-house-1.jpg landscape %}Gallery and sculptures in Petworth house{% endfigure %}
+{% figure petworth-house-1.jpg landscape %}
+Gallery and sculptures in Petworth house
+{% endfigure %}
 
 That night we watched The Pianist, a sobering Polanski movie about the trials of a talented Jewish musician during World War II, we sincerely recommend it.
 

--- a/source/_posts/phong-nha-vietnam.md
+++ b/source/_posts/phong-nha-vietnam.md
@@ -24,7 +24,9 @@ Our room was modest. A bed with mosquito nets, a small bathroom, some shelves an
 
 The view from the bedroom however was breathtaking. Bright green rice paddies stretched out into the distance until they met towering limestone mountains which climbed gloriously into the sky, the sun setting just behind, amidst the orange hue of a few clouds. We stood for a few minutes just to take it all in.
 
-{% figure phong-nha-380.jpg landscape %}View from Phong Nha farmstay{% endfigure %}
+{% figure phong-nha-380.jpg landscape %}
+View from Phong Nha farmstay
+{% endfigure %}
 
 Downstairs again we said our hellos, and got to know a couple of people, Andy and Beth were on their honeymoon, they'd been to Hoi An and we shared stories and plans, as you do.
 
@@ -34,10 +36,14 @@ We had beer, some very good beef Pho and umm'd and ahh'd about which tour we sho
 
 Dave, a loud, brash, and self-proclaimed fat Australian, wearing his red hawaiian shirt, explained the cave tour. “Underground rivers, kayaking, swimming, climbing over big fuckin' rocks, there were parts where if the guide hadn't been there I'd have died. This [the Phong Nha tour] is good, but this [pointing at the cave trek], this is better than Macchu Piccu. This is incredible”. Yes, a real adventure, but this unsettled us, what had we signed up for?
 
-{% figure phong-nha-453.jpg landscape %}The tour boards at Phong Nha farmstay{% endfigure %}
+{% figure phong-nha-453.jpg landscape %}
+The tour boards at Phong Nha farmstay
+{% endfigure %}
 
 We retired, but not before standing on the balcony and watching the stunning thunderstorm taking place over the mountains. A flash of fork lightning, spreading out across the sky, lighting up the rice paddies, and then the crack of thunder.
 
 That night I imagined what the tour would be like. Would we be stranded in some pitch black cavern, squeezing through the tiniest of spaces and climbing down small holes? What if we got lost? What if I was forced to swim — I don't really do swimming. But I swiftly fell asleep beneath the mosquito nets, the red light of the anti-mozzy spray glowing dimly.
 
-{% figure phong-nha-454.jpg portrait %}Night time at the farmstay{% endfigure %}
+{% figure phong-nha-454.jpg portrait %}
+Night time at the farmstay
+{% endfigure %}

--- a/source/_posts/phong-nha-vietnam/2.md
+++ b/source/_posts/phong-nha-vietnam/2.md
@@ -21,7 +21,9 @@ To reach the cave entrance you board a yellow electronic vehicle, it's very Jura
 
 The kit consisted of a headlamp, and rugged jacket and trousers. Shoes were also available, though of course we had our own walking boots. Most of the available Vietnamese shoe sizes were too small for everyone.
 
-{% figure phong-nha-381.jpg landscape %}Paradise cave expedition group{% endfigure %}
+{% figure phong-nha-381.jpg landscape %}
+Paradise cave expedition group
+{% endfigure %}
 
 ### Magnificent Paradise Cave
 
@@ -29,13 +31,19 @@ Kitted out, headlamps tested, dressed and ready to go, we set off. The diminutiv
 
 We ambled down the slippery steps and turned the corner. Wow, we were standing in an enormous underground cavern that expanded beneath us. Larger than a concert hall, but with equally good acoustics. There was a slight haze from the moisture in the air, and we descended another 100 or so steps to its base.
 
-{% figure phong-nha-419.jpg landscape %}Paradise Cave expanding beneath us{% endfigure %}
+{% figure phong-nha-419.jpg landscape %}
+Paradise Cave expanding beneath us
+{% endfigure %}
 
 Paradise cave is simply magnificent, more enormous and wonderful than any cave I have ever seen. The stalagmites are great deformed columns that reach to the ceiling, the stalactites, equally big, hang down, deadly looking spikes hovering above. The lighting is serene, and subtly highlights the natural colours of the million year old limestone formations. From eerie and gothic bulging statues to towering frozen waterfalls, we strolled through the first kilometre, passing tour groups, proudly dressed in caving gear.
 
-{% figure phong-nha-434.jpg landscape %}Hiking 14km of this, only in the dark, with headlamps{% endfigure %}
+{% figure phong-nha-434.jpg landscape %}
+Hiking 14km of this, only in the dark, with headlamps
+{% endfigure %}
 
-{% figure phong-nha-430.jpg portrait %}A gothic towering stalagmite{% endfigure %}
+{% figure phong-nha-430.jpg portrait %}
+A gothic towering stalagmite
+{% endfigure %}
 
 ### Boardwalk to cave floor
 
@@ -43,7 +51,9 @@ The boardwalk ends with a circular viewing platform and that's where most touris
 
 In such cold black our headlamps were surprisingly powerful. We lit up the large cavern and looked around, standing somewhere less than 100 people have ever been, wary not to stand on something precious. My fears of small cramped places were blown away, these were huge towering caverns, as enormous as a few storey buildings, but seen only by a privileged few.
 
-{% figure phong-nha-386.jpg landscape %}Entering the darkness{% endfigure %}
+{% figure phong-nha-386.jpg landscape %}
+Entering the darkness
+{% endfigure %}
 
 ### Pitch black
 
@@ -55,17 +65,25 @@ Click, the light returned and we continued, each talking about how we'd felt in 
 
 We climbed limestone mounds, tiptoed across frozen limestone lakes, and marvelled at huge limestone organs, with hollow musical tubes. All around us small sapling stalagmites grew from the floor. Occasionally a giant formation lay on the ground, having grown too large and come crashing down, many thousands of years ago. Amongst the limestone were layers of thick brown clay, perfectly smooth and untouched for years.
 
-{% figure phong-nha-388.jpg landscape %}Glittering cave wall{% endfigure %}
+{% figure phong-nha-388.jpg landscape %}
+Glittering cave wall
+{% endfigure %}
 
-{% figure phong-nha-411.jpg landscape %}A Paradise Cave cavern, long exposure{% endfigure %}
+{% figure phong-nha-411.jpg landscape %}
+A Paradise Cave cavern, long exposure
+{% endfigure %}
 
-{% figure phong-nha-413.jpg landscape %}A magnificent beast{% endfigure %}
+{% figure phong-nha-413.jpg landscape %}
+A magnificent beast
+{% endfigure %}
 
 The caves were cool, but without any wind, no breeze at all, and hiking was hot and sweaty (and somewhat smelly).
 
 4km in we stopped for a rest, against many towering layers of limestone, like a natural amphitheatre, or a solid stone waterfall. We climbed to the top, where a sparkling diamond like formation stunned us, like glistening water overflowing from the peak. I set up the tripod and tried out some long exposure shots.
 
-{% figure phong-nha-392.jpg landscape %}Inside the stone amphitheatre{% endfigure %}
+{% figure phong-nha-392.jpg landscape %}
+Inside the stone amphitheatre
+{% endfigure %}
 
 Dong stopped amidst a large cavern and pointed to the ceiling, “highest point” he said. A drip was falling from the roof, creating a small stalagmite beneath us, we watched the water fall, glistening in the light of our headlamps, falling for an eternity. Drip… … drip… … drip.
 
@@ -73,7 +91,9 @@ Dong stopped amidst a large cavern and pointed to the ceiling, “highest point�
 
 Something small was moving on the ground ahead of us. A bug, a colourless spiny sub-species of grasshopper with enormous antennae. It lives its entire life in pitch black. How did it get here? How does it survive down here? We marvelled at this peculiar creature, and watched as it scurried away.
 
-{% figure phong-nha-391.jpg landscape %}Colourless creatures living in the depths of Paradise Cave{% endfigure %}
+{% figure phong-nha-391.jpg landscape %}
+Colourless creatures living in the depths of Paradise Cave
+{% endfigure %}
 
 ### Cave kayaking
 
@@ -83,7 +103,9 @@ When the first group left, those of us still at the clay walled stony port turne
 
 We were the penultimate two to go by kayak, and it was a shaky ordeal. The water was shallow, and the formations made using oars difficult. We ducked as a low ceiling narrowly passed us. I put on the fluorescent orange lifejacket, and hoped we'd make it across without a problem. And we did, arriving at a similar clay port where those waiting were sculpting many small clay figures on the river bank. Half way through a red and white coloured moth landed on my hand, “what are you doing here?” I asked, perplexed that my new friend could be in here.
 
-{% figure phong-nha-410.jpg landscape %}Underground kayaking in Paradise Cave{% endfigure %}
+{% figure phong-nha-410.jpg landscape %}
+Underground kayaking in Paradise Cave
+{% endfigure %}
 
 As we continued through a few more caverns, passing the “lowest point” in the cave, a low ceiling we ducked and clambered through (nothing too strenuous). We were nearing the end of the route, the midpoint of the hike and our spot to have some lunch.
 
@@ -93,9 +115,13 @@ A narrow entryway to a cavern was met with a delightful cool breeze, and from th
 
 And then we saw the light source and the area it shone down upon, and what a site to behold. A giant, luscious sinkhole with sunlight and rainwater pouring in, trees towering above, roots wrapped around the walls, above a raging underground river in a cavern large enough to house a twenty storey building. Between the sinkhole and the river, a layer of definitive white cloud. Phenomenal and beautiful. Despite my trying, it was impossible to capture the enormity and wonder of this place in a photo.
 
-{% figure phong-nha-400.jpg portrait %}An enormous sink hole{% endfigure %}
+{% figure phong-nha-400.jpg portrait %}
+An enormous sink hole
+{% endfigure %}
 
-{% figure phong-nha-398.jpg landscape %}Crossing the underground river{% endfigure %}
+{% figure phong-nha-398.jpg landscape %}
+Crossing the underground river
+{% endfigure %}
 
 ### Falling into an underground river
 
@@ -105,21 +131,31 @@ I was last to go, in my heavy duty walking boots I balanced precariously on a we
 
 In my wet state I didn't really relax in the 30 minute mid-hike break, where we ate our pork and rice and stared up into the centre of the sinkhole. Once again we watched the water drops fall for an eternity before smashing on a rock.
 
-{% figure phong-nha-406.jpg landscape %}Looking up at the light{% endfigure %}
+{% figure phong-nha-406.jpg landscape %}
+Looking up at the light
+{% endfigure %}
 
-{% figure phong-nha-405.jpg portrait %}Samantha beneath the dripping sink hole{% endfigure %}
+{% figure phong-nha-405.jpg portrait %}
+Samantha beneath the dripping sink hole
+{% endfigure %}
 
 ### And back again
 
 The return route was the reverse, going back the same way. Back over the river, leaving the sinkhole, through wondrous tall caverns, through the lowest point, on the kayak, to the tallest point, and 6km, to the publicly accessible lit part of the cave. We marvelled as we discovered more stunning formations, crystal towers buried beneath mountains of rock, tucked away from prying eyes. At the final beautiful formation we stood for a group photo, everyone standing very still as I timed a long exposure shot.
 
-{% figure phong-nha-414.jpg landscape %}Heading back through the caverns of Paradise Cave, long exposure{% endfigure %}
+{% figure phong-nha-414.jpg landscape %}
+Heading back through the caverns of Paradise Cave, long exposure
+{% endfigure %}
 
-{% figure phong-nha-418.jpg landscape %}Paradise Cave expedition group, hike complete{% endfigure %}
+{% figure phong-nha-418.jpg landscape %}
+Paradise Cave expedition group, hike complete
+{% endfigure %}
 
 We returned to the light of the lit caverns, emerging from the darkness, muddy and sweaty. Tourists on the boardwalk looked astonished, we proudly smiled and walked on by. Our incredible trek complete, one of the most amazing things we've ever done or ever will do.
 
-{% figure phong-nha-420.jpg landscape %}Muddy boots{% endfigure %}
+{% figure phong-nha-420.jpg landscape %}
+Muddy boots
+{% endfigure %}
 
 ## Kaleidoscope of butterflies
 
@@ -127,9 +163,13 @@ On the way home we stopped for a quick swim, in the gorgeous turquoise waters of
 
 Back in the minibus, discussing which Sigur Ros album was best, through the remainder of the limestone hills, over the river and back to the farmstay; where the music was already playing and the party had started.
 
-{% figure phong-nha-422.jpg portrait %}Time for a swim{% endfigure %}
+{% figure phong-nha-422.jpg portrait %}
+Time for a swim
+{% endfigure %}
 
-{% figure phong-nha-421.jpg landscape %}Summon the butterflies{% endfigure %}
+{% figure phong-nha-421.jpg landscape %}
+Summon the butterflies
+{% endfigure %}
 
 Over a cave group dinner everyone planned what to do next; some were going on to Hue, others wanted to do an overnight trek through the jungle. Inside, live music beckoned, a Thai woman covering classics in her own unique style. With our beer we closed out the evening with the rambunctious Dave, and tales of his prior career as a nude life model. Meanwhile Matt was borrowing clothes for a two day trek, in bandana and khaki jacket he morphed into Rambo.
 

--- a/source/_posts/phong-nha-vietnam/3.md
+++ b/source/_posts/phong-nha-vietnam/3.md
@@ -21,13 +21,17 @@ The journey was supplemented with tales of Bich's mum, a surviving volunteer tha
 
 The park isn't strictly open to tourism, getting in by yourself isn't possible. We were allowed in as we were with locals, locals that knew the park's restrictions on where you can and can't go. A route through the park is still heavily maintained for military purposes, the old Ho Chi Minh trail.
 
-{% figure phong-nha-425.jpg landscape %}Phong Nha national park{% endfigure %}
+{% figure phong-nha-425.jpg landscape %}
+Phong Nha national park
+{% endfigure %}
 
 ### Park by Jeep
 
 On a hill we marvelled at the beautiful park. Thin layers of low hanging cloud danced amongst the limestone karsts, eerie and magnificent. Ben explained how the rocks were formed, being eroded by fresh water many millennia ago, and listed the known wildlife in the area — bears, apes, and recently tigers, spotted by British cave expedition groups. Spooked by the appearance of another tour group (Oxalis, a group Ben had helped setup), we moved on. Sam and I jumped in the jeep, held on to the metal frame and rumbled around the former gravel roads of the park.
 
-{% figure phong-nha-424.jpg landscape %}Jeep tour through the national park{% endfigure %}
+{% figure phong-nha-424.jpg landscape %}
+Jeep tour through the national park
+{% endfigure %}
 
 Next stop, an intersection, with restricted roads that connect north and south, again with wondrous views. Back to the jeep and onwards, Bob Dylan screeching from the stereo, as the convoy's classic motorbike races by. Another war story: “The Americans used to blast the sides of these mountains, causing rocks to block the road”, making it impassable for Vietnamese supplies — “the Vietnamese solution was to throw man power at the problem”; Ben slowed down and pointed out a small cave where volunteers had lived and hid, after each attack they'd come out and clear up the rocks.
 
@@ -37,7 +41,9 @@ Not famously known for being part of the war, this area was still pivotal, one o
 
 Next stop was the temple of eight ladies, or eight martyrs. Here eight women had lived in a cave which was badly bombed, the entrance became blocked, trapping them inside. For days people tried to get air and supplies to those trapped, but they perished. Now there is a shrine and temple dedicated to them where Vietnamese also pay their respects to the war dead.
 
-{% figure phong-nha-426.jpg landscape %}The temple of eight martyrs{% endfigure %}
+{% figure phong-nha-426.jpg landscape %}
+The temple of eight martyrs
+{% endfigure %}
 
 In this region Kin ancestor worship is popular, a belief in a spirit world filled with good and bad spirits and with traditions that involve burning paper items to give to their relations in the spirit world. At the temple the inside altar dedication is for the spirits you wish to be associated with, on the outside those you don't — inside first, outside second. In an unlit corner an exhibit showed items girls fighting in the war would've carried; a toothbrush, comb, the famous Ho Chi Minh sandals made from old car tyres.
 
@@ -51,7 +57,9 @@ The ingenuity of the Vietnamese fighting the Americans was on show again. This t
 
 Paradise Cave was next, the cave we hiked through the day prior. More Jurassic park jeeps, “there's a goat strung up just along there”, Ben noted. Up the steep slope we trekked, again in the rain, and into the cave. Even though it was our second time, it was wondrous, an incredible place. We wandered slowly, taking it all in, and used the tripod to capture shots of us. At the end of the boardwalk we stood for a few moments, in the damp echoey chamber by ourselves. Wasn't yesterday incredible?
 
-{% figure phong-nha-432.jpg landscape %}Return to Paradise Cave{% endfigure %}
+{% figure phong-nha-432.jpg landscape %}
+Return to Paradise Cave
+{% endfigure %}
 
 Lunch break outside the cave gave the mosquitoes the opportunity they needed to bite me, twenty times or so. I must've been the tastiest.
 
@@ -61,9 +69,13 @@ Back in the jeep, “All along the watchtower” playing, “come and take my ea
 
 “Everyone got their swimmies?”, one after another we jumped into the river and swam to the other side. As a guy that doesn't really do swimming, I didn't fancy the strong river current, even with a life jacket. Ben and I took the kayak and beers, handing out cans of 333 to everyone. Beyond the trail lies a sink hole that feeds the river, huge volumes of water are pumped up from nearby caves.
 
-{% figure phong-nha-441.jpg landscape %}The mystical Phong Nha national park{% endfigure %}
+{% figure phong-nha-441.jpg landscape %}
+The mystical Phong Nha national park
+{% endfigure %}
 
-{% figure phong-nha-444.jpg landscape %}Jeep stop{% endfigure %}
+{% figure phong-nha-444.jpg landscape %}
+Jeep stop
+{% endfigure %}
 
 ### Dark Cave
 
@@ -75,15 +87,21 @@ As a poor swimmer, I swam with Ben, who also carried Bich on his back. We probab
 
 On the way out we angle our headlamps to the roof, Sam swims on her back for the best views. Another enormous magnificent cave that we feel privileged to have seen. In the Kayak again we were much improved, and didn't arrive last. A round of chilled canned beer and back to the farmstay, with one final stop on the bridge for a photo opportunity. Not to mention a family of water buffalo freaking out in the road.
 
-{% figure phong-nha-449.jpg landscape %}The happy couple, outside the national park{% endfigure %}
+{% figure phong-nha-449.jpg landscape %}
+The happy couple, outside the national park
+{% endfigure %}
 
-{% figure phong-nha-450.jpg landscape %}Phong Nha national park{% endfigure %}
+{% figure phong-nha-450.jpg landscape %}
+Phong Nha national park
+{% endfigure %}
 
 ## Popcorn and cocktails
 
 At the farmstay freshly popped pop corn waited for us, with a free cocktail. The sun was setting over the mountains and rice paddies again; you couldn't grow tired of this view. With Dan and Fiz we ate dinner (some of the best Pho we ate in Vietnam) outside, talking about onward plans, Hue, and passing around Sam's Vietnamese hat for photo opps. The Thai singer, she'd been on the tour with us, played again tonight, though the farmstay was quieter. Looking around, one last time, this place is really quite wonderful.
 
-{% figure phong-nha-455.jpg landscape %}Back at the farmstay{% endfigure %}
+{% figure phong-nha-455.jpg landscape %}
+Back at the farmstay
+{% endfigure %}
 
 ## Sleeper train to Hanoi
 

--- a/source/_posts/prague-and-dresden-20th-may-31st-may.md
+++ b/source/_posts/prague-and-dresden-20th-may-31st-may.md
@@ -19,7 +19,9 @@ I’m currently sitting on a train, travelling from Prague through to Berlin, we
 
 Waking at 3:45am and flying from London Gatwick at 6:45am, we touched down in Prague (after sleeping through the flight), in the sun. Here we were greeted by Rebecca, our host, adorning a single flower for Samantha, she bought us coffee before guiding us through the public transport system; bus, Metro and tram.
 
-{% figure prague-02-wenceslas.JPG landscape %}St Wenceslas square{% endfigure %}
+{% figure prague-02-wenceslas.JPG landscape %}
+St Wenceslas square
+{% endfigure %}
 
 ## Prague first impressions
 
@@ -27,7 +29,9 @@ After a phase of rejuvenation through English Tetley tea and spurious instructio
 
 Rebecca and co. headed home whilst Sam and I explored a little more, walking up the river, into town, stopping at the first island; exhausted we fell asleep on the walls, circled by pedalos and wispy willow tree fluff.
 
-{% figure prague-01-wall-sleep.JPG landscape %}Sam asleep on the wall{% endfigure %}
+{% figure prague-01-wall-sleep.JPG landscape %}
+Sam asleep on the wall
+{% endfigure %}
 
 Not quite reaching the National Theatre, our feet not able to take us much further, we turned back for home - but not before feasting on stone-baked pizza in a hidden student tavern.
 
@@ -45,7 +49,9 @@ On Friday it rained and with rain came indoor events! At the National Museum we 
 
 That night we dressed up for the Prague State Opera’s rendition of Madame Butterfly, it was to be our first opera. Tickets cost 400Kc, for seats near the top, but with a good view of stage and accompanying English subtitles. We drank bubbly and ate salami and cheese 'open' sandwiches on the Opera House’s balcony, looking out at Prague.
 
-{% figure prague-03-opera-house.JPG landscape %}Prague State Opera House{% endfigure %}
+{% figure prague-03-opera-house.JPG landscape %}
+Prague State Opera House
+{% endfigure %}
 
 ## Prague castle and cathedral
 
@@ -53,11 +59,15 @@ We set aside Saturday and Sunday to explore the castle (prazsky hrad) and the ar
 
 The queues to the cathedral, which ran from the entrance right down the side, diverted us to the St. George national gallery. We both fell in love with the tiny postcard sized “A Red Parasol in the Summertime” by Josef Manes (1855). Moving on, the Powder Tower with its three floors of army histories and dressed up mannequins was lacklustre. In the beautiful warm sunshine we sat on a wall (before moving to a hidden courtyard) and ate the pre-prepared potato salad, grapes and scrumptious cherry tomato picnic. (Aside: these were the tastiest cherry tomatoes I’ve ever come across with a fresh and juicy explosion when eaten whole).
 
-{% figure prague-04-painting-parasol-summertime.jpg portrait original %}“A Red Parasol in the Summertime” by Josef Manes (1855){% endfigure %}
+{% figure prague-04-painting-parasol-summertime.jpg portrait original %}
+“A Red Parasol in the Summertime” by Josef Manes (1855)
+{% endfigure %}
 
 Sated, we learned all about the castle’s history--both old and recent, St Vitus, Wenceslas, phases of construction et al, zipping through the end of the exhibition because we were cold. We entered the cathedral itself just as the sunlight poured through the central stained glass windows, colouring the walls pink and purple. The crypt and southern tower were closed, leaving only the circular tour of the ground floor with its various chapels.
 
-{% figure prague-05-stained-glass.JPG portrait %}Stained glass window in Prague Cathedral{% endfigure %}
+{% figure prague-05-stained-glass.JPG portrait %}
+Stained glass window in Prague Cathedral
+{% endfigure %}
 
 We skipped Golden Lane, Kafka’s house and the old palace and had a cursory look at St George’s Basilica; all cultured out we took panoramic photos and stumbled down the steep hill into town, ready for an evening meal, albeit an early one.
 
@@ -65,4 +75,6 @@ We skipped Golden Lane, Kafka’s house and the old palace and had a cursory loo
 
 The Lonely Planet guide pointed us towards, “The Maltese Knights”, not much to look at from above, but downstairs the restaurant came into its own, a converted cavern, candlelit and mysteriously romantic. In shorts, and clearly tourist attire, I ate a delicious wild-boar steak in rose-hips sauce, Sam chose the lamb, sauerkraut and apple. We washed it down with an ’07 Muller-Thurgau white wine.
 
-{% figure prague-06-maltese-knights.JPG landscape %}Maltese Knights restaurant{% endfigure %}
+{% figure prague-06-maltese-knights.JPG landscape %}
+Maltese Knights restaurant
+{% endfigure %}

--- a/source/_posts/prague-and-dresden-20th-may-31st-may/2.md
+++ b/source/_posts/prague-and-dresden-20th-may-31st-may/2.md
@@ -11,14 +11,20 @@ It’s now Friday afternoon, my commentary was cut short because we had to get o
 
 On Sunday, after the Maltese Knights, we took the 11/22 trams to the castle for our second round of sightseeing, though at Malostranska we opted for a walk through the town, trekking up Nerudova and Uvoz for some spectacular panoramics. And despite the heat, we eventually reached Strahovska zahrada at the top.
 
-{% figure prague-07-panoramic.JPG landscape %}Panoramic view of Prague{% endfigure %}
+{% figure prague-07-panoramic.JPG landscape %}
+Panoramic view of Prague
+{% endfigure %}
 
 Starving and exhausted, and after discarding copious tourist eateries, we settled on St Norbert’s brewery, within the grounds of the monastery. The “black beer” was gorgeous, so too was my mustard and honey barbecued pork — Sam wasn’t so keen on her goulash and dumplings. Norbert’s special white beer was also tasty. After purchasing a glass we walked towards the mock Eiffel tower, up more steep hills and through the woods. For 150Kc we climbed to the top, with Sam just about managing her vertigo. Stunning 360 degree views of Prague awaited, including the stadium and castle.
 
-{% figure prague-08-panoramic.JPG landscape %}Prague, river and bridges{% endfigure %}
+{% figure prague-08-panoramic.JPG landscape %}
+Prague, river and bridges
+{% endfigure %}
 
 The climb down wasn’t so quick - the spiral staircase and downward views left Sam’s head spinning. With a thirst quenching coke we perused some enclosed gardens and descended the hill along a different path, around the hillside tram route and past the communist memorial, we crossed the river at Vitezna and passed the Narodni divaldo.
 
 After a small tram mishap we were home, changed for the evening, and back out again, back to Mala Strana. We ate in a superbly decorated tavern, tables were fixed upside down on the ceiling and walls garnished with quirky paintings. Sam adored her roasted lamb parcel, my mixed grill was mediocre, although the opportunity to taste the excellent black ‘Kozel’ beer was a plus. They also charged for tap water and a starter offered as “as present”. C’est la vie.
 
-{% figure prague-09-roof-table.JPG portrait %}Table on the roof{% endfigure %}
+{% figure prague-09-roof-table.JPG portrait %}
+Table on the roof
+{% endfigure %}

--- a/source/_posts/prague-and-dresden-20th-may-31st-may/3.md
+++ b/source/_posts/prague-and-dresden-20th-may-31st-may/3.md
@@ -15,11 +15,15 @@ Dresden, reached via train, on Tuesday was a breath of fresh air. A relatively s
 
 The heat was sweltering, 35C or so, we passed the commercial sector, crossed the tramlines making sure to avoid the yellow beasts, into the old town with views of the ornate Hofkirche and Zwinger palace, before reaching the Elbe riverside and a cafe. Our first opportunity for some German beer, Wernesgruner, although Sam almost ordered bourbon.
 
-{% figure dresden-01-arrival.JPG landscape %}Arrival in Dresden{% endfigure %}
+{% figure dresden-01-arrival.JPG landscape %}
+Arrival in Dresden
+{% endfigure %}
 
 With a whistle-stop tour of the old town we passed the lengthy Furstenzug mural and stopped at restaurant Kleppereck for lunch. In the course of an hour or so the clear blue skies had grown perilous with storms and heavy rain--with my Duckstein beer in one hand and potato soup in the other we nipped indoors for the rest of our meal. Sam enjoyed the pickled herring with fried potatoes and sour cream. I had the Bruckenmeistersteak with smoked bacon, jacket potato and yoghurty cream. We shared a yummy ‘apfel’ strudel for dessert.
 
-{% figure dresden-02-duckstein.JPG portrait %}Duckstein lager{% endfigure %}
+{% figure dresden-02-duckstein.JPG portrait %}
+Duckstein lager
+{% endfigure %}
 
 ## Coselpalais restaurant
 
@@ -27,7 +31,9 @@ At a break in the rain we ran for it, finding the Ibis hotel and booking a night
 
 The food here was divine, the three hours spent here act as testament to this. Asparagus and sesame seed soup opened the proceedings. For mains I ate the succulent roasted musk duck breast with sesame dumplings and gorgeous peaches and leeks. Sam had the roasted saddle of lamb, with ewe’s milk cheese and olive herbal crust and potato torte. WOW! With rain battering down dessert was the only option. Samantha chose a chocolate sponge - milk, white and a thin layer of dark chocolate, layered with fruits of the forrest. I tried the home-made Tiramisu, the best I’ve had yet, it came with wild-berries and pistachios grated over cream - truly scrumptious. Not yet ready to leave, and with theatre-goers coming in drenched, we shared eine Bailey’s coffee and eine coffee with Kahlua, cream and chocolate syrup.
 
-{% figure dresden-03-coselpalais.JPG portrait %}Samantha at Coselpalais restaurant{% endfigure %}
+{% figure dresden-03-coselpalais.JPG portrait %}
+Samantha at Coselpalais restaurant
+{% endfigure %}
 
 When the time came to leave the storm was directly above us. A bolt of lightning shot across the night sky, lighting up the Frauenkirche in a perfect photo opportunity missed as I stood in the doorway amongst sapling waterfalls. In our summer clothes, without our pre-packed warmth back in Prague, what are the chances then that this restaurant sold umbrellas? We bought one and a tin of coffee from their souvenir shop and, in the rain (navigating the streams and lakes of Dresden’s streets), returned to the hotel--thoroughly happy.
 

--- a/source/_posts/prague-and-dresden-20th-may-31st-may/4.md
+++ b/source/_posts/prague-and-dresden-20th-may-31st-may/4.md
@@ -13,7 +13,9 @@ I’m now on the Easyjet flight home, the attendants are selling perfumes and ot
 
 Dresden day two was overcast, and the sun didn’t return for the rest of the holiday. Early in the morning we checked out of the Ibis, grabbed some croissant and raspberry savouries and headed to the river to catch a steam boat. For 30 Euros we travelled upstream to Pillnitz, 90 minutes each way, on a fully functional 100 year old steam boat, complete with cafe. The wind billowed whilst Sam roughly translated the German commentary, passing old castles and stately homes.
 
-{% figure DSC05385.JPG landscape %}Steamboats on the river Elbe{% endfigure %}
+{% figure DSC05385.JPG landscape %}
+Steamboats on the river Elbe
+{% endfigure %}
 
 At Pillnitz we ate large pretzels and more tasty tasty patisserie desserts before exploring the mountain palace, its gardens and orangery. After a brief chat with a lovely German lady, pleased to see foreign tourists in the gardens, we trotted back to the boat, with quiche and ham roll in hand.
 
@@ -21,7 +23,9 @@ At Pillnitz we ate large pretzels and more tasty tasty patisserie desserts befor
 
 Back on land in Dresden, after sleeping the trip back, we crossed the river to explore the new town. The graffiti here, unlike Prague, was smart and interesting, the shops original and the area swimming in student culture and modern art. Our best find was the kunsthofpassage, a small alley of shops selling hand made goods and many weird but cool items. The walls of the buildings were decorated with wondrous designs of drain pipes and wildlife - an amazing commercial community of artists.
 
-{% figure DSC05387.JPG portrait %}Kunsthofpassage{% endfigure %}
+{% figure DSC05387.JPG portrait %}
+Kunsthofpassage
+{% endfigure %}
 
 We ate at Kurfurstenshanke, next to the Coselpalais, in the old town. A place that, in every respect, wanted to be the Coselpalais. I had the flame grilled lamb skewer with zucchini and pepper, whilst Sam had the Ostrich medallions and veg, with not enough sauce. It also came with something delightfully described as “potato squidge”. The Krusovice dark beer was good, Sam’s melon lemonade not so (as I’m typing this, my exotic juice and Sprite concoction was very tasty).
 

--- a/source/_posts/prague-and-dresden-20th-may-31st-may/5.md
+++ b/source/_posts/prague-and-dresden-20th-may-31st-may/5.md
@@ -17,7 +17,9 @@ For 4kc each we reached Melnik in about 45 minutes, and walked the small hill in
 
 With the rain beating down hard, the only food option was the castle’s restaurant. My opportunity to sample the local beef stroganoff and dumplings, although I can’t say I was too impressed. The views from here were spectacular, as we watched the bands of rain pass by, a hill in the distance (Rip, where legend says Cech and Lech stopped before forming the Czech and Pole nations), disappearing and re-appearing periodically. We chattered over dinner about traveling through Eastern Europe, life down under, places to visit, sights to see; Sam scribbled notes frantically--I remember a trip to Vilnius was on the new to do list.
 
-{% figure DSC05417.JPG landscape %}Melnik in the rain{% endfigure %}
+{% figure DSC05417.JPG landscape %}
+Melnik in the rain
+{% endfigure %}
 
 Stopping for some much cheaper Bohemian glass and oddly shaped Melnik wine purchases (we didn’t buy the huge wine glass in the shop window, despite Sam’s pleads), we retraced our steps to the bus shelter. The rain gave us a 10 minute gap to make a dash for it.
 
@@ -33,9 +35,13 @@ Sam’s plan--part 2, saw us head out into the night in search of some jazz. It 
 
 Early meaning we left the flat at 7:15am, getting to old town square by 8am! The streets were empty, and the sights at last a pleasure to witness. No tourists, no tour groups, pick pocketers, artists, moneymakers or taxis. Charles Bridge was the same, clear and enjoyable. Perfect for some photos too (bar the weather maybe). The bride we saw dashing about the place must have thought the same.
 
-{% figure DSC05431.JPG portrait %}[Prague astronomical clock](http://en.wikipedia.org/wiki/Prague_astronomical_clock){% endfigure %}
+{% figure DSC05431.JPG portrait %}
+[Prague astronomical clock](http://en.wikipedia.org/wiki/Prague_astronomical_clock)
+{% endfigure %}
 
-{% figure DSC05436.JPG portrait %}Sam on Charles Bridge{% endfigure %}
+{% figure DSC05436.JPG portrait %}
+Sam on Charles Bridge
+{% endfigure %}
 
 ### Luxury breakfast
 
@@ -45,7 +51,9 @@ For the rest of the morning we explored side streets in Stare Mesto, perusing th
 
 When hours had passed and people had woken from their slumber, we crossed Charles Bridge towards  Mala Strana, up Trziste, through some lanes and out onto Nerudova, stopping at U Zeleneho Yaje for fancy teas. Smoked moldovian tea with milk, sugar and vanilla--very WOW. Sam’s strong Irish tea with cocoa beans, served in a ceramic tea pot was not so interesting, but equally tasty, as was the marble cake! It’d been empty on arrival, but as we left the girl taking orders and making teas was frantically busy serving customers.
 
-{% figure DSC05453.JPG portrait %}Smoked moldovian tea at U Zeleneho Yaje{% endfigure %}
+{% figure DSC05453.JPG portrait %}
+Smoked moldovian tea at U Zeleneho Yaje
+{% endfigure %}
 
 ## Valdstejnska zahrada gardens
 
@@ -53,7 +61,9 @@ Going back down the hill, we stumbled into the Valdstejnska zahrada gardens, wit
 
 Heading under Charles Bridge, along Na Kampe, we found some charming pottery places, where we dreamt of a house to put things in. Coming back up via St Nicholas’s church, we paid a visit to the recommended St Nicholas’s cafe for the next course. Supposedly an original underground dwelling, it was more of a smoky pizzeria that couldn’t do Coke and garlic bread properly.
 
-{% figure DSC05470.JPG portrait %}Uhhm…{% endfigure %}
+{% figure DSC05470.JPG portrait %}
+Uhhm…
+{% endfigure %}
 
 ## An evening of live Jazz and Blues
 
@@ -68,9 +78,13 @@ After thanking them and moving on, it was time (10pm) for some serious Jazz at U
 We were served by a chirpy and kind waitress that met our every need, the drinks kept coming. Bailey’s coffee, Mexican coffee (rum, kahlua, coffee and cream), white russians, margheritas and even Bailey’s cheesecake. We spent a fortune and loved every second.
 Even for the USP, this act was something special. We didn’t hesitate in buying the CD. Nothing short of awesome.
 
-{% figure DSC05483.JPG landscape %}Inside U stare pani{% endfigure %}
+{% figure DSC05483.JPG landscape %}
+Inside U stare pani
+{% endfigure %}
 
-{% figure DSC05485.JPG landscape %}Jazz Club U stare pani{% endfigure %}
+{% figure DSC05485.JPG landscape %}
+Jazz Club U stare pani
+{% endfigure %}
 
 Catching the penultimate trams home, our mammoth 18 hour day in Prague drew to a close--a magical day wherein we found the hidden joys of the Czech capital; embracing the culture, seeing the sights and jamming to the music, a perfect ending.
 

--- a/source/_posts/rio-de-janeiro-brazil.md
+++ b/source/_posts/rio-de-janeiro-brazil.md
@@ -13,7 +13,9 @@ pages: 4
 page: 1
 ---
 
-{% figure brazil-070.jpg landscape %}Samantha with a Caipirinha on Sugarloaf mountain{% endfigure %}
+{% figure brazil-070.jpg landscape %}
+Samantha with a Caipirinha on Sugarloaf mountain
+{% endfigure %}
 
 We felt unprepared for Brazil, we booked the flights and the first week of hotels but left the second week open for whatever we pleased. The holiday sneaked up on us whilst we were busy working, and suddenly we were on the plane from Heathrow, stopping at Paris for some Camembert and an excellent nighttime view of the Eiffel tower, then onwards, to Rio, via an 11 hour Air France flight with complimentary champagne.
 
@@ -25,9 +27,13 @@ It took an hour or so to make it to Botafogo and our hotel, O Veleiro B&B, atop 
 
 Inside a dark wooden staircase takes you up to the living room and communal dining area where we checked in. Our room was simple with wooden shutter doors, a double bed, sink, some mosquito spray and an outdoor shared toilet and shower next to some hammocks.
 
-{% figure IMG_3603.JPG landscape %}O Veleiro B&B{% endfigure %}
+{% figure IMG_3603.JPG landscape %}
+O Veleiro B&B
+{% endfigure %}
 
-{% figure IMG_3602.JPG landscape %}Gardens at O Veleiro B&B{% endfigure %}
+{% figure IMG_3602.JPG landscape %}
+Gardens at O Veleiro B&B
+{% endfigure %}
 
 Hoteliers Rob and Rich showed us around and pointed out the sights, Botafogo below us, the head of Christ the Redeemer to the right, and sugarloaf hiding behind the trees. All checked-in and ready to go, we set off to explore Rio for the first time, very aware of our belongings and security.
 
@@ -39,17 +45,23 @@ Tourists are advised to use taxis but the metro is very safe, and simple too. R$
 
 There was a sunny haze about the beach. Huge waves crashed against the shore amongst perfect bodied volleyballers, skaters, swimmers and sunbathers. Military personnel stood around in shorts and t-shirt, their guns holstered but hanging out for all to see. The sand was fine and warm between our toes.
 
-{% figure brazil-003.jpg landscape %}Ipanema beach{% endfigure %}
+{% figure brazil-003.jpg landscape %}
+Ipanema beach
+{% endfigure %}
 
 Every 200m or so you can find a corn on the cob stand, which we had to try. We nipped into town looking for food. At Polis Sucos we ordered freshly made juice, but guessed from the foreign menu, I remembered maracuja was passion fruit, the other juice was pink, and probably raspberry and something, but I can’t be sure.
 
-{% figure brazil-004.jpg landscape %}Sam with her corn on the cob{% endfigure %}
+{% figure brazil-004.jpg landscape %}
+Sam with her corn on the cob
+{% endfigure %}
 
 ### Brazilian-japanese sushi fusion
 
 We came out next to Ipanema lagoon. Across the water was Christ the Redeemer. Joggers and cyclists ran by, many on Rio’s orange Boris bikes. Desperate for some food, we sat down at the fluorescent orange Koni, a trendy new restaurant chain, for some brazilian-japanese sushi fusion.
 
-{% figure brazil-005.jpg landscape %}Ipanema lagoon{% endfigure %}
+{% figure brazil-005.jpg landscape %}
+Ipanema lagoon
+{% endfigure %}
 
 Koni’s specialty is based on a ‘cone’ of rice wrapped in seaweed. You choose your filling, which is usually tempura. The honey roast tuna, shimeji tempura and salmon tempura were all yummy. We washed it all down with some iced tea.
 

--- a/source/_posts/rio-de-janeiro-brazil/2.md
+++ b/source/_posts/rio-de-janeiro-brazil/2.md
@@ -17,7 +17,9 @@ The next train was two hours away! Ah well, we bought our tickets and avoided th
 
 Further up the hill was Largo do Boticario, a colourful but dilapidated 19th century mansion. Moss grew thick on sky blue walls, window shutters were broken, and the grand wooden doors had seen better days.
 
-{% figure brazil-006.jpg landscape %}Largo do Boticario{% endfigure %}
+{% figure brazil-006.jpg landscape %}
+Largo do Boticario
+{% endfigure %}
 
 ### Safety in Rio
 
@@ -31,37 +33,55 @@ With still an hour to go we explored the nearby church, a grand circular buildin
 
 Beneath rows of flags, in the station, we boarded the two carriage cog train. Sitting on the right, facing down the hill gives the best views. The train set-off, chugging up the hill, gradually climbing to the summit. It took about half an hour, the trees occasionally subsiding to reveal views of Rio and its beaches below.
 
-{% figure brazil-027.jpg portrait %}Cog trains up to Christ the Redeemer{% endfigure %}
+{% figure brazil-027.jpg portrait %}
+Cog trains up to Christ the Redeemer
+{% endfigure %}
 
 ### Viewing platform
 
 At the top, up some steps and there he is, Christ the Redeemer, arms outstretched in all his glory. The viewing platform is rammed with people, many crouching to the floor to get the tight angled photo of the statue, others spreading their arms out wide in the familiar pose. Around the edges people jostled for the best views.
 
-{% figure brasil-006.jpg portrait %}Christ the Redeemer{% endfigure %}
+{% figure brasil-006.jpg portrait %}
+Christ the Redeemer
+{% endfigure %}
 
 Below us Rio looked magnificent. We took all the photos we could imagine, and then some more. Down over Ipanema, and views of the lagoon, where a helicopter landed on the large yellow H. Then out towards Botafogo and the sugarloaf, cable cars going up and down, with Niteroi just visible out across the sea. Favelas everywhere, towers of rickety shacks popping up on the hills and between tower blocks. Rain lashed down and we wiped the lens clean.
 
-{% figure brasil-003.jpg landscape %}View of Rio de Janeiro{% endfigure %}
+{% figure brasil-003.jpg landscape %}
+View of Rio de Janeiro
+{% endfigure %}
 
-{% figure brazil-018.jpg portrait %}Sam high above Rio{% endfigure %}
+{% figure brazil-018.jpg portrait %}
+Sam high above Rio
+{% endfigure %}
 
-{% figure brazil-019.jpg landscape %}Paul looking out at the city{% endfigure %}
+{% figure brazil-019.jpg landscape %}
+Paul looking out at the city
+{% endfigure %}
 
-{% figure brazil-023.jpg landscape %}Rio{% endfigure %}
+{% figure brazil-023.jpg landscape %}
+Rio
+{% endfigure %}
 
 Of course the pictures rarely give the view justice. You can’t capture the dizzying wind, the sounds of birds in the forest, or that vertiginous feeling of looking over the edge.
 
 Then for 30 minutes in the entire day the sun returned, the views cleared and on a quiet bench behind the redeemer we shared our picnic lunch before heading back down.
 
-{% figure brazil-026.jpg portrait %}Grumpy Paul with the cog train tickets{% endfigure %}
+{% figure brazil-026.jpg portrait %}
+Grumpy Paul with the cog train tickets
+{% endfigure %}
 
 Sam had the camera on the route down, and she probably snapped a few hundred images of blurry trees. And then we walked home again, back through Laranjeiras, stopping once for a delicious cinnamon cappuccino amongst the half decorated Christmas trees.
 
-{% figure brazil-030.jpg portrait original %}Less grumpy Paul with a cinnamon cappuccino{% endfigure %}
+{% figure brazil-030.jpg portrait original %}
+Less grumpy Paul with a cinnamon cappuccino
+{% endfigure %}
 
 Back at the hotel we relaxed on the hammocks, read our guide and played with the tortoise, unwilling to test whether he really did eat toes. Four new guys arrived, also from London, and we shared our stories so far. They’d just flown in from Sao Paulo. They weren’t sure whether to stay, the place seemed too far ‘away from the action’, but we sung its praises and they warmed to it.
 
-{% figure brazil-031.jpg landscape %}Hungry tortoise wants your toes{% endfigure %}
+{% figure brazil-031.jpg landscape %}
+Hungry tortoise wants your toes
+{% endfigure %}
 
 ## The awful Siri Mole & Cia restaurant
 

--- a/source/_posts/rio-de-janeiro-brazil/3.md
+++ b/source/_posts/rio-de-janeiro-brazil/3.md
@@ -15,9 +15,13 @@ We walked down through Botafogo, along the white stony paths, past the guards an
 
 Urca is a small village-like retreat within Rio. Sitting tightly beneath the sugarloaf, it juts out into the sea, and there are just a few rows of houses. But the signs of Rio are gone, no taxis, no security or graffiti, just Christ the Redeemer standing tall in the distance, amidst a beautiful view of the city and well tended gardens.
 
-{% figure brasil-014.jpg portrait %}View of Christ the Redeemer from Urca{% endfigure %}
+{% figure brasil-014.jpg portrait %}
+View of Christ the Redeemer from Urca
+{% endfigure %}
 
-{% figure brasil-016.jpg landscape %}Wavy pavements and Converses{% endfigure %}
+{% figure brasil-016.jpg landscape %}
+Wavy pavements and Converses
+{% endfigure %}
 
 A sea wall and promenade surrounds Urca, and we followed it round. Joggers and their dogs ran by, fishermen sat with their lines cast into the sea, a cheeky heron hanging around nearby waiting to grab their catch. Kids played on the beach and the area had a lovely small-community feel to it.
 
@@ -27,63 +31,93 @@ At the end of the promenade, where we could walk no further, there is a busy bar
 
 We were casually looking for a restaurant, and found it by accident after eating our snacks. Garota da Urca was hugely popular with the locals, and on this national holiday it was heaving with families, all having the same thing: thin steak cooked on a hot plate, served with farofa, chips, salad and rice. We pointed, “we’ll have one of those”, and still hungry we gorged ourselves on tasty steak and carbs. Delicious, even if it did induce a food coma.
 
-{% figure brazil-036.jpg landscape original %}Beef on the grill{% endfigure %}
+{% figure brazil-036.jpg landscape original %}
+Beef on the grill
+{% endfigure %}
 
-{% figure brazil-035.jpg portrait original %}Paul enjoying steak and chips at Garota da Urca{% endfigure %}
+{% figure brazil-035.jpg portrait original %}
+Paul enjoying steak and chips at Garota da Urca
+{% endfigure %}
 
 ### Pista Claudio Coutinho trail
 
 Sated, rested and ready for the rest of the day we headed out of Urca, round past the cable car entrances, along the small Praia Vermelha, past a performing amateur drama group, and onto a 2km walking nature trail, Pista Claudio Coutinho.
 
-{% figure brazil-038.jpg landscape %}Praia Vermelha{% endfigure %}
+{% figure brazil-038.jpg landscape %}
+Praia Vermelha
+{% endfigure %}
 
 The trail arches around the southern side of Päo de Açúar (suagarloaf). In wooded surroundings, the great rock towered to our left while waves crashed against it’s foot to the right. The quiet route had the occasional jogger, family or climber. On large wooden boards the types of wildlife were listed, but only in Portuguese. Bright red birds flitted between the leaves and tame marmosets climbed down to say hello, clearly expecting to be fed something. Large black vultures sat in the trees above us, and a father was teaching his son to boulder.
 
-{% figure brazil-044.jpg portrait %}Inquisitive marmoset{% endfigure %}
+{% figure brazil-044.jpg portrait %}
+Inquisitive marmoset
+{% endfigure %}
 
-{% figure brazil-046.jpg landscape %}Marmoset poses for us on the Pista Claudio Coutinho trail{% endfigure %}
+{% figure brazil-046.jpg landscape %}
+Marmoset poses for us on the Pista Claudio Coutinho trail
+{% endfigure %}
 
 ### Cable cars to the summit
 
 We walked out, to the large pillar and the end of the trail, then back again, and to the cable cars. Sam swallowed her fear of rooms that dangle in mid-air, and we climbed aboard. The large modern car took us up 220m to Morro da Urca.
 
-{% figure brazil-049.jpg portrait %}Looking down from the cable cars{% endfigure %}
+{% figure brazil-049.jpg portrait %}
+Looking down from the cable cars
+{% endfigure %}
 
 Atop we passed the helipad and restaurant, and started snapping photos of the incredible Rio views. Tower blocks rise from greenery, and nestle into every possible corner, gradually rising up the mountainside. The clouds fly beneath Christo Redentor, through the valleys, and misty hilltops poke out above them. We are already high above Botafogo and Urca. This ‘level’ also has a museum, showing how the cable cars were built, and with a scary example of the first one.
 
-{% figure brazil-051.jpg portrait %}Cable car museum{% endfigure %}
+{% figure brazil-051.jpg portrait %}
+Cable car museum
+{% endfigure %}
 
 Then upwards again, onto the second cable car to take us to Päo de Açúar, 396m above Rio. Wow, the views are incredible. From here you can see Botafogo, Centro, Copacabana, Ipanema poking from behind a rock, Flamengo and beyond to Sao Cristovao and out across the sea to Niteroi.
 
 We took photos at every angle, explored the shops and walkways, and watched other tourists pose for their own shots. It was quiet and lovely.
 
-{% figure brazil-063.jpg landscape %}Paul looking out at Rio from Sugarloaf mountain{% endfigure %}
+{% figure brazil-063.jpg landscape %}
+Paul looking out at Rio from Sugarloaf mountain
+{% endfigure %}
 
-{% figure brazil-061.jpg landscape %}Sam taking photos for other tourists{% endfigure %}
+{% figure brazil-061.jpg landscape %}
+Sam taking photos for other tourists
+{% endfigure %}
 
 ### Caipirinhas and sunset
 
 Sam bought us Caipirinhas and we sat to take in the scenery, waiting for the sun to set. Rays of sunlight peaked through the clouds, occasionally dazzling us in sunshine. A light breeze kept us cool. Black herons swarmed high above us and marmosets hopped around the white railings, scavenging for food. Our Brazil Lonely Planet book sat rested on the table, well thumbed and scribbled on. Rio life continuing beneath us.
 
-{% figure brazil-066.jpg landscape %}Christ the Redeemer silhouette{% endfigure %}
+{% figure brazil-066.jpg landscape %}
+Christ the Redeemer silhouette
+{% endfigure %}
 
 We watched as aeroplanes lifted from their runway, climbing and circling above the water, where ships were heading to the docks. The quiet whirring sounds of cable cars going up and down were met with idle Brazilian chit-chat. It was peaceful, tranquil and beautiful. We could see everything. There was no rush to do anything, nothing to worry about, only the city, the hills, the sea and the wildlife.
 
-{% figure brazil-070.jpg landscape %}Samantha with a Caipirinha on Sugarloaf mountain{% endfigure %}
+{% figure brazil-070.jpg landscape %}
+Samantha with a Caipirinha on Sugarloaf mountain
+{% endfigure %}
 
-{% figure brazil-071.jpg landscape %}Paul, also with Caipirinha cocktail{% endfigure %}
+{% figure brazil-071.jpg landscape %}
+Paul, also with Caipirinha cocktail
+{% endfigure %}
 
 The sky began to darken, and the city lights turned on, one by one, through twilight into night. We positioned our tripod and took sweeping photos of the cityscape, Christ the Redeemer now basking in white light. After a couple of shots we noticed him disappear behind a thick cloud.
 
-{% figure brazil-074.jpg landscape %}Sam as sun sets over Rio{% endfigure %}
+{% figure brazil-074.jpg landscape %}
+Sam as sun sets over Rio
+{% endfigure %}
 
-{% figure brazil-075.jpg landscape %}Rio at night{% endfigure %}
+{% figure brazil-075.jpg landscape %}
+Rio at night
+{% endfigure %}
 
 ### Sudden storm
 
 Then the cloud moved closer, covering Rio beneath us, lit up from below. The winds picked up and then it was too late to go anywhere; swirling winds and lashing rain hit the sugarloaf, we were inside the storm cloud and dashed for cover.
 
-{% figure brazil-078.jpg landscape %}Storm over Rio{% endfigure %}
+{% figure brazil-078.jpg landscape %}
+Storm over Rio
+{% endfigure %}
 
 At the cable car station we all sheltered from the 100kmph winds. The cable car closed and we were stranded until it passed, if it passed. In our wet weather gear we befriended the other tourists, and I ventured outside a couple of times. The wind pushed me down and rain soaked my face, as I clambered high above the city lights.
 

--- a/source/_posts/rio-de-janeiro-brazil/4.md
+++ b/source/_posts/rio-de-janeiro-brazil/4.md
@@ -13,7 +13,9 @@ Eating home made cake, spreading butter on toast and trying the latest fruit jui
 
 From the dining room in O Veleiro’s bed and breakfast we looked out across Botafogo, today you couldn’t even see Christ the Redeemer, he was quite literally up in the clouds. We hung around on the hammocks by our room, reading the Lonely Planet and planning the next stage of our journey, keeping an eye out for hummingbirds that occasionally fly down and hover around the flowers.
 
-{% figure brazil-079.jpg landscape %}Sam relaxing in a hammock{% endfigure %}
+{% figure brazil-079.jpg landscape %}
+Sam relaxing in a hammock
+{% endfigure %}
 
 ## Zuka restaurant
 
@@ -36,7 +38,9 @@ The food was incredible and, at last, good value. Served on oblong stone plates,
 
 A taxi home at Rio rush hour, back to the B&B where everyone was still lounging around, reading their books, browsing the internet or using their phones. It was very much a day of doing nothing. In light of this the guys decided we should all go out to a live samba night in Lapa, at the centre of Rio’s bohemian scene amongst all the dilapidated old mansions and the tram line that no longer runs.
 
-{% figure IMG_3600.JPG landscape %}A quiet day at the B&B{% endfigure %}
+{% figure IMG_3600.JPG landscape %}
+A quiet day at the B&B
+{% endfigure %}
 
 At 7ish Richard made us all Caipirinhas and the eight of us went by two taxis to Carioca da Gema. R$ 20 for the music, and the place was packed. We found a table upstairs overlooking the stage where we ordered beer and shared nibbles, I can’t remember any of the portuguese names of things, just that the little bean samosas were lovely.
 
@@ -56,6 +60,8 @@ O Veleiro really felt like a home in Rio, and it helped us make the best of the 
 
 Packed and ready to go, we said our goodbyes the next morning and taxi’d (because you go everywhere in Rio by taxi) to the international airport. We’d booked our flight and Igaucu hotel beforehand, but we hadn’t planned the return leg at all. So after check-in we frantically ran around the Gol, TAM and Webjet desks to get flight quotes from anyone that spoke a little bit of English.
 
-{% figure brazil-082b.jpg landscape %}Rio from the sky{% endfigure %}
+{% figure brazil-082b.jpg landscape %}
+Rio from the sky
+{% endfigure %}
 
 [To Iguaçu Falls &rarr;](/2011/12/iguacu-falls-brazil/)

--- a/source/_posts/rounding-out-2010.md
+++ b/source/_posts/rounding-out-2010.md
@@ -31,7 +31,9 @@ In between these screenings, our small screen viewings also stood out. “An Edu
 
 As a birthday treat I took Sam to the luxurious Wolseley in London where we enjoyed the finest Champagne tea, our own small slice of decadence. Champagne tea? Crustless and exquisite finger sandwiches, perfect pastries, homemade scones and jam (specially made without fruit by request - there’s nothing Sam likes less than raisins in her scones!), two pots of tea (the Wolesely afternoon blend and Sam’s favourite, Assam), and a glass of Pommery Brut Royal NV each. That’s one of Timeout’s 1000 things to do in London crossed out.
 
-{% figure IMG_2736.JPG square original %}[The Wolseley goodie bag](http://instagram.com/p/eGD5/){% endfigure %}
+{% figure IMG_2736.JPG square original %}
+[The Wolseley goodie bag](http://instagram.com/p/eGD5/)
+{% endfigure %}
 
 Beforehand we paid a visit to the Natural History Museum to see this years Wildlife Photographer of the year exhibit. After a short queue we entered a dark room where 3ft by 2ft photos were mounted perfectly along the walls. Back-lit, the sharpness and delicate detail of the photos and nature itself shone through. Our world felt fleeting, fragile and perfect.
 
@@ -39,21 +41,31 @@ A downward shot of a seabird diving from a cliff gave us vertigo and a majestic 
 
 As an aspiring photographer, I left wanting to travel, to build my own hide and to sit with patience, ready to capture that all too rare wildlife moment.
 
-{% figure wildlife-of-the-year-2010-drop.jpg landscape original %}[The drop](http://www.nhm.ac.uk/visit-us/wpy/gallery/2010/images/animals-in-their-environment/4319/the-drop.html) by Andrew Parkinson{% endfigure %}
+{% figure wildlife-of-the-year-2010-drop.jpg landscape original %}
+[The drop](http://www.nhm.ac.uk/visit-us/wpy/gallery/2010/images/animals-in-their-environment/4319/the-drop.html) by Andrew Parkinson
+{% endfigure %}
 
-{% figure wildlife-of-the-year-2010-cheetahs.jpg landscape original %}[The moment](http://www.nhm.ac.uk/visit-us/wpy/gallery/2010/images/behaviour-mammals/4337/the-moment.html) by Bridgena Barnard{% endfigure %}
+{% figure wildlife-of-the-year-2010-cheetahs.jpg landscape original %}
+[The moment](http://www.nhm.ac.uk/visit-us/wpy/gallery/2010/images/behaviour-mammals/4337/the-moment.html) by Bridgena Barnard
+{% endfigure %}
 
-{% figure wildlife-of-the-year-2010-langurs.jpeg landscape original %}[Sunset moment](http://www.nhm.ac.uk/visit-us/wpy/gallery/2010/images/urban-wildlife/4410/sunset-moment.html) by Olivier Puccia{% endfigure %}
+{% figure wildlife-of-the-year-2010-langurs.jpeg landscape original %}
+[Sunset moment](http://www.nhm.ac.uk/visit-us/wpy/gallery/2010/images/urban-wildlife/4410/sunset-moment.html) by Olivier Puccia
+{% endfigure %}
 
 ## Christmas
 
-{% figure xmas-2010-biscotti-tree.jpg portrait %}Homemade Christmas biscotti{% endfigure %}
+{% figure xmas-2010-biscotti-tree.jpg portrait %}
+Homemade Christmas biscotti
+{% endfigure %}
 
 This Christmas we were in Banstead where Sam’s mum made us a delicious traditional turkey roast with all the trimmings. Petra, the dog, ran around with her new squeaky toy, (thankfully she’s now grown out of all the toe nipping and lace tugging) and ate up a couple of flying cracker toys.
 
 After dinner we sat in front of the roaring wood fire and shamelessly sat back to endure a little Poirot, amongst the ad breaks and the cheese and crackers (all too full to really embrace the fine cheese). Amanda’s indoor helicopter toy was carefully manoeuvred from the table to the ceiling, making sure Petra was out of sight.
 
-{% figure 2010-12-25-IMG_7525.jpg portrait %}Petra, the dog{% endfigure %}
+{% figure 2010-12-25-IMG_7525.jpg portrait %}
+Petra, the dog
+{% endfigure %}
 
 The recent snow hadn’t melted and it was the perfect white Christmas - crisp, white and snowy, but without the immediate travel chaos. With some Christmas cake wrapped in foil, and packed into an old Quality Streets tin, we drove to Bristol on boxing day, with some delicious smoked salmon and scrambled egg on toast to keep us going.
 
@@ -61,7 +73,9 @@ In Yate, after enduring the obvious M25 traffic jam, my mum and sister treated u
 
 We rushed about Bristol seeing friends and family while we could, stopping at my aunts in Yatton for a bite to eat and a talk about the horses and cats, with ET on in the background, muted. At my Grandparents my Grandpa knocked up a delicious quick bubble n squeak from Xmas day leftovers, complete with the much needed pickled onions and homemade quiche, and trifle for dessert. And we went to my old friend Gary’s for an evening, to see how he’s settling into his new house with fiancee Rachel; Sam’s Xbox skills were pushed to her limit as she played a run, jump and explode teamwork game. Each day, and with each stop, we dropped off a box of our homemade truffles and Christmas biscotti, and sometimes a plant or a bottle of mulling syrup (the good stuff from Selsley) too.
 
-{% figure 2010-12-28-IMG_7695.jpg landscape %}My aunt’s cat{% endfigure %}
+{% figure 2010-12-28-IMG_7695.jpg landscape %}
+My aunt’s cat
+{% endfigure %}
 
 Back in Brighton, in the downtime before New Year’s, we found the perfect oak bed from Warren Ellis, complete with 55% + 10% off. It’s gorgeous, and the smell of new wood continues to permeate the flat. And that’s not the best part, the bed is high enough for us to see out the window from our pillows, I can see the sea from my pillow. My bed is my new favourite place.
 

--- a/source/_posts/shanghai-china.md
+++ b/source/_posts/shanghai-china.md
@@ -17,9 +17,13 @@ Our hectic China itinerary, booked through [Rickshaw travel](http://www.chinatra
 
 The Astor House hotel serves a delicious breakfast spread from the decadent and historic Peacock ballroom, once a famed and landmark place. The hotel itself is over 100 years old, it was the first western style hotel in the city and comes with an enormous amount of dark wood panelling. Our sixth floor room had a kingsize bed, a couple of sofas and two small windows which looked out over The Bund. A perfect location for a spot of night time photography.
 
-{% figure china-shanghai-007.jpg landscape %}Our room at Astor House hotel{% endfigure %}
+{% figure china-shanghai-007.jpg landscape %}
+Our room at Astor House hotel
+{% endfigure %}
 
-{% figure china-shanghai-009.jpg square %}Breakfast in the Peacock ballroom{% endfigure %}
+{% figure china-shanghai-009.jpg square %}
+Breakfast in the Peacock ballroom
+{% endfigure %}
 
 ## The Bund
 
@@ -29,7 +33,9 @@ The waterfront, lined with mid 19th century architecture, looks out across the H
 
 On our side of the river were the arguably more elegant HSBC building, Custom house with its Big Ben clock tower and the Fairmont Peace hotel.
 
-{% figure china-shanghai-006.jpg landscape %}Paul and Shanghai’s famous view from The Bund{% endfigure %}
+{% figure china-shanghai-006.jpg landscape %}
+Paul and Shanghai’s famous view from The Bund
+{% endfigure %}
 
 ## Shanghai museum and People’s square
 
@@ -39,11 +45,17 @@ We weren't in the mood for looking around a museum, but as we were here we shoul
 
 Given our mood and tiredness, it's testament to the quality and interestingness of the museum that we explored all of it. From 18th century BC bronze-wear, to Genghis Khan coins, a history of calligraphy, classic porcelain china, Qin dynasty furniture and exquisite Chinese paintings of mystical mountains and pagodas, this museum was spectacular.
 
-{% figure china-shanghai-005.jpg landscape %}A Buddha statue in the Shanghai museum{% endfigure %}
+{% figure china-shanghai-005.jpg landscape %}
+A Buddha statue in the Shanghai museum
+{% endfigure %}
 
-{% figure china-shanghai-004.jpg landscape %}Samantha examining some of the bronzeware exhibits{% endfigure %}
+{% figure china-shanghai-004.jpg landscape %}
+Samantha examining some of the bronzeware exhibits
+{% endfigure %}
 
-{% figure china-shanghai-003.jpg landscape %}Classic Chinese artwork on show in the Shanghai museum{% endfigure %}
+{% figure china-shanghai-003.jpg landscape %}
+Classic Chinese artwork on show in the Shanghai museum
+{% endfigure %}
 
 ## Pudong cityscape
 
@@ -55,9 +67,13 @@ Sadly the sky and clouds were unremarkable, a thick hazy mist blocked out whatev
 
 After dinner we walked back to our hotel along the promenade. By now, 10pm, the mists had cleared and tufty grey clouds gave the sky some substance whilst the full moon shone through. At last! With tripod setup again, we hung around for another half an hour taking more photos.
 
-{% figure china-shanghai-002.jpg landscape %}[Panoramic of Shanghai](https://500px.com/photo/87436849/shanghai-light-beams-by-paul-hayes) from The Bund as a boat passes by{% endfigure %}
+{% figure china-shanghai-002.jpg landscape %}
+[Panoramic of Shanghai](https://500px.com/photo/87436849/shanghai-light-beams-by-paul-hayes) from The Bund as a boat passes by
+{% endfigure %}
 
-{% figure china-shanghai-001.jpg landscape %}A full moon over Shanghai’s financial center{% endfigure %}
+{% figure china-shanghai-001.jpg landscape %}
+A full moon over Shanghai’s financial center
+{% endfigure %}
 
 ## Lost Heaven
 
@@ -67,7 +83,9 @@ The decor was dark panelled and luscious red, and inside it was dimly lit but aw
 
 For dinner we shared a Burmese beef curry, like a spicy stew; a plate of snow peas and stir fried lily bulbs — onion like in texture but sweeter and more watery; Dai spiced pork served in banana leaf; and crispy crab cakes with a mango sauce. All washed down with a pot of Pu-erh Yunnan tea. All dishes were scrumptious.
 
-{% figure china-shanghai-008.jpg portrait %}Samantha at Lost Heaven{% endfigure %}
+{% figure china-shanghai-008.jpg portrait %}
+Samantha at Lost Heaven
+{% endfigure %}
 
 ## A blight on our perfect day
 

--- a/source/_posts/shangri-la-rasa-ria-borneo.md
+++ b/source/_posts/shangri-la-rasa-ria-borneo.md
@@ -20,9 +20,13 @@ From the [LimeTree hotel in Kuching](/2014/05/kuching-borneo/) we took a leisure
 
 The reception is enormous, and filled with lounging guests in flip-flops. It looks out past the pool at the pristine beach and exudes a sense of calm. Our room was on the fourth floor and had a “rainforest view”, which suited us just fine. I don’t think we’ve ever seen a bed so big. The beach faces west for a perfect beachside sunset. As the sun went down and the sky turned red, guests flocked to the sea with their expensive cameras and tripods (or iPads) to try and capture it.
 
-{% figure kota-kinabalu-098.jpg landscape %}Shangri-la Rasa Ria, a beachside paradise{% endfigure %}
+{% figure kota-kinabalu-098.jpg landscape %}
+Shangri-la Rasa Ria, a beachside paradise
+{% endfigure %}
 
-{% figure kota-kinabalu-003.jpg landscape %}Sunset in paradise{% endfigure %}
+{% figure kota-kinabalu-003.jpg landscape %}
+Sunset in paradise
+{% endfigure %}
 
 ## Coast restaurant
 
@@ -34,4 +38,6 @@ At Coast, one of the many restaurants on site, it was Lobster night and that won
 * seared duck breast (jerusalem artichoke puree . pineapple chutney . pickled onion . crispy potato . orange jus)
 {% endmenu %}
 
-{% figure kota-kinabalu-005.jpg portrait %}Jellyfish lights at Coast{% endfigure %}
+{% figure kota-kinabalu-005.jpg portrait %}
+Jellyfish lights at Coast
+{% endfigure %}

--- a/source/_posts/shangri-la-rasa-ria-borneo/2.md
+++ b/source/_posts/shangri-la-rasa-ria-borneo/2.md
@@ -15,17 +15,25 @@ After breakfast we wandered across the resort to the nature reserve, passing ben
 
 A large group of us, perhaps 30, watched a video that demonstrated the work done here, before filing into the reserve and up the dirt path towards the viewing platforms. In the daylight a tame mouse deer watched us, and a pen housed Sambar deer. At the wooden platforms we chose our spot; a good view, a bit of shade, and once again, like in Semenggoh we waited for orangutans.
 
-{% figure kota-kinabalu-006.jpg landscape %}Mouse deer in the hotel nature reserve{% endfigure %}
+{% figure kota-kinabalu-006.jpg landscape %}
+Mouse deer in the hotel nature reserve
+{% endfigure %}
 
 ### Two young male orangutan
 
 After 10 minutes there was a rustling in the trees, you could see the treetops swaying left and right. Two young males swung from the branches, one, then another, from the trees to the ropes and on to the feeding platform, to gather their breakfast. They scoffed their faces with bananas and fruit and dopily climbed to the tree tops. We watched them for half an hour, mesmerised by their lanky arms, grabbing feet and dark piercing eyes. Samantha and I swapped between zoom lens and binocs, alternating between photos and a better view. Eventually they nestled down in the branches high above us, in their newly made nest of leaves, settled down and out of sight.
 
-{% figure kota-kinabalu-011.jpg landscape %}Young orang-utans feeding at the hotel nature reserve{% endfigure %}
+{% figure kota-kinabalu-011.jpg landscape %}
+Young orang-utans feeding at the hotel nature reserve
+{% endfigure %}
 
-{% figure kota-kinabalu-023.jpg portrait %}Young male orang-utan swinging in a tree{% endfigure %}
+{% figure kota-kinabalu-023.jpg portrait %}
+Young male orang-utan swinging in a tree
+{% endfigure %}
 
-{% figure kota-kinabalu-018.jpg landscape %}Furry orange silhouette of an orang-utan{% endfigure %}
+{% figure kota-kinabalu-018.jpg landscape %}
+Furry orange silhouette of an orang-utan
+{% endfigure %}
 
 ### Timid canopy walk
 
@@ -33,11 +41,17 @@ There are three orangutans here, the third is female, she is new and still very 
 
 The people we met at Shangri-la were much older than us, mostly in their late forties or fifties. A couple from the UK, they'd been here for two weeks told us about a snake they'd spotted at the park entrance. Sure enough, on a branch, perfectly camouflaged (you'd walk right past it unless you knew to look), a Bornean keeled pit viper. Light green on top, pale underneath, it sat perfectly still and was unfazed by the family of long-tailed macaques that began playing nearby. “Is it poisonous?”, “Yes, very”. Some snakes of this species are even nicknamed the “100 pace snake”, if bitten you can walk 100 paces before dropping dead. Lovely, let's not get too close.
 
-{% figure kota-kinabalu-025.jpg landscape %}[Bornean keeled green pit viper](http://www.projectnoah.org/spottings/220636130 "Project Noah"){% endfigure %}
+{% figure kota-kinabalu-025.jpg landscape %}
+[Bornean keeled green pit viper](http://www.projectnoah.org/spottings/220636130 "Project Noah")
+{% endfigure %}
 
-{% figure kota-kinabalu-029.jpg landscape %}Stunned long-tailed macaques{% endfigure %}
+{% figure kota-kinabalu-029.jpg landscape %}
+Stunned long-tailed macaques
+{% endfigure %}
 
-{% figure kota-kinabalu-030.jpg landscape %}Contemplating a manicure{% endfigure %}
+{% figure kota-kinabalu-030.jpg landscape %}
+Contemplating a manicure
+{% endfigure %}
 
 As everyone else was leaving, we stuck around to watch the playful macaques, about 7 of them. They hung from their tales and squabbled over fruit, wrestled in the leaves, and groomed each other.
 
@@ -45,7 +59,9 @@ As everyone else was leaving, we stuck around to watch the playful macaques, abo
 
 For the rest of the day we relaxed by the (warm) pool, drinking ice cold lime soda. The poolside food was tasty too, just a pizza and burger for us, nothing too fancy. And the sunset was again spectacular, the sky turned orange and the sun melted into the ocean.
 
-{% figure kota-kinabalu-038.jpg landscape %}The sun before it melted into the ocean{% endfigure %}
+{% figure kota-kinabalu-038.jpg landscape %}
+The sun before it melted into the ocean
+{% endfigure %}
 
 ## Teppan-yaki Kozan restaurant
 
@@ -68,4 +84,6 @@ But it was the chef that stole the show. He used cooking utensils with the skill
 
 <figure class="generated-figure generated-figure--retina generated-figure--620 generated-figure--video"><div class="video-wrapper"><iframe class="vimeo" src="http://player.vimeo.com/video/95799132" width="620" height="413" frameborder="0"></iframe></div><figcaption class="generated-figure-caption">Video of our chef flame cooking steak</figcaption></figure>
 
-{% figure borneo-iphone-020.jpg landscape %}Our teppan-yaki chef{% endfigure %}
+{% figure borneo-iphone-020.jpg landscape %}
+Our teppan-yaki chef
+{% endfigure %}

--- a/source/_posts/shangri-la-rasa-ria-borneo/3.md
+++ b/source/_posts/shangri-la-rasa-ria-borneo/3.md
@@ -11,9 +11,13 @@ By 9am it's already too hot to wander along the beach without burning your feet 
 
 After a buffet breakfast feast we lounged in the early morning sun near. On a whim we paid to ride Segways around a dirt track circuit. Neither of us had been on one before. You lean forward to go forward, and lean back to stop, turning is as simple as leaning left or right. It's all about centre of gravity, and once you've got it it comes naturally. But until then it's a little jerky, and Sam's hilarious and calamitous forward-backwards-somersault off the front is testament to that. But we were soon zipping around the circuit, taking corners at speed and splashing through the track's water hole.
 
-{% figure borneo-iphone-001.jpg landscape %}Paul on a segway{% endfigure %}
+{% figure borneo-iphone-001.jpg landscape %}
+Paul on a segway
+{% endfigure %}
 
-{% figure borneo-iphone-021.jpg portrait %}Samantha on a segway{% endfigure %}
+{% figure borneo-iphone-021.jpg portrait %}
+Samantha on a segway
+{% endfigure %}
 
 ## Parasailing
 
@@ -21,7 +25,9 @@ It gave Sam an adrenaline rush, and on the back of that she rushed over to the w
 
 10 minutes later we'd scrambled onto a boat, been strapped into a harness and were flying in the air beneath the rainbow colours of a parachute. Tied to the boat by a metal cable, it unwound, sending us higher and higher. We could see for miles, the expansive sea opened out in front of us, and behind us the peak of Mount Kinabalu poked out from above the clouds, detached from anything else, like a floating fortress.
 
-{% figure borneo-iphone-022.jpg landscape %}Paul and Samantha beginning their parasail{% endfigure %}
+{% figure borneo-iphone-022.jpg landscape %}
+Paul and Samantha beginning their parasail
+{% endfigure %}
 
 ## Spa day and spider hunt
 
@@ -29,13 +35,21 @@ This is all perfect preparation for a spa day. From the boat, pumped full of adr
 
 Meanwhile I embarked on a fully personalised nature tour; I walked where I wanted to looking for animals. By the golf course the lotus flowers looked spectacular, and at the Ocean wing sunbirds danced about the pink flowers (they're almost as tiny and as nimble as hummingbirds), by Coast I found a frightened baby scops owl that had fledged its nest too soon (it was soon in the care of the park ranger), and out the back of the hotel, with our friends from the Orangutan sanctuary, I found a giant golden orb-weaver spider. The more you look, the more you see, and for a quick midday wander I found a lot to talk about and photograph.
 
-{% figure kota-kinabalu-045.jpg landscape %}Monitor lizard{% endfigure %}
+{% figure kota-kinabalu-045.jpg landscape %}
+Monitor lizard
+{% endfigure %}
 
-{% figure kota-kinabalu-047.jpg landscape %}Tiny sunbird{% endfigure %}
+{% figure kota-kinabalu-047.jpg landscape %}
+Tiny sunbird
+{% endfigure %}
 
-{% figure kota-kinabalu-052.jpg landscape %}Terrified [baby scops owl](http://www.projectnoah.org/spottings/240186040 "Project Noah"){% endfigure %}
+{% figure kota-kinabalu-052.jpg landscape %}
+Terrified [baby scops owl](http://www.projectnoah.org/spottings/240186040 "Project Noah")
+{% endfigure %}
 
-{% figure kota-kinabalu-058.jpg landscape %}[Giant golden orb weaver](http://www.projectnoah.org/spottings/239436047 "Project Noah"){% endfigure %}
+{% figure kota-kinabalu-058.jpg landscape %}
+[Giant golden orb weaver](http://www.projectnoah.org/spottings/239436047 "Project Noah")
+{% endfigure %}
 
 Rejuvenated, and somewhat calmer, Sam returned from her spa and we shared a greek wrap by the pool. Waiting for sunset and our pre-booked firefly tour, we played boules.
 

--- a/source/_posts/shangri-la-rasa-ria-borneo/4.md
+++ b/source/_posts/shangri-la-rasa-ria-borneo/4.md
@@ -9,7 +9,9 @@ page: 4
 
 For our third morning at Shangri-la Rasa Ria we booked a 6am summit trail and breakfast. We hoped for a gorgeous sunrise and romantic brekkie, with views of Mount Kinabalu. At the entrance to the Nature Reserve we joined two British couples and met our guide (and carrier of food). The climb to the top took about half an hour, and although it was all straight up it wasn’t too strenuous. Our guide was ready and willing to point out wildlife; on the rope bridge he showed us a stick insect, on the way down a giant golden orb-weaver, and in between a couple of squirrels and cicadas. At the peak sits a small wooden viewing platform. As we’d hoped for, there were spectacular morning views across Sabah, and the silhouette of Mount Kinabalu rose out of the mist in the distance (we were too late for sunrise, the sun was already high in the sky).
 
-{% figure kota-kinabalu-064.jpg landscape %}Paul at the summit, with a view across Sabah{% endfigure %}
+{% figure kota-kinabalu-064.jpg landscape %}
+Paul at the summit, with a view across Sabah
+{% endfigure %}
 
 The breakfast table was set back from the view in a forest clearing. Packed breakfast was fresh fruit, pastries and yoghurt. Before coming away we’d had a frantic week of looking at a flat, making an offer and preparing for purchase. On Tuesday morning we got an email, our offer had been accepted. We celebrated with our new friends at the top of the summit trail, toasting with orange juice. Breakfast attracted a large shield bug, which flew towards us and around us looking for somewhere to perch. Unfortunately for Samantha it decided to suddenly land its big beetle body on her lips; with her lips pursed shut, Sam winced and flustered until it flew away. “I could feel it in my mouth”, she said. These are the romantic moments you don’t consider when booking such idyllic things.
 
@@ -17,24 +19,38 @@ The breakfast table was set back from the view in a forest clearing. Packed brea
 
 Down at the hotel, breakfast walked off, sweat evaporated, still hungry, we headed to air-conditioned Coast for breakfast number two. That meant a couple of glasses of prosecco, some Nasi Lemak and a noodle soup, amongst all the other buffet breakfast treats we still craved. And no bugs in sight. The rest of the day was spent lounging in the sun, relaxing by the beach, drinking cocktails, swimming in the pool, swinging in a hammock, forgetting to re-apply sun lotion. All that sort of taxing stuff.
 
-{% figure kota-kinabalu-066.jpg landscape %}Nasi lemak as a top-up breakfast{% endfigure %}
+{% figure kota-kinabalu-066.jpg landscape %}
+Nasi lemak as a top-up breakfast
+{% endfigure %}
 
-{% figure kota-kinabalu-068.jpg landscape %}Samantha relaxing in a beachside chalet{% endfigure %}
+{% figure kota-kinabalu-068.jpg landscape %}
+Samantha relaxing in a beachside chalet
+{% endfigure %}
 
 ## The lizard and the toad
 
 Monitor lizards are not an uncommon sight around the hotel grounds, they’re about two feet long and plod by without you noticing. From my hammock I watched one approach a rock, not more than a metre away, and start digging. I suspected it was making itself somewhere to rest in the shade. Its dig was slow, stopping every few seconds to look around and check for danger. Finally it climbed all the way in, and that was that I thought. But then it wriggled out backwards as fast as it could, and in its jaws it held a bloated toad. Like a dog with a toy it shook its head voraciously, and viciously smacked the toad to the floor until it was dead. Then up, jaws open, blink and you’ll miss it, the lizard swallowed the toad whole. The lizard resumed its innocent plod, nothing to see here, and it skulked away into the bushes.
 
-{% figure kota-kinabalu-074.jpg landscape %}Monitor lizard devouring a toad{% endfigure %}
+{% figure kota-kinabalu-074.jpg landscape %}
+Monitor lizard devouring a toad
+{% endfigure %}
 
 ## Tepi Laut Makan
 
 After a dazzling sunset (and the inevitable photo taking of orange and purple skies), and happy hour orangutan themed cocktails, we found a table at Tepi Laut Makan for a sumptuous buffet of asian street food. Its design simulates a night market, and with your plate you can visit each open-fronted store for something different; stir fries, curries, stews. We took great delight in trying all the Malaysian desserts put out for us, even those that sounded or looked like something we’d dislike.
 
-{% figure kota-kinabalu-079.jpg landscape %}Samantha's sunset selfie{% endfigure %}
+{% figure kota-kinabalu-079.jpg landscape %}
+Samantha's sunset selfie
+{% endfigure %}
 
-{% figure kota-kinabalu-088.jpg landscape %}A fake hawker stall at Tepi Laut Makan{% endfigure %}
+{% figure kota-kinabalu-088.jpg landscape %}
+A fake hawker stall at Tepi Laut Makan
+{% endfigure %}
 
-{% figure kota-kinabalu-089.jpg landscape %}Pandan desserts{% endfigure %}
+{% figure kota-kinabalu-089.jpg landscape %}
+Pandan desserts
+{% endfigure %}
 
-{% figure kota-kinabalu-004.jpg landscape %}Another gorgeous sunset{% endfigure %}
+{% figure kota-kinabalu-004.jpg landscape %}
+Another gorgeous sunset
+{% endfigure %}

--- a/source/_posts/shangri-la-rasa-ria-borneo/5.md
+++ b/source/_posts/shangri-la-rasa-ria-borneo/5.md
@@ -9,7 +9,9 @@ Our last day at the Shangri-la. Although we weren’t flying to Borneo Rainfores
 
 For our last breakfast we returned to Coast, for the free prosecco and bucks fizz. The eggs benedict came with two perfectly poached eggs that seemed to not stop oozing yolk. Despite Sam’s pancake, Nasi Lemak and buffet choices, she was so impressed she immediately ordered one too. Four breakfasts, why not?
 
-{% figure kota-kinabalu-091.jpg landscape %}Perfect eggs benedict{% endfigure %}
+{% figure kota-kinabalu-091.jpg landscape %}
+Perfect eggs benedict
+{% endfigure %}
 
 The rest of the day was much the same as before, hammock swinging, poolside sunbathing, happy hour cocktails, fresh lime sodas, a very tight competitive game of boules, bird watching and sunset photography. Only this time we checked out at midday and paid for all amenities with cash. The Shangri la was an oasis of calm, a place to relax, eat fantastic food and worry only about the size of the hotel tab. A delightful slice of luxury and decadence.
 
@@ -17,4 +19,6 @@ The rest of the day was much the same as before, hammock swinging, poolside sunb
 
 We watched the sun set over the pristine sandy beach one last time, cocktails in hand, a band playing, the sky turning dark. And we looked forward to the final part of our Malaysia and Borneo holiday, when we’d travel into the depths of the jungle, come face to face with leeches and hopefully see some wild orangutans. Tomorrow we travel to the [Borneo Rainforest Lodge](/2014/05/borneo-rainforest-lodge/ "Borneo Rainforest Lodge").
 
-{% figure kota-kinabalu-082.jpg portrait %}Goodbye Kota Kinabalu{% endfigure %}
+{% figure kota-kinabalu-082.jpg portrait %}
+Goodbye Kota Kinabalu
+{% endfigure %}

--- a/source/_posts/songpan-china.md
+++ b/source/_posts/songpan-china.md
@@ -17,9 +17,13 @@ Songpan is a small historic town with rebuilt city walls, ancient city gates and
 
 On our first venture out, the town felt like China's equivalent of the Wild West. The sun bore down on a barren mountainous landscape, at an altitude of over 3000m. Shops sold furry dog and yak skins and were drying meat and mushrooms by the dusty roadside. And with this remote and quaint atmosphere came a lot of character; a mixture of Tibetan and Qiang lifestyles.
 
-{% figure china-songpan-002.jpg landscape %}Songpan, China’s wild west{% endfigure %}
+{% figure china-songpan-002.jpg landscape %}
+Songpan, China’s wild west
+{% endfigure %}
 
-{% figure china-songpan-015.jpg landscape %}Meat drying by the dusty roadside{% endfigure %}
+{% figure china-songpan-015.jpg landscape %}
+Meat drying by the dusty roadside
+{% endfigure %}
 
 ## Old house hotel
 
@@ -29,17 +33,25 @@ Just down the road is [Emma's kitchen](http://www.tripadvisor.co.uk/Restaurant_R
 
 With the sun out the temperatures quickly rose to about 20C. Down the main road, and through the city gates, the shops are more contemporary. In old style but recently built shops you can find mobile phones, shoes, clothes etc. A middle of nowhere town centre seemingly essential for the nearby mountain villages.
 
-{% figure china-songpan-001.jpg landscape %}Songpan’s old (but new) town, inside the city gates{% endfigure %}
+{% figure china-songpan-001.jpg landscape %}
+Songpan’s old (but new) town, inside the city gates
+{% endfigure %}
 
-{% figure china-songpan-008.jpg landscape %}Songpan’s south city gate{% endfigure %}
+{% figure china-songpan-008.jpg landscape %}
+Songpan’s south city gate
+{% endfigure %}
 
 ## Afternoon hike
 
 At the end of town we found a little path that headed into the hills via Guanyin Ge temple. The path to the peak has been recently built, and if it wasn't so steep it would be a pleasant stroll. We begun to climb and noticed that we grew short of breath quickly, and that our pulse was racing. It wasn't until we were near the top that we realised it was an effect of the altitude. The new path is also considerate of this, every few twists and turns there's a resting point.
 
-{% figure china-songpan-006.jpg landscape %}Heading up, above Songpan{% endfigure %}
+{% figure china-songpan-006.jpg landscape %}
+Heading up, above Songpan
+{% endfigure %}
 
-{% figure china-songpan-003.jpg landscape %}Stopping for a trendy fashion shoot midway up. (Turned up jeans are _in_){% endfigure %}
+{% figure china-songpan-003.jpg landscape %}
+Stopping for a trendy fashion shoot midway up. (Turned up jeans are _in_)
+{% endfigure %}
 
 We were advised it might take an hour, we took it very slowly, it was hot and we were carrying and wearing cold weather clothes. Half way up we stopped to sleep on the wooden benches, a calm break with spectacular views. Then we slugged on, going up and up and up, almost giving up on a couple of occasions. We had another welcome break when we stopped to speak to two travellers on their way down, an Austrian couple, they'd taken a year off to travel around Asia. Resting on a gravel path, we sat and chatted for almost an hour.
 
@@ -47,15 +59,21 @@ Eventually, and finally, we made it to the peak. We celebrated with victory phot
 
 When we began to head down we had what can only be described as a magical moment. Two enormous birds of prey, birds bigger than we've ever seen, flew up from the valley and using the wind currents hovered above our heads. They were two wild golden eagles, a pair, hunting for their evening meal. After a minute or so they swept down towards Songpan and then they'd crossed the valley and were out of sight. We didn't have the zoom lens with us, all we could do was watch in wonder.
 
-{% figure china-songpan-005.jpg landscape %}Victory photos at the top{% endfigure %}
+{% figure china-songpan-005.jpg landscape %}
+Victory photos at the top
+{% endfigure %}
 
-{% figure china-songpan-014.jpg landscape %}View from the top, looking down at Songpan{% endfigure %}
+{% figure china-songpan-014.jpg landscape %}
+View from the top, looking down at Songpan
+{% endfigure %}
 
 ## Dinner in Songpan
 
 The hike down was easy, and soon we were back at the hotel, freshening up for dinner. Sam had spotted an outdoor Tibetan place at the end of town. When we got there it was closed, and too cold and windy to eat outside. Strolling back through town we saw people setting up an outdoor cinema in the town square, there were little street food stalls, and the towns electric red lanterns were all glowing.
 
-{% figure china-songpan-009.jpg portrait %}Street food vendors in Songpan{% endfigure %}
+{% figure china-songpan-009.jpg portrait %}
+Street food vendors in Songpan
+{% endfigure %}
 
 ### Hotpot
 
@@ -63,8 +81,12 @@ For dinner we chose a hotpot place because of its comfy looking grey sofas. Hotp
 
 We ordered too much food, so easily done in China, where they seem to eat gargantuan portions of fatty food yet stay so very slim. With a lot of food left uneaten we left, but we needed some dessert. [Amdo coffee house inn](https://foursquare.com/v/amdo-coffee-house-inn/54183010498e962a4c8542d6) is, as the name suggests, a cafe-cum-hotel — it's chintzy and a perfect place to eat chocolate cake and milkshake.
 
-{% figure china-songpan-012.jpg landscape %}Our hotpot restaurant{% endfigure %}
+{% figure china-songpan-012.jpg landscape %}
+Our hotpot restaurant
+{% endfigure %}
 
-{% figure china-songpan-010.jpg landscape %}Songpan at night{% endfigure %}
+{% figure china-songpan-010.jpg landscape %}
+Songpan at night
+{% endfigure %}
 
 Our day in Songpan was over, and it felt like we'd been here much longer. It's all quite quaint and lovely, especially the Tibetan folk, who always seem to greet you with a smile.

--- a/source/_posts/spending-time-in-the-west-end.md
+++ b/source/_posts/spending-time-in-the-west-end.md
@@ -17,7 +17,9 @@ date: 2008-11-09 19:04:14
 
 Living in St Albans I've recently taken the opportunity to see as much theatre as possible, and now I have a couple of spare minutes between all the shows, holiday and traveling, I'll write a bit about them all.
 
-{% figure mrfofr-20081109-les-mis.jpg landscape original %}Les Miserables poster{% endfigure %}
+{% figure mrfofr-20081109-les-mis.jpg landscape original %}
+Les Miserables poster
+{% endfigure %}
 
 ## Les Miserables
 
@@ -29,7 +31,9 @@ I left wanting more.
 
 ## Marguerite
 
-{% figure mrfofr-20081109-marguerite.jpg square original %}Marguerite poster{% endfigure %}
+{% figure mrfofr-20081109-marguerite.jpg square original %}
+Marguerite poster
+{% endfigure %}
 
 I had already seen Miss Saigon, although I do believe it wasn't one of the best performances, I didn't overly enjoy it. It probably deserves a second chance with my now renewed interest. Marguerite was a new musical with songs by Michel Legrand (see Umbrellas of Cherbourg!) and the hook, lyrics by Alain Boublil and Claude-Michel Schonberg.
 
@@ -37,7 +41,9 @@ The show, music and performances were all bitterly disappointing; the leading si
 
 ## Fat Pig
 
-{% figure mrfofr-20081109-fat-pig.jpg portrait original %}Fat Pig poster{% endfigure %}
+{% figure mrfofr-20081109-fat-pig.jpg portrait original %}
+Fat Pig poster
+{% endfigure %}
 
 Jo, Sam and I saw Fat Pig in its first English incarnation at the Trafalgar studios with Kris Marshall and Robert Webb. The comedy has a simple premise; some guy begins dating a fat girl and must face his work colleagues and their taunts - the 'obsessed with looks' ex-date and the crude and womanizing buddy.
 
@@ -47,13 +53,17 @@ I heartily recommend this, though cannot vouch for the new lineup or venue.
 
 ## 39 Steps
 
-{% figure mrfofr-20080911-39steps-1.jpg square original %}39 Steps{% endfigure %}
+{% figure mrfofr-20080911-39steps-1.jpg square original %}
+39 Steps
+{% endfigure %}
 
 Another comedy, we got tickets cheap for this one in the stalls, and thought why not. None of us had actually seen the movie, so we didn't know quite what to expect, especially with only four cast members playing the role of many. It turned out to be a slapstick affair with very clever prop jokes, costume changes and role switching; a good laugh and another recommended night out.
 
 ## Avenue Q
 
-{% figure mrfofr-20080911-avenue-q-london.jpg landscape original %}Avenue Q{% endfigure %}
+{% figure mrfofr-20080911-avenue-q-london.jpg landscape original %}
+Avenue Q
+{% endfigure %}
 
 Sam and I saw this one on our weekend to the [Hoxton Hotel](http://www.mrfofr.com/2008/10/hoxton-hotel-london/),
 
@@ -63,7 +73,9 @@ This adult puppet comedy, although making us laugh, really didn't grab us as we 
 
 ## Rain Man
 
-{% figure mrfofr-20080911-rainman.jpg portrait original %}Rain Man poster{% endfigure %}
+{% figure mrfofr-20080911-rainman.jpg portrait original %}
+Rain Man poster
+{% endfigure %}
 
 Another performance caught on the Hoxton weekend, lucky enough to get tickets on the day,
 
@@ -73,7 +85,9 @@ It is very much a love story, a comedy and a drama. I must remember to now watch
 
 ## Zorro
 
-{% figure mrfofr-20080911-zorro.jpg landscape original %}Zorro{% endfigure %}
+{% figure mrfofr-20080911-zorro.jpg landscape original %}
+Zorro
+{% endfigure %}
 
 Zorro is the most recent of musicals I have seen after Sam grabbed four tickets for £40; this opened earlier in the year and Matt Rawle plays the lead and once again I had no expectations or even a clue as to the story. The show is none too serious (despite the brilliant 'Man behind the Mask' number) and comes accompanied with flamenco gypsy dancing, heel stomping, sword fights, fire and The Gypsy Kings (see Bamboleo); 'a fun filled romp' some tabloid review might say and it certainly was. With a dance and clap encore I left with dancing feet completely satisfied with my night out, bar the Gypsy King tracks that looped around my cranium for the remainder of the night.
 

--- a/source/_posts/sushi-sunday.md
+++ b/source/_posts/sushi-sunday.md
@@ -14,7 +14,9 @@ Sam and I have been meaning to make our own sushi since my birthday, but what wi
 
 We had all the ingredients ready; sushi rice, sushi vinegar, the bamboo rolling mat, a ten pack of nori and something tasty for the middle.
 
-{% figure sushi-1.jpg landscape %}Homemade sushi{% endfigure %}
+{% figure sushi-1.jpg landscape %}
+Homemade sushi
+{% endfigure %}
 
 Not really sure what we were doing, beyond what a guy had told Sam over the shop counter, we consulted recipe books and YouTube’s “How to make Sushi” videos. joschez’s 4 min short was the most helpful:
 
@@ -26,16 +28,26 @@ We cleaned the rice, and let it soak for 30 mins. With the correctly measured am
 
 Now the fun bit; with the nori laid out on the rolling mat, we took turns making rolls. With wet hands (otherwise rice will stick to everything!), we spread the rice across the seaweed to create an even layer, leaving space at the back as the envelope edge.
 
-{% figure sushi-3.jpg landscape %}Laying out the rice and nori{% endfigure %}
+{% figure sushi-3.jpg landscape %}
+Laying out the rice and nori
+{% endfigure %}
 
-{% figure sushi-7.jpg landscape %}Sam checking the roll before slicing{% endfigure %}
+{% figure sushi-7.jpg landscape %}
+Sam checking the roll before slicing
+{% endfigure %}
 
 For the tasty middles we used whatever we could find; cucumber, pepper, wasabi, egg, tuna, crab sticks, onion, smoked salmon and haddock (we completely forgot about our umeboshi puree). Choosing some of these ingredients, we lay them out in the middle of the rice, before wetting the nori edge and rolling using the bamboo, slowly and forcefully, just like the video told us to. Using Sam’s expensive kitchen knife, dipped in water to stop it sticking, we sliced the rolls.
 
-{% figure sushi-4.jpg landscape %}A sushi roll ready to slice{% endfigure %}
+{% figure sushi-4.jpg landscape %}
+A sushi roll ready to slice
+{% endfigure %}
 
-{% figure sushi-6.jpg landscape %}Slicing the sushi{% endfigure %}
+{% figure sushi-6.jpg landscape %}
+Slicing the sushi
+{% endfigure %}
 
 All told, we made 6 different rolls and about 56 pieces of sushi. And we'll be eating them all week.
 
-{% figure sushi-2.jpg landscape %}Ready to eat sushi{% endfigure %}
+{% figure sushi-2.jpg landscape %}
+Ready to eat sushi
+{% endfigure %}

--- a/source/_posts/the-great-escape-2011.md
+++ b/source/_posts/the-great-escape-2011.md
@@ -14,7 +14,9 @@ We were joined by Sarah and Mark, travelling down from Bristol they arrived earl
 
 At Jubilee square we picked up our shiny red weekend wristbands and searched for the Queen’s Hotel on the seafront. Luluc, Rhob Cunningham, Moddi and 22 were playing what we called the “morning session”, which ran from 12 ‘til 4pm. On a carpeted hotel room we caught the end of Luluc’s set; guitar and deep beautiful vocals, their track made famous by Grey’s Anatomy. Rhob Cunningham was up next, an irishman, his songs were stories with guitar and they were lovely. And between tracks he had stories too, seems he was attacked by a falling starfish when he arrived in Brighton. Moddi followed, a beautiful serene norwegian folk act with cello and accordion, this set turned out to be a festival highlight. The music so incredibly powerful and different from everything else on offer. With Becks and Corona in plastic beer cups, 22 took the stage, norwegian again but very very different - compared to Muse and The Mars Volta, they were an extremely energetic young band that liked to jump around and punch their fists through the ceiling, I can’t say we were overly impressed. The weird half-backwards-mohican the lead singer sported was entertaining however.
 
-{% figure great-escape-moddi.jpg landscape original %}Moddi by [Rob Orchard](http://www.flickr.com/photos/rob_orchard/){% endfigure %}
+{% figure great-escape-moddi.jpg landscape original %}
+Moddi by [Rob Orchard](http://www.flickr.com/photos/rob_orchard/)
+{% endfigure %}
 
 Ready for more music, we nipped into an alternative escape venue, the appropriately named “Live music bar”, to see Brother and Bones and Model Society perform. On the way back we were lucky enough to catch Cloud Control perform three songs, including my favourite, “There’s nothing in the water we can’t fight”, at Jubilee square.
 
@@ -22,10 +24,14 @@ Ready for more music, we nipped into an alternative escape venue, the appropriat
 
 Home for pizzas and back out again with Sam, we headed to St Mary’s church for the fat cat records event. Sat in the pews at the front, sipping wine (beer in a church feels awfully wrong), a stage with grand piano and projector was setup beneath the dim light of a chandelier and the dying stained glass sunlight. Dustin O’Halloran opened the show, with a gorgeous, deceptively simple piano composition, accompanied by a string quartet. It was  reminiscent of Ludovico Einaudi. Sitting a little awkwardly in the wooden seats, we watched Hauschka perform his peculiar strain of piano music, heavy on the obscure percussion and ending with ping pong balls being thrown into the grand, it was delightfully different. We spent most of the act trying to work out how he was making such incredible noises. In the dark now, all sunlight vanished, Max Richter culminated the show with a perfect rendition of his Infra album, complete with strings, he also played my favourite, “On the nature of daylight”. All in all an excellent post-classical event, and now onto something very different.
 
-{% figure great-escape-dustin-halloran.jpeg landscape original %}Dustin O’Halloran by [Andy Sturmey](http://iskrastringquartet.blogspot.com/2011/06/dustin-ohalloran-great-escape-festival.html){% endfigure %}
+{% figure great-escape-dustin-halloran.jpeg landscape original %}
+Dustin O’Halloran by [Andy Sturmey](http://iskrastringquartet.blogspot.com/2011/06/dustin-ohalloran-great-escape-festival.html)
+{% endfigure %}
 
 ## Gang Gang Dance
 
 At 10:30 we arrived at the Pavilion Theatre (the Uncut stage) to catch the end of Babe,Terror’s (not “Baby torture”, I might add), improvised and very clever drone set, but consisting of a single man surrounded by fairy lights and humming into a mic occasionally, it wasn’t the most riveting viewing. I love this sort of music, but with the room filling up for Gang Gang Dance, the vibe wasn’t there. And then the main set, the reason we were here, the very loud and awesome Gang Gang Dance, playing their new album “Eye Contact”. With tribal drums, Kate Bush-esque vocals, and a flag waver, the gang dance kicked into full swing. It was phenomenal and I’ve had their albums on repeat ever since. In their vietcong hats they danced with us, and we went home, ears ringing, ready for two more days of awesome music.
 
-{% figure great-escape-gang-gang-dance.jpg portrait original %}Gang Gang Dance by [Ricardo Vamp](http://www.datatransmission.co.uk/Features/852){% endfigure %}
+{% figure great-escape-gang-gang-dance.jpg portrait original %}
+Gang Gang Dance by [Ricardo Vamp](http://www.datatransmission.co.uk/Features/852)
+{% endfigure %}

--- a/source/_posts/the-great-escape-2011/2.md
+++ b/source/_posts/the-great-escape-2011/2.md
@@ -8,9 +8,13 @@ page: 2
 
 Friday started with all four of us downstairs at Komedia, its dark wooden floor and low ceilings a stark contrast to the carpeted Queens Hotel. Oh So Quiet opened our proceedings, and we were dutifully impressed. The General played next, but they were trying too hard, and we left for “The Hope” venue to see a hung over Marina Gasolina play her entertaining female punk act, with its so very punk “I’m so hungover I’ve forgotten the words” moments. Great fun mind. We weren’t sure where to go next, but our well thumbed band guide told us about REBEKA, “polish electro acoustic lo-fi disco with Chinese techno and dirty synths”. Sold! Out to Horatio’s on the peer we headed, via the free chocolate stick stands. Out over the sea, REBEKA performed their phenomenal mix of beats and vocals, they were loving it, we were loving it, it was fabulous. Shame they didn’t have an album out, I’d have bought it instantly.
 
-{% figure great-escape-marina-gasolina.jpg portrait original %}Marina Gasolina by [Rob Orchard](http://www.flickr.com/photos/rob_orchard/){% endfigure %}
+{% figure great-escape-marina-gasolina.jpg portrait original %}
+Marina Gasolina by [Rob Orchard](http://www.flickr.com/photos/rob_orchard/)
+{% endfigure %}
 
-{% figure great-escape-rebeka.jpeg landscape original %}Rebeka by [Just Music I like](http://www.justmusicthatilike.com/2011/05/great-escape-2011-friday-review.html){% endfigure %}
+{% figure great-escape-rebeka.jpeg landscape original %}
+Rebeka by [Just Music I like](http://www.justmusicthatilike.com/2011/05/great-escape-2011-friday-review.html)
+{% endfigure %}
 
 ## Dan Parsons
 
@@ -20,6 +24,10 @@ At the vietnamese place, Pho, for lunch, where we didn’t try the weasel shit c
 
 Onwards to the Uncut venue. Dean McPhee took the stage first, I already own his fabulous Brown Bear 12”, I bought it instantly after hearing the phenomenal Sky Burial track. A one man act, he showed us how astounding his guitar skills were, it gave me shivers, and I am eagerly anticipating his first album. Incredible haunting and complex sounds produced from a single guitar. We all sat to watch Trevor Moss and Hanna Lou, a quaint country act that grew on us as the set continued, really very pleasant. The guy we’d come to see though was Josh T. Pearson, a bearded giant, his soft grasping folk and guitar work stole the show, as did his between track jokes and wry humour, “what’s the difference between a musician and a large pizza? A large pizza can feed a family,” he joked, wearily. Despite being full, the venue was hushed and in awe, his presence all encompassing. “How good was that!?”, Mark exclaimed. The headliners were Villagers with their Frodo like lead singer. We all knew “Becoming a Jackal”, and soon day two of the festival was over. With some 1am chips we stumbled home.
 
-{% figure great-escape-josh-pearson.jpeg portrait original %}Josh T. Pearson by [Just Music I like](http://www.justmusicthatilike.com/2011/05/great-escape-2011-friday-review.html){% endfigure %}
+{% figure great-escape-josh-pearson.jpeg portrait original %}
+Josh T. Pearson by [Just Music I like](http://www.justmusicthatilike.com/2011/05/great-escape-2011-friday-review.html)
+{% endfigure %}
 
-{% figure great-escape-villagers.jpeg portrait original %}The Villagers{% endfigure %}
+{% figure great-escape-villagers.jpeg portrait original %}
+The Villagers
+{% endfigure %}

--- a/source/_posts/the-great-escape-2011/3.md
+++ b/source/_posts/the-great-escape-2011/3.md
@@ -8,13 +8,17 @@ page: 3
 
 Sam cooked up some brie and mango quesadillas for Saturday breakfast and sooner than we knew it bands were playing again! Down the hill again, past the station, to Komedia, upstairs this time for the canadian acts. Hey Rosetta! started our last day with jumping indie rock complete with cello and violin. They played tracks from their Seeds album and we all loved these guys. Young Empires came next, an energetic threesome with electronic beats, slightly camp but extremely danceable. On Kitsune they’re an act to keep an eye on though we missed their free CDs. Finally (and I mean finally, they took forever setting up), Braids performed their experimental dreamy electronic pop-rock fusion. With the venue brimming, it wasn’t to everyone’s taste, but I loved it and I’ve had the album, “Native Speaker,” on all week. Of course, they were the reason we were there.
 
-{% figure great-escape-braids.jpeg landscape original %}Braids by [Mary Ann](http://www.flickr.com/photos/26266850@N07/){% endfigure %}
+{% figure great-escape-braids.jpeg landscape original %}
+Braids by [Mary Ann](http://www.flickr.com/photos/26266850@N07/)
+{% endfigure %}
 
 ## Dry the River, The Antlers, Okkervil River
 
 We stopped at The House for dinner/lunch; yummy burgers, steak and fish pie refuelled us for our final evening of loud music and awesomeness. Down to the sea front and to Concorde 2. Guitars, violins and synths in the form of Malpas began the night, but the bass was turned up too high, it was loud enough to shake your bones and restart your heart and it completely drowned out the music. Dry the River’s americana rock didn’t take my fancy, but it filled the floors and rocked the house. The Antlers came next, playing incredible haunting rock from their new album “Burst Apart”, so good we bought it straight away. The act that brought us in were Okkervil River, playing a full set, indie folk-rock tracks were hammered out back-to-back. The ripping harmonies of “Lost Coastlines” and “Our life is not a movie or maybe” had everyone in ecstasy, singing out loud, smiling and jumping. It was glorious.
 
-{% figure great-escape-dry-the-river.jpeg landscape original %}Dry the River by [Jade Hopcroft](http://jadeemmahopcroft.blogspot.com/2011/05/great-escape-2011.html){% endfigure %}
+{% figure great-escape-dry-the-river.jpeg landscape original %}
+Dry the River by [Jade Hopcroft](http://jadeemmahopcroft.blogspot.com/2011/05/great-escape-2011.html)
+{% endfigure %}
 
 ## The Secret Sisters, Alela Diane
 

--- a/source/_posts/the-great-escape-2012.md
+++ b/source/_posts/the-great-escape-2012.md
@@ -14,7 +14,9 @@ One year on and it's another Great Escape Festival in Brighton. Over 300 bands a
 
 As [like last year](/2011/06/the-great-escape-2011/), Sarah and Mark joined us from Bristol for the three days. And at midday on Thursday we set into town to grab our wrist bands and programmes, via co-op for some tasty fresh croissants. At Jubilee Square the TGE staff struggle to snap on each of our cotton itchy-feeling wrist bands.
 
-{% figure tge-2012-poster.jpeg portrait original %}The Great Escape 2012 lineup poster{% endfigure %}
+{% figure tge-2012-poster.jpeg portrait original %}
+The Great Escape 2012 lineup poster
+{% endfigure %}
 
 ## François and the Atlas Mountains, Porcelain Raft
 
@@ -24,11 +26,15 @@ The first set we wanted to see was at The Prince Albert, back up towards the sta
 
 **François and the Atlas Mountains** filled the stage next, on the small stage they were really very cramped. Sam and I had been playing their album beforehand, "E Volo Love", dancing around the living room to "Les Plus Beaux", as if we were on top of the pops. French lyrics meld with a joyous african rhythm, to create something lovely. But the performance wasn't without hindrance, a mic broke, and many songs were interrupted with white noise or feedback. The band shone through these technical problems, "these things happen", François said.
 
-{% figure tge-2012-francois-atlas-mountains.jpeg landscape %}[François and the Atlas Mountains](http://owlbynight.blogspot.co.uk/2012/05/great-escape-festival-2012-thursday_17.html){% endfigure %}
+{% figure tge-2012-francois-atlas-mountains.jpeg landscape %}
+[François and the Atlas Mountains](http://owlbynight.blogspot.co.uk/2012/05/great-escape-festival-2012-thursday_17.html)
+{% endfigure %}
 
 **Porcelain Raft** are one of my favourite bands at the moment. I'd seen them live with M83 but hadn't heard their album at that point. "Is it too deep for you?" and "Backwords" are fantastic, wistful, hypnotic, dreamy songs. Perhaps I'd hyped them up too much, but this set was awful, not that I fault the band themselves. The Prince Albert was full, people were squeezing in, it was hot and humid, we wanted lunch and it was overwhelming, but not in a good way. The two piece struggled to cope with The Prince Albert's sound setup: the snares were penetrating and the lyrics became drowned out, the balance was all wrong, not to mention the earthy buzz that surrounded everything. It was also very loud and we'd forgotten our ear plugs. Simply the wrong atmosphere and environment for this relaxing music.
 
-{% figure tge-2012-porcelain-raft.jpeg portrait %}Porcelain Raft by [Marcus Moxham](http://www.flickr.com/photos/moxcod/7199995740/in/set-72157629732958152){% endfigure %}
+{% figure tge-2012-porcelain-raft.jpeg portrait %}
+Porcelain Raft by [Marcus Moxham](http://www.flickr.com/photos/moxcod/7199995740/in/set-72157629732958152)
+{% endfigure %}
 
 ## Pompoko restaurant
 
@@ -44,7 +50,9 @@ It was overcast, the clouds were heavy and there was faint mist. We went home, h
 
 First up, Sticky Mike's Frog Bar for **Young Dreams**. Downstairs, in the dark, another small venue, we stood right at the front in the middle, Sam would at least see one band without some tall guy getting in the way. Described as tropicalia, psychedelic rock, they combined synths, guitars and tambourines with a pop sensibility. Their self-titled track, "Young Dreams", stood out from the set, it was excellent.
 
-{% figure tge-2012-young-dreams-3.jpg landscape %}Young Dreams{% endfigure %}
+{% figure tge-2012-young-dreams-3.jpg landscape %}
+Young Dreams
+{% endfigure %}
 
 **New Look** followed, a two piece haling from Canada. Futuristic, minimal pop laced with dubstep. Their self-titled album attracted me, "The Ballad" standing out. As a live act, Sarah Ruba looked gorgeous in 1940s attire, alongside her smartly dressed buttoned up collar husband, Adam Pavao. Together they played their minimal pop, as patterns of light danced across the stage. But the set lacked energy, and began to sound 'same-y', it was perhaps too minimal. Not until the final track, "Teen Need", did we really see what they were capable of.
 
@@ -56,11 +64,15 @@ Next up, the Pavilion Theatre for Club Uncut, a favourite venue of ours from las
 
 We got in before **TOY** started, a krautrock post-rock act with long hair, with a singer that sounded like a heavy Jarvis Cocker. Despite all that we really enjoyed their 7 minute epic tracks. A pleasant surprise.
 
-{% figure tge-2012-toy.jpeg landscape original %}[TOY](http://www.uncut.co.uk/blog/festivals/club-uncut-at-the-great-escape-day-one){% endfigure %}
+{% figure tge-2012-toy.jpeg landscape original %}
+[TOY](http://www.uncut.co.uk/blog/festivals/club-uncut-at-the-great-escape-day-one)
+{% endfigure %}
 
 Next up were **Django Django**, headlining the evening, a Scottish quartet, "art-rock that melds intangible electronic flourishes to the visceral rub of live instrumentation". You could also describe them as psychedelic rock, a concoction of 80s rhythm and 60s beach boy-esque vocal harmonies. Either way, I think they're awesome, and enjoyed the set immensely, dancing like a fool to all the tracks, even to the Egyptian themed "Skies over Cairo".
 
-{% figure tge-2012-django-django.jpeg landscape original %}Django Django{% endfigure %}
+{% figure tge-2012-django-django.jpeg landscape original %}
+Django Django
+{% endfigure %}
 
 <iframe width="580" height="435" src="http://www.youtube.com/embed/oCK8PYcJ2ZU" frameborder="0" allowfullscreen></iframe>
 

--- a/source/_posts/the-great-escape-2012/2.md
+++ b/source/_posts/the-great-escape-2012/2.md
@@ -14,7 +14,9 @@ The reason we were here was **Husky**, a band Mark had heard recently on 6music.
 
 Up next on The Guardian's "new band of the day" stage, were a London act called **Duologue**. Four guys, without their bassist, but a violinist, sampler, singer and guitarist. With a sparse electronic rhythm, deep bass, crisp male vocals and the crescendos of violin and guitar, this experimental rock band created something lovely. They played songs from their EP "A - B".
 
-{% figure tge-2012-duologue.jpeg landscape original %}Duologue by [Andy Wright](http://www.flickr.com/photos/litost/7214580034/in/photostream){% endfigure %}
+{% figure tge-2012-duologue.jpeg landscape original %}
+Duologue by [Andy Wright](http://www.flickr.com/photos/litost/7214580034/in/photostream)
+{% endfigure %}
 
 <iframe width="580" height="326" src="http://www.youtube.com/embed/dPzs9XiPZcg" frameborder="0" allowfullscreen></iframe>
 
@@ -24,7 +26,9 @@ The final act of this session at The Warren were the clean cut **Swiss Lips**, w
 
 With the sun out, we spent an hour or so on the pebbly beach, letting the time whisk by, waiting until we were hungry for dinner. We threw pebbles at beer cans but never hit them. Just around the corner we repeated last year's proceedings with dinner at Pho, specialising in vietnamese street food. A baby at the table opposite stared at us, as Mark tried his Weasel coffee.
 
-{% figure IMG_4768.JPG square original %}[Converses on the beach](http://instagram.com/p/KkziztNFEt/){% endfigure %}
+{% figure IMG_4768.JPG square original %}
+[Converses on the beach](http://instagram.com/p/KkziztNFEt/)
+{% endfigure %}
 
 ## Grimes, YACHT, My Best Fiend, Half Moon Run
 
@@ -32,11 +36,15 @@ Not wanting to miss out on Grimes, we got to Digital on the sea front before it 
 
 I was quite excited about **My Best Fiend**, I'd starred their opening track "Higher Palms" on Spotify, it was a stand out track from the Great Escape playlist. With atmospheric keyboards, gritty guitars and emotional alt-rock male vocals, this should have been fantastic. But the set was a little flat, the beautiful lyrics washed away with heavy bass.
 
-{% figure tge-2012-my-best-fiend.jpeg portrait original %}My Best Fiend by [Chiaki Karasawa](http://www.flickr.com/photos/chiakikrsw/7211957102/in/set-72157629925495522/){% endfigure %}
+{% figure tge-2012-my-best-fiend.jpeg portrait original %}
+My Best Fiend by [Chiaki Karasawa](http://www.flickr.com/photos/chiakikrsw/7211957102/in/set-72157629925495522/)
+{% endfigure %}
 
 Canadian trio **Half Moon Run** were next, a technically awesome indie rock band with an incredible drummer; with one hand and foot he played drums, with another he played the keyboard, and then he sung at the same time. Mind blowing talent, Sam was so impressed she bought the CD and asked about his musical training. The crowd were loving them, and they played a killer set. When it was cut short, even with Grimes coming up next, there were boos, everyone wanting more. But Digital were keeping to a strict schedule, no doubt to finish in time for a Friday night club night.
 
-{% figure tge-2012-half-moon-run.jpeg landscape original %}Half Moon Run by [Chiaki Karasawa](http://www.flickr.com/photos/chiakikrsw/7211957606/in/set-72157629925495522/){% endfigure %}
+{% figure tge-2012-half-moon-run.jpeg landscape original %}
+Half Moon Run by [Chiaki Karasawa](http://www.flickr.com/photos/chiakikrsw/7211957606/in/set-72157629925495522/)
+{% endfigure %}
 
 
 And now the big act, the one we'd all been wanting to see at this festival, **GRIMES**! A one woman act with samplers, a keyboard and a microphone. Claire Boucher in a t-shirt bearing the anarchy symbol and sporting a pink fringe, played her dark and dreamy Visions album. Two amateurish arm waving dancers set the scene on stage and there were roars of delight when the intro to "Oblivion" began.
@@ -45,22 +53,32 @@ And now the big act, the one we'd all been wanting to see at this festival, **GR
 
 <iframe width="580" height="326" src="http://www.youtube.com/embed/i20mWIT0PDY" frameborder="0" allowfullscreen></iframe>
 
-{% figure tge-2012-grimes.jpeg landscape original %}Grimes by [Rob Ball](http://www.mintsouth.com/2012/2012/05/the-great-escape-festival-in-pictures/){% endfigure %}
+{% figure tge-2012-grimes.jpeg landscape original %}
+Grimes by [Rob Ball](http://www.mintsouth.com/2012/2012/05/the-great-escape-festival-in-pictures/)
+{% endfigure %}
 
-{% figure tge-2012-grimes-2.jpeg landscape %}[Grimes](http://emilyramone.tumblr.com/){% endfigure %}
+{% figure tge-2012-grimes-2.jpeg landscape %}
+[Grimes](http://emilyramone.tumblr.com/)
+{% endfigure %}
 
-{% figure tge-2012-grimes-3.jpeg landscape %}[Grimes](http://flyingwithanna.com/2012/05/16/great-escape-review-friday/){% endfigure %}
+{% figure tge-2012-grimes-3.jpeg landscape %}
+[Grimes](http://flyingwithanna.com/2012/05/16/great-escape-review-friday/)
+{% endfigure %}
 
 The only downside to this performance is that it wasn't longer, a light 30 minutes, an hour would have been more suiting. We all wanted more. At the end, Digital emptied, the place deserted, but reaching full again by the time YACHT turned up.
 
 I'd seen **YACHT** before at Hoxton Bar, and I ranked it as one of the best gigs I'd ever been to. YACHT's music is good on record, but it really comes alive when performed, enhanced by the energy and antics of the band members. They're electro dystopian disco is matched with flying microphones, odd dance moves and a singer that likes to tie herself up in cables. Aye-ye-aye-ye-aye-ya, "Psychic City", was the highlight, with its singable chorus and party-starting lyrics. "We're having fun now, aren't we?", singer Claire Evans asks. We agreed, the set was brilliant.
 
-{% figure tge-2012-yacht.jpeg landscape original %}YACHT by [Tim Boddy](http://thefourohfive.com/news/article/in-photos-special-the-great-escape-2012){% endfigure %}
+{% figure tge-2012-yacht.jpeg landscape original %}
+YACHT by [Tim Boddy](http://thefourohfive.com/news/article/in-photos-special-the-great-escape-2012)
+{% endfigure %}
 
 ## Blanck Mass, Forest Swords
 
 Still raring to go, we marched over to Pavilion Theatre for a very different experience: **Blanck Mass**. A 45 minute non-stop set of complex atmospherics and ambient electronics, themed on cerebral hypoxia. One man act, Ben Power, stood centre stage and barely moved as strong green lights shone from behind, creating a silhouette amidst the smoke machines. Whirls of smoke and patterns of light accompanied slow changing drone layers, the occasional hidden rhythm emerging from the noise, and disappearing again. Exhausted I shut my eyes and rested with Sam, embracing the wall of sound. It was excellent, all we lacked was a sofa or bed.
 
-{% figure tge-2012-blanck-mass.jpg portrait %}Blanck Mass{% endfigure %}
+{% figure tge-2012-blanck-mass.jpg portrait %}
+Blanck Mass
+{% endfigure %}
 
 **Forest Swords** were on a midnight. An hour long set of disparate spectral techno accompanied with a video. By now we were too tired for this, and a drunken heckler shouting "sea bass, kick him in the ass" destroyed any atmosphere we could've absorbed. Leaving early, I ate my pain au chocolat saved from lunch time and we headed home.

--- a/source/_posts/the-great-escape-2012/3.md
+++ b/source/_posts/the-great-escape-2012/3.md
@@ -22,11 +22,15 @@ Digital was the nearest venue so we nipped in to catch the Australian acts perfo
 
 **Chet Faker** appeared next with his own brand of lo-fi electronic soul and No Diggity cover. He normally plays with a band, but a long way from home, he was a one man act with samplers, et al. Playing just his third European gig, he was brilliant.
 
-{% figure tge-2012-chet-faker.jpeg landscape original %}[Chet Faker](http://www.flickr.com/photos/undertheradarmag/7221039700/){% endfigure %}
+{% figure tge-2012-chet-faker.jpeg landscape original %}
+[Chet Faker](http://www.flickr.com/photos/undertheradarmag/7221039700/)
+{% endfigure %}
 
 The final act of the session was **Jinja Safari**, a mad quintet that leaped around with citars playing some form of indie pop. Their energy created a good show, but the music was all a little normal.
 
-{% figure tge-2012-jinja-safari.jpeg landscape original %}[Jinja Safari](http://www.theaureview.com/artist/jinja-safari){% endfigure %}
+{% figure tge-2012-jinja-safari.jpeg landscape original %}
+[Jinja Safari](http://www.theaureview.com/artist/jinja-safari)
+{% endfigure %}
 
 ---
 
@@ -38,7 +42,9 @@ Back on the paths again, we returned to Sticky Mike's Frog Bar for Luke's choice
 
 <iframe width="580" height="435" src="http://www.youtube.com/embed/5t13KNjPFnc" frameborder="0" allowfullscreen></iframe>
 
-{% figure tge-2012-suicide-western-culture.jpeg portrait original %}The Suicide of Western Culture{% endfigure %}
+{% figure tge-2012-suicide-western-culture.jpeg portrait original %}
+The Suicide of Western Culture
+{% endfigure %}
 
 ## Husky, Theme Park, We are scientists
 
@@ -48,7 +54,9 @@ Country singer-songwriter **Jodie Marie** came next. Her voice was refreshing bu
 
 By now the venue was packed, it was sweaty and humid, like a rainforest filled with apes, or something. The schedule was running behind by 45 minutes or so. Everyone had arrived to watch We Are Scientists, but **Theme Park** were just getting started. A new, British indie rock band, likened to Talking Heads, they had some trouble with microphones on stage, and they showed a lack of experience. But their songs came through this mess, "Wax" and "Milk" being the standout songs. And when they found their flow they were enjoyable.
 
-{% figure tge-2012-theme-park.jpeg landscape original %}[Theme Park](http://www.gigwise.com/photos/72971/14/The-Great-Escape-day-three-Howler-New-Look-and-more){% endfigure %}
+{% figure tge-2012-theme-park.jpeg landscape original %}
+[Theme Park](http://www.gigwise.com/photos/72971/14/The-Great-Escape-day-three-Howler-New-Look-and-more)
+{% endfigure %}
 
 The final act of our night were the Coalition headliners, **We Are Scientists** from New York. A three piece - front man-George Clooney-lookalike, the dry comedian and the drummer. Indie, rock, alt-rock, jump about, shout about, their 45 minute set packed a punch, including their popular festival titled track, "The Great Escape".
 
@@ -56,4 +64,6 @@ The final act of our night were the Coalition headliners, **We Are Scientists** 
 
 And that was that, we tried to get in to EMA at the Pavilion but the delay meant we couldn't get in. We said goodbye to Luke who ran for his train and we called it a night, heading home at 1am for a cup of tea and a chat.
 
-{% figure IMG_4766.JPG landscape %}The Great Escape wrist band{% endfigure %}
+{% figure IMG_4766.JPG landscape %}
+The Great Escape wrist band
+{% endfigure %}

--- a/source/_posts/the-prisoner-of-second-avenue.md
+++ b/source/_posts/the-prisoner-of-second-avenue.md
@@ -11,7 +11,9 @@ date: 2010-07-09 08:57:45
 
 After a scrumptious Jamaican burger (mango and ginger relish included) from the [Gourmet Burger Kitchen](http://4sq.com/a3pchq) near Covent Garden, Jo, Jo's Aunt and Uncle, Sam and I headed to the [Vaudeville theatre](http://foursquare.com/venue/143717) for the recently opened, "Prisoner of Second Avenue".
 
-{% figure prisonerSecondAvenue.gif portrait original %}The Prisoner of Second Avenue poster{% endfigure %}
+{% figure prisonerSecondAvenue.gif portrait original %}
+The Prisoner of Second Avenue poster
+{% endfigure %}
 
 We didn't really know much about the play before deciding to go and see it, or even before we walked in. A black comedy starring Jeff Goldblum was enough to sway me and Jo, and Sam reluctantly came along for the ride - though she was glad she did. The play also starred the excellent Mercedes Ruehl, and was originally written by Neil Simon. There's a Jack Lemmon film as well.
 

--- a/source/_posts/the-skydive.md
+++ b/source/_posts/the-skydive.md
@@ -32,9 +32,13 @@ By this time most of my nerves had gone, it's always the waiting that's worst. T
 
 The aircraft was tiny, and without seats. Seven of us were jumping, and we squeezed in, sitting between each others legs. It would take ten minutes to reach the jumping altitude of 10,000ft. And off we went, climbing higher and higher, the great flat expanse of Suffolk growing beneath us. Higher and higher, there's no turning back now. Towards the clouds, through the clouds and above the clouds.
 
-{% figure IMG_8817.jpg portrait %}Paul on the plane before takeoff{% endfigure %}
+{% figure IMG_8817.jpg portrait %}
+Paul on the plane before takeoff
+{% endfigure %}
 
-{% figure IMG_8825.JPG landscape %}The nervous fliers{% endfigure %}
+{% figure IMG_8825.JPG landscape %}
+The nervous fliers
+{% endfigure %}
 
 ## Falling with style
 
@@ -42,27 +46,43 @@ Then the aircraft slowed down, and the time had come. The hatch opened and the g
 
 OH SHIT! My genuine first thought, as the unnatural feeling of weightlessness takes hold. We roll over, and I look up at the clear blue sky and the underbelly of the plane flying off.
 
-{% figure IMG_8836.JPG landscape %}Leaning out of the plane{% endfigure %}
+{% figure IMG_8836.JPG landscape %}
+Leaning out of the plane
+{% endfigure %}
 
-{% figure IMG_8837.JPG landscape %}Too late to back out now{% endfigure %}
+{% figure IMG_8837.JPG landscape %}
+Too late to back out now
+{% endfigure %}
 
-{% figure IMG_8838.JPG landscape %}Oh shit!{% endfigure %}
+{% figure IMG_8838.JPG landscape %}
+Oh shit!
+{% endfigure %}
 
 Now the weightlessness disappears, and all you can feel is the rush of air against you, getting stronger and stronger as you accelerate up to 120mph. But as you're falling you have time to think, to notice that the cloud is getting closer, to think about your breathing as the wind tries to take your breath away. And to think, this is amazing, this is magnificent. I was breathless and awestruck.
 
-{% figure IMG_8847.JPG landscape %}Paul and the clouds{% endfigure %}
+{% figure IMG_8847.JPG landscape %}
+Paul and the clouds
+{% endfigure %}
 
-{% figure IMG_8848.JPG landscape %}Hey, this isn’t so bad{% endfigure %}
+{% figure IMG_8848.JPG landscape %}
+Hey, this isn’t so bad
+{% endfigure %}
 
-{% figure IMG_8887.JPG landscape %}Incoming clouds{% endfigure %}
+{% figure IMG_8887.JPG landscape %}
+Incoming clouds
+{% endfigure %}
 
 I put my arms out and felt the air fly past me, and then we hit the cloud, and we're falling through fog. The moisture gathers on my face, and it's refreshing. Then the parachute is deployed, a sharp halt and I switch from a falling to a standing position. I watch as my cameraman disappears into the fog beneath me, like some weird scene in The Neverending Story. And all is quiet again, the rushing wind stops and the fog clears.
 
-{% figure IMG_8894.JPG landscape %}Time to open the parachute{% endfigure %}
+{% figure IMG_8894.JPG landscape %}
+Time to open the parachute
+{% endfigure %}
 
 I look up and see the blue parachute above me. I look down, I see my feet, my familiar Converse shoes, and then a field, a long long way down. I am floating in the sky, it is silent, and wonderful. Except perhaps for the tightness across my chest.
 
-{% figure IMG_8899.JPG landscape %}Landing zone{% endfigure %}
+{% figure IMG_8899.JPG landscape %}
+Landing zone
+{% endfigure %}
 
 The silence was unexpected, the guy on my back points out the sights as we descend. Great Yarmouth, Norwich, the sea, and so on.
 
@@ -70,9 +90,13 @@ Then, unexpectedly, it's my turn to control. I put my hands in the yellow parach
 
 Beneath me I see the plane landing, and the landing zone. I relinquish control and we come in for our landing, legs up, legs up, and down, bums skidding across the grass, back on solid ground. With an ear to ear grin, I shake the guys hand and sit back to watch Marek and Linda landing behind me.
 
-{% figure IMG_8901.JPG landscape %}Legs up for landing{% endfigure %}
+{% figure IMG_8901.JPG landscape %}
+Legs up for landing
+{% endfigure %}
 
-{% figure IMG_8913.JPG landscape %}Too dazed to pose for a picture{% endfigure %}
+{% figure IMG_8913.JPG landscape %}
+Too dazed to pose for a picture
+{% endfigure %}
 
 <iframe width="580" height="326" src="http://www.youtube.com/embed/AfxSk1l4UgQ" frameborder="0" allowfullscreen></iframe>
 

--- a/source/_posts/two-weeks-in-molyvos-in-lesbos-greece.md
+++ b/source/_posts/two-weeks-in-molyvos-in-lesbos-greece.md
@@ -15,7 +15,9 @@ page: 1
 
 <!-- As with our trip to Sozopol, Bulgaria, I'm taking a quick moment out of a few days to recant our recent tails. Those lucky enough to find this rare and valuable hard copy will note the delightful [Molyvos](http://en.wikipedia.org/wiki/Molyvos) image on the front of this book. -->
 
-{% figure molyvos-harbour.JPG landscape %}Molyvos harbour on the island of Lesvos{% endfigure %}
+{% figure molyvos-harbour.JPG landscape %}
+Molyvos harbour on the island of Lesvos
+{% endfigure %}
 
 ## London to Lesbos
 
@@ -29,10 +31,14 @@ I shall not get into our laborious process of deciding which island/resort to vi
 
 On landing we discarded our jumpers, breathed in the hot air and set about across the mountainous terrain of Lesbos, via taxi, to the north of the island - about an hours drive, at a speedy pace with horn honking at junctions and overtaking of one handed motorcyclists that were texting on their phones. We checked in and proceeded up the 100-odd steps to our room, with a glorious North Lesvos sea view, and Turkey clear in our sights over the water. The room is nice, excellent for sleeping and looking after our clothes, which is all we need it for. The Sun Rise Hotel offers a full and half board food service, we got the breakfasts but opted out of the evening meals - we like our restaurants! A good choice considering their food is over priced and not very good (we sampled a chicken a la creme, a tuna salad and a burger on our first day - though not again since - Sam also made the Chicken Creme mistake in Sozopol).
 
-{% figure greece-sun-rise-hotel-room.JPG landscape %}Our room in the Sun Rise Hotel{% endfigure %}
+{% figure greece-sun-rise-hotel-room.JPG landscape %}
+Our room in the Sun Rise Hotel
+{% endfigure %}
 
 ---
 
 I'm currently sitting by their pool, basking in the hot sun, as I write this - it looks so refreshing and the sound of the water fountain is soothing. Every now and then a House Martin swoops down to take a quick drink. Sam's reading her book "The Lollipop Shoes" and her sun burn has mostly gone down, though I am sure it will quickly return. I am reading Mark Danielewski's "House of Leaves". We've played some table tennis but hand to eye co-ordination isn't Sam's strong point.
 
-{% figure greece-sun-rise-hotel-pool.JPG landscape %}Sun Rise Hotel swimming pool{% endfigure %}
+{% figure greece-sun-rise-hotel-pool.JPG landscape %}
+Sun Rise Hotel swimming pool
+{% endfigure %}

--- a/source/_posts/two-weeks-in-molyvos-in-lesbos-greece/2.md
+++ b/source/_posts/two-weeks-in-molyvos-in-lesbos-greece/2.md
@@ -9,9 +9,13 @@ page: 2
 
 On our first day we ate our cheese, egg and tomato breakfast rolls, drunk the odd tasting tea and took the SRH courtesy bus down to Molyvos. It's a small coastal town built against a towering rock with castle atop. The roads are thin, cobbled up'n'down affairs, navigated by the locals on their mopeds and bikes. The central streets are lined with small but cute touristy shops, restaurants with balconies and expensive clothes shops - each of which Sam has thoroughly explored. At the bottom lies the small port and all the highly rated places to eat, with their freshly caught wild fish. There are also cats - everywhere! We met two northern English couples here fishing with a small line they had bought, using bread to catch small fish and octopi.
 
-{% figure greece-sam-researching-the-trips.JPG landscape %}Researching boat trips{% endfigure %}
+{% figure greece-sam-researching-the-trips.JPG landscape %}
+Researching boat trips
+{% endfigure %}
 
-{% figure greece-sam-investigating-the-shops.JPG portrait %}Shopping in Molyvos{% endfigure %}
+{% figure greece-sam-investigating-the-shops.JPG portrait %}
+Shopping in Molyvos
+{% endfigure %}
 
 ## Fantastico
 
@@ -25,9 +29,13 @@ Saturday took us on a 40 min walk towards Eftalou's hot water springs via pebbly
 
 After cooling down in the pool, now a common practice, we walked into Molyvos (20-40mins) for a meal at The Captain's Table, a place run by English speaking Melinda and family. We'd read that their Mezes and Fish were particularly tasty and everyone has spoken very highly of them. Here I sampled the cloudy white Ouzo, spicy aubergines, [Tabouleh](http://en.wikipedia.org/wiki/Tabouleh) (a cracked wheat dish), salted Anchovies (perfect with Ouzo), salted uncooked swordfish, "Grandma's Cheese Pie", grilled octopus, home-made chips and lettuce salad ~€43. We plan to return for some fresh fish. We stopped for some cocktails at Molly's bar (another recommended place), drawn in by the awful sounds of the Eurovision song contest. A black russian, pina colada, strawberry daquiris and weird green thing with ice cream later and the room was buzzing with international cheers and boos as songs played and the votes came in. Not the same without Wogan but the zealous laughter and insults more than made up.
 
-{% figure greece-captains-table.JPG landscape %}Paul and Sam at The Captain’s Table{% endfigure %}
+{% figure greece-captains-table.JPG landscape %}
+Paul and Sam at The Captain’s Table
+{% endfigure %}
 
-{% figure greece-octopus.JPG landscape %}Our first taste of octopus{% endfigure %}
+{% figure greece-octopus.JPG landscape %}
+Our first taste of octopus
+{% endfigure %}
 
 Everyone here on Lesbos is very open, talkative and friendly. You can go and speak to anyone and they'll be happy to engage with you. Everything is incredibly welcoming - there's banter between tables at restaurants and friendly chatter everywhere between strangers. It's very easy to make friends and feel like part of something bigger - whether its the Greek native or the holiday atmosphere, this place brings out the best.
 
@@ -35,7 +43,9 @@ Everyone here on Lesbos is very open, talkative and friendly. You can go and spe
 
 Needless to say, we got home at 2am, thoroughly sloshed. Sunday became a tiring shopping trip with a quest for sun-block, hats and shoes. We ate at Betty's for lunch, sharing a pork [Kleftiko](http://en.wikipedia.org/wiki/Kleftiko) with some giant white beans. Sam also discovered a taste for iced tea, I drank one of only four beers available on the island - Amstel. A charming place on the hill with overlooking balcony.
 
-{% figure greece-bettys-view.JPG landscape %}View from Betty’s{% endfigure %}
+{% figure greece-bettys-view.JPG landscape %}
+View from Betty’s
+{% endfigure %}
 
 After a nap under a tree near the Olive Press, and a dip in the pool, it was back to Fantastico for a shared Pizza and cheap night out.
 
@@ -43,7 +53,9 @@ After a nap under a tree near the Olive Press, and a dip in the pool, it was bac
 
 Monday brought the start of the local bus service from Eftalou through to Anaxos for only €1.40. With this we headed to [Petra](http://en.wikipedia.org/wiki/Petra,_Lesbos), the beachy tourist trap - I haggled for a hat and Sam for some olive decorated pottery. In the heat we climbed the central rock and the church at the top. After coming back down, we walked through the back streets of the town, heading back to the centre via a beach-side walk, hilariously ending with Sam's shoes falling unceremoniously into the Sea right as we decided to head back to the road. For lunch we had fresh bread, salami and cinammon doughnuts. There's not a lot to do in Petra, other than sunbathe and shop for post cards, and maybe ride a pedalo. So we took the bus back to Molyvos for the evening - despite Sam's desire to go to an obscure "Greek night" which offered a set meal, somewhere on the edge of Petra.
 
-{% figure greece-petra-rock.JPG portrait original %}Petra{% endfigure %}
+{% figure greece-petra-rock.JPG portrait original %}
+Petra
+{% endfigure %}
 
 ## Le Grand Bleu restaurant
 

--- a/source/_posts/two-weeks-in-molyvos-in-lesbos-greece/3.md
+++ b/source/_posts/two-weeks-in-molyvos-in-lesbos-greece/3.md
@@ -7,25 +7,37 @@ page: 3
 
 It is Sunday now and we are back by the pool in a much busier hotel. Tuesday's plan was a romantic starlight cruise round the North West bay, on arrival we found that, much to our disappointment, although advertised, it did not run "this early in the season" - not enough people. At a loss we wandered the harbour watching schools of fish in the clear water beneath us. Into the harbour cmae a small boat advertising personal trips for a maximum of 4 persons - running to grap the captain, Stradis, Sam found that he offered a 1-2 hour trip at €60.
 
-{% figure greece-boat-escape.JPG landscape original %}Alternative Boat Trips{% endfigure %}
+{% figure greece-boat-escape.JPG landscape original %}
+Alternative Boat Trips
+{% endfigure %}
 
 ## The Captain's Table (again)
 
 With a prospect of a night time boat ride the next night we happily settled for our second meal at The Captain's Table, looking for some fresh fish! On showing our interest, Melinda invited us into the kitchen to peruse the fresh fish they had - taking them out of the ice box one by one explaining taste, type, bones and price. The Hate and Sea Bream took our fancy, and after Sam's anxiety over bones, her's came pre-filleted, both with head and tail still attached.  Delicious! Next to us were a couple from our hotel, with a lovely looking Captains Platter. We chatted over complimentary Ouzo before having a lift home from our new friends.
 
-{% figure greece-captains-table-second-night.JPG landscape %}Outside at The Captain’s table{% endfigure %}
+{% figure greece-captains-table-second-night.JPG landscape %}
+Outside at The Captain’s table
+{% endfigure %}
 
 ## Hiking from Petra to Anaxos and Ambelia
 
 Wednesday brought an early start, at breakfast for 7:30, in taxi at 8:10, we headed to Petra to begin the first of three walks as outlined in “[Walks in North Lesvos](http://amzn.to/k0UhfE)” by Lance Chilton. For something easy to begin with, we took the 30 - 45 min walk to Anaxos around the coast, along Petra's main road, round the waterline past seaweed mounds, a mooring place and rocks to scramble over, we reached Anaxos with relative ease. On discovery that Anaxos is nothing more than a taverna/hotel filled tourist trap for sun worshipers, we opted for the second walk, round a dirt track in the hills to the secluded beach of Ambelia, about an hours walk. The temperature was rising, but the route offered some shade and it was just bearable for Sam. After some trouble finding the start of the trail, our walk took us to a wonderful view of the beach and the high up village of Skoutaros, then winding down across a small river and finally to the south end of the sandy beach. A single Taverna, "George's" gave us our much needed refreshment and toilet stop. Here we found a riverbed filled with Terrapin's which fought over chunks of our crusty bread.
 
-{% figure greece-ambelia-walk.JPG landscape %}Sam while hiking to Ambelia{% endfigure %}
+{% figure greece-ambelia-walk.JPG landscape %}
+Sam while hiking to Ambelia
+{% endfigure %}
 
-{% figure greece-terrapins.JPG landscape %}Terrapins at Ambelia{% endfigure %}
+{% figure greece-terrapins.JPG landscape %}
+Terrapins at Ambelia
+{% endfigure %}
 
-{% figure greece-looking-south-from-ambelia.JPG landscape %}Lesvos coastal view{% endfigure %}
+{% figure greece-looking-south-from-ambelia.JPG landscape %}
+Lesvos coastal view
+{% endfigure %}
 
-{% figure greece-ambelia-walk-home.JPG landscape %}Hiking home from Ambelia{% endfigure %}
+{% figure greece-ambelia-walk-home.JPG landscape %}
+Hiking home from Ambelia
+{% endfigure %}
 
 We ate our salami and bread lunch in a shaded alcove at the end of the bay, throwing remains to the ever grateful fish. Our return route, the third walk, took us up and over the cliffs, the coastal path. Glorious views of cliffs covered in "Yellow everlasting", Poppies and clear blue sea's below came at the cost of no shade and the odd thorny encounter plus some beastly hornets, as well as passing one man and his reluctant horse in tow. Taking this route in the height of the day did not prove to be the best idea, we missed our bus and were left utterly parched and sun-roasted in the terrible Anaxos. We were saved by a lady named Alison, pointing us towards a pool and some refreshments where we cooled off for an hour or two, with countless applications of moisturiser and sun lotion.
 
@@ -33,11 +45,17 @@ We ate our salami and bread lunch in a shaded alcove at the end of the bay, thro
 
 After the bus home, tired and headached, we opted to postpone the boat trip and headed for the recommended Eftalou Restaurant. From our hotel to the restaurant at the pebbly beach we were accompanied by a charming little dog. Amongst numerous cats and denied food requests ("we don't have that - try this…") we ate the fish of the day and a fresh tuna steak, with complimentary Watermelon for dessert. Whilst its hard to pinpoint anything bad, we left very disappointed with the place. Perhaps it was the selection of food on offer (Zucchini pie advertised but not available) or the misunderstanding over fish of the day not gilt headed bream as it appeared, but the unexciting Cod, who knows. Despite the mediocrity we left with high spirits.
 
-{% figure greece-paul-and-the-dog.JPG landscape %}Paul and the dog{% endfigure %}
+{% figure greece-paul-and-the-dog.JPG landscape %}
+Paul and the dog
+{% endfigure %}
 
-{% figure greece-eftalou-restaurant.JPG portrait %}Eftalou restaurant{% endfigure %}
+{% figure greece-eftalou-restaurant.JPG portrait %}
+Eftalou restaurant
+{% endfigure %}
 
-{% figure greece-sun-set-eftalou.JPG landscape %}Greek sunset{% endfigure %}
+{% figure greece-sun-set-eftalou.JPG landscape %}
+Greek sunset
+{% endfigure %}
 
 ## Changeover Thursday
 
@@ -47,11 +65,17 @@ Thursday was another day spent by the pool, saying goodbye to friends we made in
 
 With all the old English gone and the new not yet acquainted, Molyvos was very quiet on Thursday night - as we headed to the harbour for our boat trip. Unfortunately, today the wind had picked up to coincide with hotter temperatures (33C), making the sea too choppy for a romantic night on a small boat for 2. With banana and watermelon ice creams we pondered the cost, when a slightly larger 10 person glass bottomed boat docked. Through Sam's sprint for the captain and inquisitive nature we bagged a discounted €15 each trip around Petra and Rabbit island with dinner included, ditching Stradis and his smaller boat - which we felt bad about but concluded that he would not have taken us out in the wind. The larger boat cut through the waves much easier and the greek music played as our captain Alex took us to a mooring place on Rabbit island, via some underwater reefs viewed through the bottom. The thousands of nesting gulls on the island were not best pleased to see us as we headed to the top they squawked and began to dive at us, "WHOOSH" over my head, needless to say we were out of there quickly, back on the boat for the prepared barbecue. Our return took us via Petra, watching the red sunset quickly descent into the haze of the horizon.
 
-{% figure DSCN3251.JPG landscape %}Seagulls on rabbit island{% endfigure %}
+{% figure DSCN3251.JPG landscape %}
+Seagulls on rabbit island
+{% endfigure %}
 
-{% figure DSCN3249.JPG landscape %}Heading back to the boat{% endfigure %}
+{% figure DSCN3249.JPG landscape %}
+Heading back to the boat
+{% endfigure %}
 
-{% figure greece-boat-trip-into-petra.JPG landscape %}View of Petra{% endfigure %}
+{% figure greece-boat-trip-into-petra.JPG landscape %}
+View of Petra
+{% endfigure %}
 
 ## Tropicana restaurant
 
@@ -69,10 +93,16 @@ After trying out the roads we knew, we bravely headed through the winding, peril
 
 After 4 hours the school kids were out, splashing loudly they engulfed the beach so we returned back to the car and onwards to Skala Kallonis correctly this time. Upon parking, a very British club-going sort of fella that now lived on the island explained and divulged the secret wonders of the moths and caterpillars, as long swirling, squiggly things rained on us from the trees above. The famed migratory birds had long gone, to my disappointment. Rather than eating at Medusa which we finally found, amongst a fisherman clubbing an octopus, we drove home before nightfall, with a small detour to Agia Paraskevi in search of Apollo's temple.
 
-{% figure greece-clubbed-octopus.JPG landscape %}A man beating an octopus with a cricket bat{% endfigure %}
+{% figure greece-clubbed-octopus.JPG landscape %}
+A man beating an octopus with a cricket bat
+{% endfigure %}
 
-{% figure greece-car-rental.JPG landscape %}Samantha and our yellow Hyundai rental{% endfigure %}
+{% figure greece-car-rental.JPG landscape %}
+Samantha and our yellow Hyundai rental
+{% endfigure %}
 
 Sam's fear of heights really kicked in on the return leg, we made safe but slow progress. Congratulating Sam on a job well done, something she was clearly very nervous about doing, we returned the car (I had a small scooter trip), and had a full meal of Beef [Goulash](http://en.wikipedia.org/wiki/Goulash) and [Stifado](http://en.wikipedia.org/wiki/Stifado) at Tropicana, with their speciality salad and feta stuffed peppers. Stuffed, happy and relieved, we slept soundly.
 
-{% figure greece-topicana-beef-goulash.JPG landscape %}Paul with beef goulash at Tropicana{% endfigure %}
+{% figure greece-topicana-beef-goulash.JPG landscape %}
+Paul with beef goulash at Tropicana
+{% endfigure %}

--- a/source/_posts/two-weeks-in-molyvos-in-lesbos-greece/4.md
+++ b/source/_posts/two-weeks-in-molyvos-in-lesbos-greece/4.md
@@ -9,26 +9,38 @@ page: 4
 
 Saturday brought another early morning to this holiday, the Wild West coach excursion around North West Lesvos, pickup at 8:15am. For €33 each we were to explore the area of Limonos, the village Vatoussa, the [Petrified Forest](http://en.wikipedia.org/wiki/Petrified_forest_of_Lesbos) and [Skala Eressos](http://en.wikipedia.org/wiki/Eressos). Another young couple from our hotel were on the tour with us, they flew in on Thursday and we shared with them our tips. The large air conditioned coach and charismatic guide Ismini greeted us and we were off, through Petra and Anaxos for more pickups, speedily along the tight mountain roads, winding around, horns blown at corners, rip-roaring around the hair pins with the spoken histories of Petra and Anaxos being explained to us, down towards Skala Kallonis where we were yesterday, for the last pickup. Then back up to Limonos Monastery, largest of the island, with a father superior and two monks.
 
-{% figure greece-limonos-monastery.JPG landscape %}Limonos Monastery{% endfigure %}
+{% figure greece-limonos-monastery.JPG landscape %}
+Limonos Monastery
+{% endfigure %}
 
 The area is surrounded with small church like monuments, paid for by families as dedications to lost loved ones. The monastery is in a yard with with walled protection in the form of Monk's cells and a small family of Peacocks. We opted out of the little Byzantine museum, instead wandering the court-yards. An old ruling prevents women from entering the monastery itself ("to stop temptation"). so I went in alone - the walls, ceilings and coves were all elaborately decorated, one depiction of a shark teethed individual being jested by an angel sticks in my mind. No pictures allowed.
 
 Leaving here, sticking to our rigid time constraints, we travelled to Vatoussa which exists within the crater of a dormant volcano, via Filia and Anemotia, stopping for some local [Baclava](http://en.wikipedia.org/wiki/Baclava) then whisked away again, before we could catch our breath, to the petrified forest. This lies past the high up, mountain perched Ipsilou monastery, overlooking the island - you can see Molyvos in the distance from here. The roads became more perilous, steep, unprotected drops as the coach roars onwards as fast as possible. The petrified forest, a collection of fossilized trees, is amongst the most barren of landscapes, almost moon like - the hottest part of the tour at the hottest time of the day. The largest trees have been uncovered, sparsely populating the park, protected with frail wooden fences, tourists are urged not to touch, but do so anyway. Smaller "tree-rocks" remain unearthed, fragments scattered about the place, some even jutting out of dirt paths. Some shade, a coke and it's back on the bus and down to Skala Eressos, birthplace of [Sappho](http://en.wikipedia.org/wiki/Sappho). On our travels here we were lucky enough to see a Black Stork.
 
-{% figure greece-ipsilou-monastery.JPG landscape %}View of Ipsilou monastery, from the coach{% endfigure %}
+{% figure greece-ipsilou-monastery.JPG landscape %}
+View of Ipsilou monastery, from the coach
+{% endfigure %}
 
-{% figure greece-pretified-forest-and-guide.JPG portrait %}Our guide Ismini with a petrified tree trunk{% endfigure %}
+{% figure greece-pretified-forest-and-guide.JPG portrait %}
+Our guide Ismini with a petrified tree trunk
+{% endfigure %}
 
-{% figure greece-petrified-forest-paul.JPG landscape %}Paul amongst petrified trees{% endfigure %}
+{% figure greece-petrified-forest-paul.JPG landscape %}
+Paul amongst petrified trees
+{% endfigure %}
 
 <object width="425" height="344"><param name="movie" value="http://www.youtube.com/v/fUzVRyZZHPw&hl=en&fs=1"></param><param name="allowFullScreen" value="true"></param><embed src="http://www.youtube.com/v/fUzVRyZZHPw&hl=en&fs=1" type="application/x-shockwave-flash" allowfullscreen="true" width="425" height="344"></embed></object>
 
 A 2 hour stop brought us some Mezes at the Aegean in the square; fried zucchini, aubergine dip, fries and some feta - just right. By the time we were done, 4:30 had come and the coach was leaving once more, giving us no time to explore the church or the beach. Although a tourist resort it has more character and flavour than Petra offers. Time to head home on a 2 hour round trip, expertly through Messotopos, Agra, passed the entrance to the bay and Parakila, then up through the hills and Kalloni once more. Although interesting, the weariness, driving, constant turning, up and down and heat were incredibly nauseating. Whilst we did a lot, saw a lot and learned a lot, it was not the most enjoyable of days given the sickness and time constraints. If you are a confident driver its probably better to buy a guide and drive yourself.
 
-{% figure greece-aegean-restaurant.JPG landscape %}A restaurant in Skala Eressos{% endfigure %}
+{% figure greece-aegean-restaurant.JPG landscape %}
+A restaurant in Skala Eressos
+{% endfigure %}
 
 ## An awful evening meal
 
 Home by 6:30pm and despite exhaustion, we went for the evening to a small taverna, triangular shaped at the cross roads between Molyvos and Eftalou, for their "Greek Night" with live music accompaniment. The loud music played and the menu appeared promising - we made our choices; stuffed peppers and lamb kleftiko. They had neither, five iterations later (no potato salad, meatballs or stews) it appeared they had none of the food on their menu. In the meantime the music became piercingly loud, headache inducing with constant feedback from the singer, and those next to us lit up their cigs, smoke blowing in our faces. We should have left, but they had my last choice, a burger, and we decided to judge them on their food - a mistake. After taking what felt like an eternity our food was cold, partly cooked and disgusting; a congealed lamb sauce with no flavour, hard rice, soggy chips and all at an expensive price. Going against my principles we fed the waiting cats, they didn't like it much either. As we were served our complimentary desserts/drink we paid and left. DO NOT GO HERE. To recover our evening we had ice creams in the harbour (mocha/chocolate! mmm), meeting an equally unhappy couple in the process, with whom we proceeded to bitch. On the bus home we overheard others praising the place; I cannot think how or why.
 
-{% figure greece-horrible-place-dont-go-here.JPG landscape %}A restaurant to avoid{% endfigure %}
+{% figure greece-horrible-place-dont-go-here.JPG landscape %}
+A restaurant to avoid
+{% endfigure %}

--- a/source/_posts/two-weeks-in-molyvos-in-lesbos-greece/5.md
+++ b/source/_posts/two-weeks-in-molyvos-in-lesbos-greece/5.md
@@ -19,17 +19,25 @@ Flagged down as we passed them at "Cafe Pirate", we ate with them at the corner 
 
 Stirring at 9:30am, just making Monday's breakfast (cheese, scrambled egg, tomato, bacon roll, grapefruit juice and now black tea because the milk tastes funny), we postponed the planned coastal walk - instead we chose a hangover recovery procedure, consisting of painkillers and sleep. Avoiding another day by the pool, it was time for Sam's holiday shopping spree in Lolyvos. But not before a couple of lunch time [Gyros](http://en.wikipedia.org/wiki/Gyros) from the little "Friends" takeaway and a swim in the noisy Olive Press hotel pool. Sipping mango juice on the promenade wall, house martins on power lines above me, I left Samantha to gather olive oil and ornaments; I instead attempted to catch fish using bread, salami and a small line I purchased - unsuccessfully I might add.
 
-{% figure greece-gyros.JPG landscape %}Gyros!{% endfigure %}
+{% figure greece-gyros.JPG landscape %}
+Gyros!
+{% endfigure %}
 
 ## The Octopus restaurant
 
 Not wanting to be disappointed by unavailable menu items, dinner at "The Octopus" came early - it's the distinctive building on the corner in the harbour with the red shutters on its windows; sitting down to a pretty table for two beneath the parasols. AT LAST we found a place that offered AND had Zucchini pie, a delicious one to boot, with it we ate [Taramasalata](http://en.wikipedia.org/wiki/Taramasalata) and crinkle cut chips. For mains we shared fresh red mullet, chosen from inside at €50 per kg, consuming five between us. Although Sam's ongoing gut troubles / illness meant she couldn't enjoy these to the fullest. So much so we paid a visit to the pharmacist on the way home, for advice and medicines.
 
-{% figure greece-octopus-red-mullet-eaten.JPG portrait %}Red mullet remains at The Octopus restaurant{% endfigure %}
+{% figure greece-octopus-red-mullet-eaten.JPG portrait %}
+Red mullet remains at The Octopus restaurant
+{% endfigure %}
 
-{% figure greece-molyvos-olive-press.JPG landscape %}View of The Olive Press{% endfigure %}
+{% figure greece-molyvos-olive-press.JPG landscape %}
+View of The Olive Press
+{% endfigure %}
 
-{% figure greece-octopus-molyvos-restaurant.JPG landscape %}The Octopus restaurant, Molyvos{% endfigure %}
+{% figure greece-octopus-molyvos-restaurant.JPG landscape %}
+The Octopus restaurant, Molyvos
+{% endfigure %}
 
 <!--* Looks like in-flight lunch is coming *-->
 
@@ -39,41 +47,61 @@ Properly prepped with an early night, Tuesday brought us into the day fresh and 
 
 As expected, the road is long and winding, dipping in land for swooping corners, sliding up and down as the coastal terrain changes - the walk is about 3 hours from Molyvos, affording the occasional chance to get a closer look at the flora and fauna, birds and the bees. Halfway along there is a small taverna for drinks - at which Sam unwisely decided was the time to satisfy her English-Black tea fix; instead she received an obscure Cinnamon/lemon and very weak concoction - "eugh", I did warn her. We ended up sharing a bottle of coke.
 
-{% figure greece-nasty-tea.JPG landscape %}This tea is not good{% endfigure %}
+{% figure greece-nasty-tea.JPG landscape %}
+This tea is not good
+{% endfigure %}
 
 Shortly thereafter, with some further up and downs, we reached the very small coastal village of Skala Sikiminea. Three tavernas (with parrot, lobster tanks and kittens in trees), two tourist shops selling jewelry, a small harbour and a church sitting on a small rocky outcrop. This church is meant to contain a depiction of the Virgin Mary as a mermaid - either it was hidden away or not there, but we couldn't find it.  For lunch we had the mixed warm mezes from "The Cuckoo Nest" which included [bourekakia](http://recipes.wikia.com/wiki/Bourekakia) and [tzatziki](http://en.wikipedia.org/wiki/Tzatziki).
 
-{% figure greece-skala-sikiminea.JPG landscape %}Skala Sikiminea{% endfigure %}
+{% figure greece-skala-sikiminea.JPG landscape %}
+Skala Sikiminea
+{% endfigure %}
 
 ### Captain Alex to the rescue
 
 By the afternoon it was too hot to walk back, and expensive for a taxi - our aim was to hitch a boat ride back to Molyvos. Luckily for us, the charismatic and welcoming Captain Alex came to the rescue. By chance he was there to pick up a large group of Dutch tourists that had just happened to follow us on our walk; with space for two more on the boxes at the back of his glass bottomed boat, we hitched a ride for €10 each. Excellent. With Greek music playing we basked in the sun as we passed the sights again, sharing almond biscuits courtesy of Alex. In Molyvos we ate ice cream and walked back to our pool.
 
-{% figure greece-molyvos-boat-back.JPG landscape %}Sam pleased to be heading back to Molyvos by boat{% endfigure %}
+{% figure greece-molyvos-boat-back.JPG landscape %}
+Sam pleased to be heading back to Molyvos by boat
+{% endfigure %}
 
-{% figure molyvos-alex-the-captain.JPG landscape %}Alex the captain{% endfigure %}
+{% figure molyvos-alex-the-captain.JPG landscape %}
+Alex the captain
+{% endfigure %}
 
 ## The Captain's Table (third time)
 
 The evening brought us back to The Captain's table, for house wine, spicy fried aubergine, olives and a Captain's platter for two. Although Sam ended up with white wine spilt down her dress (which led to a courtesy glass and free Cinnamon dessert, on top of Ouzo and small jelly cubes). This was a beautiful evening with a fabulous meal - the calamari was divine, which we ate with Mackerel, Bream, Saddled Bream and a fish that sounded like "melina", as part of the platter. Our unexpected dessert was the best we had eaten all holiday. Despite having one day left, this became our unofficial last romantic night in lesbos - we decided we couldn't top it. We caught the bus back to the Sun Rise Hotel after a short chat with "Gomez", the waiter neat the bus stop; we said our goodbyes and rode home to our room.
 
-{% figure molyvos-captains-platter.JPG landscape %}Captain’s platter at The Captain’s Table{% endfigure %}
+{% figure molyvos-captains-platter.JPG landscape %}
+Captain’s platter at The Captain’s Table
+{% endfigure %}
 
 ## Last day
 
 Wednesday seemed like a spare day, we'd achieved most of what we wanted to do, time to mop up the loose ends as it were. Sam paid a trip to the hot hot Eftalou springs with dips interspersed with a cooling sea swim - I plowed through 100 pages of my book. A word of warning - avoid the eateries here, we were subject to high prices and arrogant waiters, the food was equally horrid. To reset my pallet I swiftly purchased some delightful home made Baclava  from the Women's agricultural co-operative of Mithymna, and Fantastico provided another tasty tasty pork souvlaki - we just couldn't get enough of them, they made a perfect lunch time snack.
 
-{% figure greece-dog-on-van.JPG landscape %}A dog on a van{% endfigure %}
+{% figure greece-dog-on-van.JPG landscape %}
+A dog on a van
+{% endfigure %}
 
 Without wishing to taint our last evening, we chose a safe option on our last night - Lamb kleftiko and beef stifado from Tropicana, this time with a rose wine at Sam's request. The friendly neighbourhood diners shared with us their stories of walks, snakes and visits to Petri. As our chairs wobbled on the cobbled floor, the debonair head waiter shared stories and engaged with everyone and the cute black and white dog made its hunger rounds amidst all the cats, we prepared to say goodbye to Lesbos. Waving goodbye with some night time photography and squinting to see the flashing light emitted from Ipsilou, miles away to the West.
 
-{% figure greece-scooter-and-cool-tree.JPG portrait %}Scooter and tree{% endfigure %}
+{% figure greece-scooter-and-cool-tree.JPG portrait %}
+Scooter and tree
+{% endfigure %}
 
-{% figure greece-me.JPG landscape %}Paul at Tropicana{% endfigure %}
+{% figure greece-me.JPG landscape %}
+Paul at Tropicana
+{% endfigure %}
 
-{% figure greece-sam-and-paul.JPG landscape %}Sun kissed Paul and Samantha{% endfigure %}
+{% figure greece-sam-and-paul.JPG landscape %}
+Sun kissed Paul and Samantha
+{% endfigure %}
 
-{% figure greece-molyvos-at-night.JPG landscape %}Molyvos at night{% endfigure %}
+{% figure greece-molyvos-at-night.JPG landscape %}
+Molyvos at night
+{% endfigure %}
 
 ## Goodbye Molyvos
 
@@ -81,4 +109,6 @@ We're just crossing the English Channel now, and our ears are popping with the d
 
 That's it then. Goodbye Lesbos and all the wonderful people there. Gomez, the Fantastico men, Stradis, Alex, the breakfast waiters, friendly English tourists, Molly's bar, the helpful Avis man, Melinda and Co., the jester like waiter at Tropicana, the cats, the dogs, the house martins and bugs. The end.
 
-{% figure greece-molyvos-from-on-high.JPG landscape %}Flying over Molyvos{% endfigure %}
+{% figure greece-molyvos-from-on-high.JPG landscape %}
+Flying over Molyvos
+{% endfigure %}

--- a/source/_posts/xian-china.md
+++ b/source/_posts/xian-china.md
@@ -16,7 +16,9 @@ page: 1
 
 Our overnight sleeper train (the [20:43 Z19](http://www.seat61.com/China.htm) [from Beijing](/2014/09/beijing-china)) pulled into Xi'an at 8am — a comfortable and economic journey that didn't feel like 11 hours. It’s preferable to a long-haul flight in economy that's for sure. What wasn't quite so good was the weather — outside it was raining, and raining hard, the pavements were forming little rivers and in sandals it was pretty cold. The rain didn't let up, and for the entire time we stayed in Xi'an, from stepping off the train to boarding our flight to Jiuzhaigou, it rained, and it rained heavy. We were soaked just walking to the minibus which would drive us the short route to our hotel.
 
-{% figure china-xian-010.jpg landscape %}The wet Beiyuanmen street in the Muslim quarter of Xi’an {% endfigure %}
+{% figure china-xian-010.jpg landscape %}
+The wet Beiyuanmen street in the Muslim quarter of Xi’an 
+{% endfigure %}
 
 ## Bell Tower Hotel
 
@@ -32,27 +34,41 @@ After a nap and a shower, with wet weathers and sandals on, we set out to explor
 
 Mercifully we were close to the Muslim quarter, although the whole area is perpetuated with street-food and open-air stalls — each with their own form of umbrella to protect them, that always somehow managed to funnel the water onto my head. That said, the street food was the best we've ever had.
 
-{% figure china-xian-003.jpg landscape %}Street-food vendor in Xi’an’s Muslim quarter. Meat on a stick.{% endfigure %}
+{% figure china-xian-003.jpg landscape %}
+Street-food vendor in Xi’an’s Muslim quarter. Meat on a stick.
+{% endfigure %}
 
 Right at the entrance to [Beiyuanmen](http://www.tripadvisor.co.uk/Attraction_Review-g298557-d1805544-Reviews-Beiyuanmen_Street-Xi_an_Shaanxi.html) we found a place selling [Rou jia mo](http://en.wikipedia.org/wiki/Rou_jia_mo), or Chinese hamburgers. At this stall a long queue were waiting for slow cooked lamb to be diced and shredded, slipped into a _mo_ flatbread, before a little bit of sauce is drizzled on top ([video](http://instagram.com/p/s6vGQlNFGg/)). These were so good we came back for more on two more occasions.
 
-{% figure china-xian-007.jpg portrait %}Street-food vendor making our first [Rou jia mo](http://en.wikipedia.org/wiki/Rou_jia_mo), or Chinese hamburger{% endfigure %}
+{% figure china-xian-007.jpg portrait %}
+Street-food vendor making our first [Rou jia mo](http://en.wikipedia.org/wiki/Rou_jia_mo), or Chinese hamburger
+{% endfigure %}
 
-{% figure china-xian-008.jpg landscape %}A delicious Rou jia mo{% endfigure %}
+{% figure china-xian-008.jpg landscape %}
+A delicious Rou jia mo
+{% endfigure %}
 
 Next door a stall was selling crispy fried squid on a stick. Of course we had to try that too. Then there was meat cooked on wooden skewers, walnuts were being rolled around in sugar, pigs trotters coated in sauce and sesame seeds, baked cakes and desserty snacks, rice pudding cakes, fried potatoes, swirls of mushroom and tofu, men beating slabs of sugar with mallets, fresh pomegranate juice — and so much more. We reached a point where we were too full to eat any more.
 
-{% figure china-xian-001.jpg landscape %}Squids on sticks{% endfigure %}
+{% figure china-xian-001.jpg landscape %}
+Squids on sticks
+{% endfigure %}
 
-{% figure china-xian-009.jpg portrait %}Samantha eating that thing out of Aliens{% endfigure %}
+{% figure china-xian-009.jpg portrait %}
+Samantha eating that thing out of Aliens
+{% endfigure %}
 
 ### Folk house (Gaojia Dayuan)
 
 Inside the Muslim quarter, down Beiyuanmen street is an old folk house that provided just enough cover from the rain to let us dry off a bit. I say just enough, it's a few buildings that you still need to hop between, so inevitably you never really dry off. We paid a bit extra for the tickets to go and see the shadow puppets and have a drink of tea (it's never just a drink, always a ceremony). The shadow puppet story was all in Chinese, so we were simply bemused by shadowy figures flying around a white canvas. The buildings themselves are filled with antique furniture, paintings and calligraphy; the ceilings are wooden and outside hang traditional red lanterns. It doesn’t quite meet the standards you’d expect of say a National Trust place in the UK, but it’s a good stop for an hour or so.
 
-{% figure china-xian-004.jpg landscape %}Entrance to the folk house (Gaojia dayuan){% endfigure %}
+{% figure china-xian-004.jpg landscape %}
+Entrance to the folk house (Gaojia dayuan)
+{% endfigure %}
 
-{% figure china-xian-005.jpg landscape %}Tea ceremony at the folk house{% endfigure %}
+{% figure china-xian-005.jpg landscape %}
+Tea ceremony at the folk house
+{% endfigure %}
 
 ## Finding dinner
 
@@ -60,7 +76,9 @@ After returning to the hotel, drying off and heading back out again, it was time
 
 From the Kaiyuan shopping mall we took some evening photos of the bell tower, and inside we checked out the food court. All the places looked good, but they were mostly buffet and we wanted a proper sit-down-meal after eating street food all day. The mall itself could have been in any country, and the lifts were painfully slow.
 
-{% figure china-xian-006.jpg landscape %}Xi’an drum and bell towers at night{% endfigure %}
+{% figure china-xian-006.jpg landscape %}
+Xi’an drum and bell towers at night
+{% endfigure %}
 
 Outside the rain continued, and we meandered up and down streets, peering in restaurant windows and checking out the few menus we could find. At one point we found ourselves in a trendy karaoke night club by mistake, thinking it was somewhere we could eat. Eventually we gambled on a place which we couldn’t see in from the outside, [some red steps](http://www.dianping.com/photos/78216520) went up to a higher floor, but the sign clearly showed a stylised picture of some noodles.
 
@@ -74,4 +92,6 @@ The specialty seemed to be bullfrog, but we played it safe, ordering fried rice,
 
 Not quite done with the day, we had the hotel bar prepare us some cocktails, before sneaking to the roof to get some night shots of the bell tower.
 
-{% figure china-xian-011.jpg landscape %}Xi’an bell tower at night{% endfigure %}
+{% figure china-xian-011.jpg landscape %}
+Xi’an bell tower at night
+{% endfigure %}

--- a/source/_posts/xian-china/2.md
+++ b/source/_posts/xian-china/2.md
@@ -14,7 +14,9 @@ page: 2
 
 ## Army of Terracotta Warriors
 
-{% figure china-xian-day-2-009.jpg landscape %}Army of Terracotta Warriors. Unique expressions, heights and pose.{% endfigure %}
+{% figure china-xian-day-2-009.jpg landscape %}
+Army of Terracotta Warriors. Unique expressions, heights and pose.
+{% endfigure %}
 
 Returning to our scheduled itinerary, a driver picked us up from our hotel at 8:45am to take us to one of the world’s most famous archaeological sites; the [Terracotta army](http://en.wikipedia.org/wiki/Terracotta_Army) (兵馬俑, bīngmǎ yǒng). The warriors, which belonged to the first emperor Qin Shi Huang in 210BC, weren’t discovered until 1974, some villagers were building a well and found an underground chamber. Today the excavation is still in progress. In 2007 we’d seen the British Museum’s “[The First Emperor](http://www.britishmuseum.org/whats_on/past_exhibitions/2007/archive_first_emperor.aspx)” showcase and it left us eager for the real thing. We were travelling with our dutch friends Jan and Emmie again, and from town the minibus took about an hour. The roads were lined with pomegranate trees; their fruit bagged on the tree and ready to pick.
 
@@ -22,21 +24,33 @@ The rain kept pouring, and it didn’t stop all day. Luckily the exhibits are al
 
 Pit 3 is just a taster, it has only 72 warriors, although they are all high ranking officials. Disappointingly the information on the warriors throughout the exhibit is scarce, there were very few descriptions (in Chinese or English), and those that we did find lacked depth — often focusing on the pits themselves, their discovery and size, rather than their findings. Instead the buildings have horrible touristy photo rooms for picturing yourself against a cardboard backdrop, and overpriced shops selling jade sculptures and figures of Chairman Mao. A concrete path surrounds each pit, and the warriors are buried some 15ft beneath ground level. Binoculars and a zoom lens help to see them properly.
 
-{% figure china-xian-day-2-001.jpg landscape %}Headless terracotta warriors in pit 3{% endfigure %}
+{% figure china-xian-day-2-001.jpg landscape %}
+Headless terracotta warriors in pit 3
+{% endfigure %}
 
 Pit 2 is vast, and contains over 1300 warriors. Most of these are yet to be uncovered, still standing dormant, enclosed beneath rolling wave-like arches which form an ancient rooftop. Most of the warriors are a distance away, but there are 5 exhibits showing the different types of warrior up close; a kneeling archer, a one of a kind standing archer, a cavalryman with his horse, an officer and a general (of which there are very few). The detail is astonishing — the facial expression, the hair style, the patterns on the soles of their feet.
 
-{% figure china-xian-day-2-003.jpg landscape %}Intricate chestplate details on the warriors, seen up close in pit 2{% endfigure %}
+{% figure china-xian-day-2-003.jpg landscape %}
+Intricate chestplate details on the warriors, seen up close in pit 2
+{% endfigure %}
 
-{% figure china-xian-day-2-002.jpg portrait %}Elaborate and detailed hair style of an archer{% endfigure %}
+{% figure china-xian-day-2-002.jpg portrait %}
+Elaborate and detailed hair style of an archer
+{% endfigure %}
 
 Pit 1 is the main attraction, a circular route around an excavation that houses over 6000 warriors, the best vantage point is the crowded entrance. Here three lines of perfectly restored warriors stand ready for battle, behind them troops and horses line 11 wide corridors which disappear into the distance. Realistically the further back you look the less impressive the pit becomes, only because the warriors still lie in pieces and the effort to put them back together is gargantuan. At the back and sides of pit 1 we saw some of the stages to this; gathering parts, identifying them, connecting the dots, painstaking reassembly. The three lines of warriors at the very front are the most impressive part of the whole site, lined up together you can see that each is an individual; a different face, a hairstyle, an expression; but also their height and build. So lifelike is their appearance it’s easy to imagine them fighting battles in the afterlife; in reality they get to watch the never-ending camera battle of their modern descendants.
 
-{% figure china-xian-day-2-008.jpg landscape %}The view when you enter the extraordinary pit 1{% endfigure %}
+{% figure china-xian-day-2-008.jpg landscape %}
+The view when you enter the extraordinary pit 1
+{% endfigure %}
 
-{% figure china-xian-day-2-004.jpg landscape %}The most impressive pit, pit 1, where warriors await battle{% endfigure %}
+{% figure china-xian-day-2-004.jpg landscape %}
+The most impressive pit, pit 1, where warriors await battle
+{% endfigure %}
 
-{% figure china-xian-day-2-006.jpg landscape %}Part of the painstaking re-assembly of each warrior{% endfigure %}
+{% figure china-xian-day-2-006.jpg landscape %}
+Part of the painstaking re-assembly of each warrior
+{% endfigure %}
 
 There’s a small museum on site, the highlight of which is a bronze horse and chariot from the site of the emperor’s tomb, but we left quickly, the room dark and filled with phone wielding tourist groups. We also nipped around an out of place exhibition showing Italian antiquities.
 
@@ -44,7 +58,9 @@ The final _attraction_ of the visit is outside the main grounds; the exit takes 
 
 This was the last activity we’d share with Jan and Emmie, and from the minibus we said our goodbyes and exchanged emails — we’d be going to Jiuzhaigou, they were going to Tiger Leaping Gorge. Purely by chance, we did bump into each other again in Guilin.
 
-{% figure china-xian-day-2-014.jpg portrait %}Our own terracotta warrior{% endfigure %}
+{% figure china-xian-day-2-014.jpg portrait %}
+Our own terracotta warrior
+{% endfigure %}
 
 ## Xi’an’s drum and bell towers
 
@@ -55,21 +71,33 @@ We arrived in time to catch a traditional musical performance with bells and som
 
 Just down the road is the [drum tower](http://en.wikipedia.org/wiki/Drum_Tower_of_Xi'an), where traditionally a drum was beat to mark sunset. Larger and more impressive than the bell tower, the building is surrounded by antique drums over 2m in diameter — inside there’s a drum museum. Once again we got lucky and arrived at the beginning of a drum-beating performance. Energetic and almost tribal, it was fascinating and wholly different to the bells. From the gift shop we bought a traditional Chinese painting.
 
-{% figure china-xian-day-2-013.jpg landscape %}"No striking", Sam and a giant drum{% endfigure %}
+{% figure china-xian-day-2-013.jpg landscape %}
+"No striking", Sam and a giant drum
+{% endfigure %}
 
-{% figure china-xian-day-2-010.jpg landscape %}Paul in the rain outside the drum tower{% endfigure %}
+{% figure china-xian-day-2-010.jpg landscape %}
+Paul in the rain outside the drum tower
+{% endfigure %}
 
-{% figure china-xian-day-2-011.jpg landscape %}Drum beating performance{% endfigure %}
+{% figure china-xian-day-2-011.jpg landscape %}
+Drum beating performance
+{% endfigure %}
 
 ## Street food
 
 Conveniently the drum tower exits into the muslim quarter, and once again we perused the streets looking for tasty food. We ate more Chinese hamburgers, rose flavoured rice desserts — to Sam’s ongoing rose misfortune and disgust, fried potatoes, spiced mushroom and freshly squeezed pomegranate juice. The latter came from the cutest and friendliest pomegranate juice bar, where we watched the hand-powered mechanical juicer do its thing. Pomegranate juice in the UK is imported, preserved and quite bitter; this freshly picked and juiced drink was something altogether more delicious.
 
-{% figure china-xian-day-2-012.jpg landscape %}Street vendor in Xi’an{% endfigure %}
+{% figure china-xian-day-2-012.jpg landscape %}
+Street vendor in Xi’an
+{% endfigure %}
 
-{% figure china-xian-day-2-015.jpg portrait %}Sam, not yet knowing she’s eating yet another rose flavoured dessert{% endfigure %}
+{% figure china-xian-day-2-015.jpg portrait %}
+Sam, not yet knowing she’s eating yet another rose flavoured dessert
+{% endfigure %}
 
-{% figure china-xian-day-2-016.jpg portrait %}Street vendor cooking us some spiced fried potatoes{% endfigure %}
+{% figure china-xian-day-2-016.jpg portrait %}
+Street vendor cooking us some spiced fried potatoes
+{% endfigure %}
 
 ## Goodbye Xi’an
 

--- a/source/_posts/yangshuo-china.md
+++ b/source/_posts/yangshuo-china.md
@@ -21,9 +21,13 @@ After a quiet nothing-day in [Chengdu](/2014/09/chengdu-china/) we had an 8pm fl
 
 Up at 7am, we had an early start with a guide for a day of biking, rafting and hiking. I opened the curtains and was shocked by the astounding beauty of in front of me. The Yulong river ran just beneath our window, the sky was a clear deep blue and we were surrounded by mysterious limestone karst mountains, each uniquely sculpted over millennia. These reflected perfectly in the still river water, which flows gently and at this time in the morning is completely undisturbed. I shut the curtains again, so Sam could get the same big reveal.
 
-{% figure china-yangshuo-013.jpg landscape %}The morning view when I opened the curtains{% endfigure %}
+{% figure china-yangshuo-013.jpg landscape %}
+The morning view when I opened the curtains
+{% endfigure %}
 
-{% figure china-yangshuo-007.jpg landscape %}View of Yulong river from our Yangshuo Mountain Retreat{% endfigure %}
+{% figure china-yangshuo-007.jpg landscape %}
+View of Yulong river from our Yangshuo Mountain Retreat
+{% endfigure %}
 
 [Yangshuo Mountain Retreat](http://www.yangshuomountainretreat.com/) itself is nestled along the river, a luxury boutique hotel with only a few rooms. The rooms are wood panelled and smell beautifully of pine, some have a balcony but we were on the ground floor. Outside is a beautiful garden area, with young banyan trees and purple flowering shrubs, frequented by dragonflies and butterflies. By day you sit at the dining tables with a beer, waving by the bamboo rafts; at night it's all lit up with lanterns. It's eco friendly; no telephone, no TV, and locally made bamboo beds — they make their own furniture too. The hotel guidebook also includes a bio of each staff member, who seemed to all treat each other like family.
 
@@ -35,7 +39,9 @@ Our guide, Ming, picked us up and from the hotel we chose bikes for the day. My 
 
 After Sam had bought a conical straw hat (which we carried about the rest of China, and now sits on our bookshelf) we clambered into seats at the rear of our raft. The raft is comprised of 10 bamboo tubes tied together, rising slightly at the ends. The seats are simple metal frames with a cushion, space for a parasol and hooks for bags. It's all a bit like punting, or gondolas, with another stick of bamboo our driver pushed off and we headed downstream. The trip would take 1h30, and it took us back past our hotel, down the [Yulong river](http://en.wikipedia.org/wiki/Yulong_River) towards moon hill.
 
-{% figure china-yangshuo-006.jpg landscape %}Bamboo rafting down Yulong river{% endfigure %}
+{% figure china-yangshuo-006.jpg landscape %}
+Bamboo rafting down Yulong river
+{% endfigure %}
 
 I imagined a scenic landscape, still, quiet and empty. I couldn't have been more wrong. Soon enough we joined the procession of Chinese tourists on their bamboo boats. Not the idyllic experience I had expected, but this was fun in itself. Some were having water fights, many climbed about the boat taking pictures from different angles — it seems it's more stable than it looks, and then we were serenaded, all the boats around us joined in song — some Chinese folk tune everyone but us knew.
 
@@ -45,9 +51,13 @@ The river is mostly quiet, but every few hundred metres there's a little foot hi
 
 At the end there are tractors that take towers of bamboo boats back upstream where they'll start all over again. These tractors also brought our bikes back to us, and we cycled onwards to moon hill. On the way Ming tried to sell us more attractions, some caves here, a tree there, a show tonight. We did go and see the 1400 year old Banyan tree, not worth the entry fee but interesting nonetheless. It was so old it had grown its own supports.
 
-{% figure china-yangshuo-005.jpg landscape %}1400 year old Banyan tree{% endfigure %}
+{% figure china-yangshuo-005.jpg landscape %}
+1400 year old Banyan tree
+{% endfigure %}
 
-{% figure china-yangshuo-010.jpg landscape %}Moon hill{% endfigure %}
+{% figure china-yangshuo-010.jpg landscape %}
+Moon hill
+{% endfigure %}
 
 Moon hill is a limestone karst mountain with a big moon shaped hole at the top of it. Depending on where you stand the moon appears to be in different phases. After lunch at the bottom, in a small cafe where we argued with each other over aubergines that were too fatty, we begun the uphill hike to the top.
 
@@ -55,11 +65,15 @@ The climb takes about an hour, and we, as always seems to be the case, were clim
 
 At the top we found stunning hazy panoramas of limestone karst mountains in the afternoon sun. Into the distance they disappeared, it looked like the back of a giant sleeping crocodile. From the viewpoint there's a small trail that takes you out the back, for even more spectacular views. And there are more secrets too; a little mud trail with a warning not to enter is rumoured to take you up to the top. We didn't try it.
 
-{% figure china-yangshuo-014.jpg landscape %}Panorama from the top of Moon hill{% endfigure %}
+{% figure china-yangshuo-014.jpg landscape %}
+Panorama from the top of Moon hill
+{% endfigure %}
 
 At the bottom, after we'd meandered back down and taken some photos of large bamboo plants, we met Ming again and got back on our bikes to ride home to the hotel. We took a pit stop for some cheap mango ice creams, then headed back through the countryside. All in all we only cycled for an hour or so and by the end we had much of the afternoon left to fill.
 
-{% figure china-yangshuo-003.jpg landscape %}Beer by the river{% endfigure %}
+{% figure china-yangshuo-003.jpg landscape %}
+Beer by the river
+{% endfigure %}
 
 ## Good food and prosecco
 
@@ -67,10 +81,16 @@ By the river we considered what to do with our time here. We could see the famou
 
 We spent a few hours watching the sunset from a table by the river, a cold local beer in hand. Then as the light was right we used tripods to try and capture the moment.
 
-{% figure china-yangshuo-002.jpg landscape %}Last bamboo raft of the evening{% endfigure %}
+{% figure china-yangshuo-002.jpg landscape %}
+Last bamboo raft of the evening
+{% endfigure %}
 
-{% figure china-yangshuo-012.jpg landscape %}Yangshuo at night{% endfigure %}
+{% figure china-yangshuo-012.jpg landscape %}
+Yangshuo at night
+{% endfigure %}
 
 By the time it was dark we were hungry, and the hotel was the perfect setting for a riverside romantic meal. With a bottle of Prosecco (why not? It cost the same as the wine). We shared a Gongbao chicken dish and a ginger fried duck one, with some local fried rice (a little odd because it contained gherkins) and then a chocolate hazelnut dessert. With our remaining bubbly we slouched on the comfy outdoor sofas and finished off the bottle. This place is magical.
 
-{% figure china-yangshuo-015.jpg portrait %}Last of the Prosecco{% endfigure %}
+{% figure china-yangshuo-015.jpg portrait %}
+Last of the Prosecco
+{% endfigure %}

--- a/source/_posts/yangshuo-china/2.md
+++ b/source/_posts/yangshuo-china/2.md
@@ -21,19 +21,27 @@ In the absence of planned activities, we planned our own, and at 10am Zeng Song,
 
 We started with basic strokes, the components of characters; a point that goes from thick to thin, a thin line to a fat line, the angle to hold a brush for different strokes. The first characters we wrote were numbers 1 to 10, characters I recognised from my mandarin lessons at university. Then we moved onto the foundation characters, upon which other characters are built; up and down, big and small, moon and sun, wood and mountain. We finished by writing our names in their equivalent sounding characters. By the end we'd grown adept at using the brush and the precise order that strokes are made, our lines were confident and the characters showed improvement — though our teachers’ examples hinted at the years and years of practice necessary to perfect this craft, every character looked perfect.
 
-{% figure china-yangshuo-day-2-002.jpg landscape %}Samantha learning Chinese calligraphy{% endfigure %}
+{% figure china-yangshuo-day-2-002.jpg landscape %}
+Samantha learning Chinese calligraphy
+{% endfigure %}
 
-{% figure china-yangshuo-day-2-001.jpg landscape %}Zeng Song teaching Paul to write his name{% endfigure %}
+{% figure china-yangshuo-day-2-001.jpg landscape %}
+Zeng Song teaching Paul to write his name
+{% endfigure %}
 
 <figure class="generated-figure generated-figure--retina generated-figure--620 generated-figure--video"><div class="video-wrapper"><iframe class="vine-embed" src="https://vine.co/v/O7HOV92guhT/embed/simple" width="620" height="620" frameborder="0"></iframe></div><figcaption class="generated-figure-caption">Our first calligraphy lesson</figcaption></figure>
 
 Zeng Song also runs painting lessons, and at the end Sam asked for a bamboo painting session, she'd seen a child doing something similar in a park in Chengdu. Turns out this is harder than it looks. For 45 minutes Sam practiced her bamboo strokes, 1-2-3, down-diagonal-horizontal, 1-2-3, thin-fat-thin to resemble a leaf. These leaves are then overlaid seemingly randomly but ultimately resembling bamboo brilliantly (or not at all). The last step is to paint the bamboo trunk, three thick strokes with a swish between each. And for the finishing touch, to sign your name and stamp with a red seal.
 
-{% figure china-yangshuo-day-2-003.jpg landscape %}Example bamboo strokes{% endfigure %}
+{% figure china-yangshuo-day-2-003.jpg landscape %}
+Example bamboo strokes
+{% endfigure %}
 
 We didn't do much after that, at the hotel we had the regional specialty ‘beer fish’, or pijiu yu — one big catfish between two, and Sam had a foot and shoulder massage.
 
-{% figure china-yangshuo-day-2-007.jpg landscape %}Beer fish, pijiu yu{% endfigure %}
+{% figure china-yangshuo-day-2-007.jpg landscape %}
+Beer fish, pijiu yu
+{% endfigure %}
 
 ## An evening away from our retreat
 
@@ -41,7 +49,9 @@ Before the evening we headed out into town via taxi; though as soon as we arrive
 
 But we didn't go home, instead we continued on to Yangshuo village inn, our hotel's sister which has a rooftop restaurant, [Luna](https://foursquare.com/v/luna-italian-restaurant/4f6b16f4e4b05595b52e5ad0). Luna is on the roof of the hotel and it looks out on Moon Hill. The views weren't as picturesque as the guides suggested (partly because of a new build which obscures the view), nor the hotel as plush as ours, but the Italian food was tasty and we enjoyed pizza and pasta with cold local beer LiQing.
 
-{% figure china-yangshuo-day-2-008.jpg landscape %}Panorama from Luna restaurant{% endfigure %}
+{% figure china-yangshuo-day-2-008.jpg landscape %}
+Panorama from Luna restaurant
+{% endfigure %}
 
 After the taxi back to our retreat, we didn't fancy bed straight away. There was a nice vibe in the bar, so we tried the Great Wall red wine (the only variety of wine we found in China) and hung about. There's a trend on holiday — Sam finds lots of small interesting things to buy as souvenirs, I find one or two things that I love that are usually massive, expensive or not available for purchase. In the bar there was one such thing; an amazing table constructed from an ornate Chinese panel window with glass fitted over the top.
 
@@ -51,4 +61,6 @@ After putting it off for a day, we did get up before dawn to capture the magnifi
 
 As we were up we had an early breakfast and then waited for our driver who'd be taking us three hours north, to the [Longsheng rice terraces](/2014/09/longsheng-rice-terraces-china/) and the remote mountaintop village of Ping’an. Our retreat was over, the relaxation was welcomed, but now it was time to return to travelling and activities. We considered cancelling the rice terraces and staying here longer, but that would have been a huge mistake, the rice terraces are incredible.
 
-{% figure china-yangshuo-day-2-005.jpg portrait %}Fisherman out on Yulong river early in the morning{% endfigure %}
+{% figure china-yangshuo-day-2-005.jpg portrait %}
+Fisherman out on Yulong river early in the morning
+{% endfigure %}


### PR DESCRIPTION
* Update from 2.8.3 to 3.1.1
  * Add missing generators
  * Update dependency minimum versions
* Update tag plugins to Hexo 3

New Hexo requires custom tags that parse markdown and have an end block to put their content on a new line. Otherwise the markdown seems to fail to parse and begins to affect subsequent content.

* Add new lines before and after content
* Used regexp  `%\}(.*){% endfigure %}` replacing with ` %}\n$1\n{%
endfigure %}`